### PR TITLE
Fix #39 merge incremental maindata server_state updates

### DIFF
--- a/app/(tabs)/transfer.tsx
+++ b/app/(tabs)/transfer.tsx
@@ -814,14 +814,14 @@ export default function TransferScreen() {
                       {formatSize(serverState.total_queued_size || 0)}
                     </Text>
                   </View>
-                  {serverState.average_time_queue > 0 && (
+                  {(serverState.average_time_queue ?? 0) > 0 && (
                     <View style={[styles.infoRow, { backgroundColor: colors.background }]}>
                       <View style={styles.infoLeft}>
                         <Ionicons name="time-outline" size={18} color={colors.textSecondary} />
                         <Text style={[styles.infoLabel, { color: colors.textSecondary }]}>Avg Queue Time</Text>
                       </View>
                       <Text style={[styles.infoValue, { color: colors.text }]}>
-                        {formatTime(serverState.average_time_queue)}
+                        {formatTime(serverState.average_time_queue ?? 0)}
                       </Text>
                     </View>
                   )}

--- a/types/api.ts
+++ b/types/api.ts
@@ -61,7 +61,7 @@ export interface MainData {
   categories_removed?: string[];
   tags?: string[];
   tags_removed?: string[];
-  server_state?: ServerState;
+  server_state?: Partial<ServerState>;
 }
 
 export interface TorrentInfo {
@@ -161,6 +161,7 @@ export interface ServerState {
   total_buffers_size: number;
   total_peer_connections: number;
   total_queued_size: number;
+  total_size?: number;
   up_info_data: number;
   up_info_speed: number;
   up_rate_limit: number;
@@ -259,4 +260,3 @@ export interface ApiResponse<T = any> {
   error?: string;
   status: number;
 }
-


### PR DESCRIPTION
Fixes incremental /sync/maindata server_state handling by merging partial server_state updates when isFullUpdate is false, instead of replacing the entire object.
Fixes #39