### PR TITLE
Fix protocol prefix handling and add community links (fixes #16)

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -13,6 +13,7 @@ import {
   Dimensions,
   Platform,
   Alert,
+  Linking,
 } from 'react-native';
 import { useRouter, useFocusEffect } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
@@ -743,6 +744,48 @@ export default function SettingsScreen() {
             </View>
           </View>
         )}
+
+        {/* About qRemote */}
+        <View style={styles.section}>
+          <Text style={[styles.sectionHeader, { color: colors.textSecondary }]}>ABOUT QREMOTE</Text>
+          <View style={[styles.card, { backgroundColor: colors.surface }]}>
+            <TouchableOpacity 
+              style={styles.settingRow}
+              onPress={() => Linking.openURL('https://github.com/taylorcox75/qremote')}
+              activeOpacity={0.7}
+            >
+              <View style={styles.settingLeft}>
+                <Ionicons name="logo-github" size={22} color={colors.primary} />
+                <Text style={[styles.settingLabel, { color: colors.text }]}>Source Code</Text>
+              </View>
+              <Ionicons name="open-outline" size={20} color={colors.textSecondary} />
+            </TouchableOpacity>
+            <View style={[styles.separator, { backgroundColor: colors.background }]} />
+            <TouchableOpacity 
+              style={styles.settingRow}
+              onPress={() => Linking.openURL('https://github.com/taylorcox75/qRemote/issues')}
+              activeOpacity={0.7}
+            >
+              <View style={styles.settingLeft}>
+                <Ionicons name="bug-outline" size={22} color={colors.primary} />
+                <Text style={[styles.settingLabel, { color: colors.text }]}>Report Issue</Text>
+              </View>
+              <Ionicons name="open-outline" size={20} color={colors.textSecondary} />
+            </TouchableOpacity>
+            <View style={[styles.separator, { backgroundColor: colors.background }]} />
+            <TouchableOpacity 
+              style={styles.settingRow}
+              onPress={() => Linking.openURL('https://www.paypal.com/donate/?business=E9XLGFHN963HN&no_recurring=0&currency_code=USD')}
+              activeOpacity={0.7}
+            >
+              <View style={styles.settingLeft}>
+                <Ionicons name="beer-outline" size={22} color={colors.primary} />
+                <Text style={[styles.settingLabel, { color: colors.text }]}>Buy Me a Beer</Text>
+              </View>
+              <Ionicons name="open-outline" size={20} color={colors.textSecondary} />
+            </TouchableOpacity>
+          </View>
+        </View>
 
         {/* Application Info */}
         {isConnected && (

--- a/app/server/[id].tsx
+++ b/app/server/[id].tsx
@@ -40,6 +40,11 @@ export default function EditServerScreen() {
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState(false);
 
+  // Helper function to strip http:// or https:// prefix from host
+  const stripProtocol = (hostString: string): string => {
+    return hostString.replace(/^(https?:\/\/)/i, '');
+  };
+
   useEffect(() => {
     loadServer();
   }, [id]);
@@ -97,7 +102,7 @@ export default function EditServerScreen() {
       const server: ServerConfig = {
         id: id!,
         name: name.trim(),
-        host: host.trim(),
+        host: stripProtocol(host.trim()),
         port: portNum,
         basePath: basePath.trim() || '/',
         username: bypassAuth ? '' : username.trim(),
@@ -148,7 +153,7 @@ export default function EditServerScreen() {
       const server: ServerConfig = {
         id: id!,
         name: name.trim(),
-        host: host.trim(),
+        host: stripProtocol(host.trim()),
         port: portNum,
         username: bypassAuth ? '' : username.trim(),
         password: bypassAuth ? '' : password.trim(),
@@ -249,7 +254,7 @@ export default function EditServerScreen() {
                   style={[styles.input, { color: colors.text }]}
                   value={host}
                   onChangeText={setHost}
-                  placeholder="IP /  Hostname (without http(s))"
+                  placeholder="IP /  Hostname"
                   placeholderTextColor={colors.textSecondary}
                   autoCapitalize="none"
                   autoCorrect={false}

--- a/app/server/add.tsx
+++ b/app/server/add.tsx
@@ -38,6 +38,11 @@ export default function AddServerScreen() {
   const [loading, setLoading] = useState(false);
   const [testing, setTesting] = useState(false);
 
+  // Helper function to strip http:// or https:// prefix from host
+  const stripProtocol = (hostString: string): string => {
+    return hostString.replace(/^(https?:\/\/)/i, '');
+  };
+
   const handleSave = async () => {
     if (!name.trim() || !host.trim()) {
       showToast('Please fill in server name and host', 'error');
@@ -65,7 +70,7 @@ export default function AddServerScreen() {
       const server: ServerConfig = {
         id: Date.now().toString(),
         name: name.trim(),
-        host: host.trim(),
+        host: stripProtocol(host.trim()),
         port: portNum,
         basePath: basePath.trim() || '/',
         username: bypassAuth ? '' : username.trim(),
@@ -119,7 +124,7 @@ export default function AddServerScreen() {
       const server: ServerConfig = {
         id: 'test-' + Date.now().toString(),
         name: name.trim(),
-        host: host.trim(),
+        host: stripProtocol(host.trim()),
         port: portNum,
         username: bypassAuth ? '' : username.trim(),
         password: bypassAuth ? '' : password.trim(),
@@ -211,7 +216,7 @@ export default function AddServerScreen() {
                   style={[styles.input, { color: colors.text }]}
                   value={host}
                   onChangeText={setHost}
-                  placeholder="IP / Hostname (without http(s))"
+                  placeholder="IP / Hostname"
                   placeholderTextColor={colors.textSecondary}
                   autoCapitalize="none"
                   autoCorrect={false}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qRemote",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "index.ts",
   "scripts": {
     "start": "expo start --go",


### PR DESCRIPTION
Fix protocol prefix handling and add community links (fixes #16)" -m "- Strip http:// and https:// prefixes from server host inputs to prevent double protocol URLs (fixes connection issues where users were unable to connect with URLs like https://https://server.com)" -m "- Add 'About qRemote' section in Settings with links to source code and issue tracker" -m "- Bump version to 1.1.1