### PR TITLE
Changes for loading screen when launching and when restoring from bac…

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -56,7 +56,7 @@ export default function SettingsScreen() {
   const [appVersion, setAppVersion] = useState<ApplicationVersion | null>(null);
   const [buildInfo, setBuildInfo] = useState<BuildInfo | null>(null);
   const [loadingAppInfo, setLoadingAppInfo] = useState(false);
-  const [autoRefreshInterval, setAutoRefreshInterval] = useState('1500');
+  const [autoRefreshInterval, setAutoRefreshInterval] = useState('1000');
   const [showAddCategory, setShowAddCategory] = useState(false);
   const [showAddTag, setShowAddTag] = useState(false);
   const [cardViewMode, setCardViewMode] = useState<'compact' | 'expanded'>('compact');
@@ -171,7 +171,7 @@ export default function SettingsScreen() {
   const loadPreferences = async () => {
     try {
       const prefs = await storageService.getPreferences();
-      const interval = prefs.autoRefreshInterval || 1500;
+      const interval = prefs.autoRefreshInterval || 1000;
       setAutoRefreshInterval(interval.toString());
       const viewMode = prefs.cardViewMode || 'compact';
       setCardViewMode(viewMode);
@@ -200,7 +200,7 @@ export default function SettingsScreen() {
       setRetryAttempts(prefs.retryAttempts || 3);
       setDebugMode(prefs.debugMode || false);
     } catch (error) {
-      setAutoRefreshInterval('1500');
+      setAutoRefreshInterval('1000');
       setCardViewMode('compact');
     }
   };


### PR DESCRIPTION
## Fix connectivity UX for app launch and background resume

### Summary

Improves connectivity handling for app launch and when resuming from background (e.g. after switching to another app). Fixes flashing "Not Connected" / "No Torrents" screens, "Something Went Wrong" after app switching, and improves connection feedback.

### Changes

**App launch**
- Show loading screen instead of "No Torrents" until first sync completes
- Add 30s loading timeout with "Tap to retry"
- Reset `initialLoadComplete` on disconnect to avoid empty state flashes

**Background / foreground**
- Pause polling when app goes to background (battery savings)
- Resume polling and reconnect when app returns to foreground
- Show "Reconnecting..." banner during reconnection
- Show "Connection lost. Tap to retry" when reconnect fails
- Avoid "Something Went Wrong" for transient background/foreground issues

**Connection states**
- Differentiate "Not Connected" (no server) vs "Connection Failed" (reachability issue)
- Add `retryConnection()` for failed connections
- Add `connectionAttemptFailed` flag in ServerContext

**Other**
- Convert `isRecoveringFromBackground` from ref to state for correct re-renders

- [ ] Connection failed: shows "Connection Failed" with "Retry" and "Go to Settings"