### PR TITLE
Color theming

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -56,8 +56,17 @@ function formatReleaseDate(isoDate: string): string {
 
 const CHANGELOG = [
   {
+    version: '2.1.0',
+    date: '2025-02-27',
+    changes: [
+      'Customizable torrent state colors in Theme & Colors (downloading, seeding, upload only, error, stalled, paused, checking, metadata, queued, other)',
+      'Separate reset-to-default for torrent state colors (Advanced colors reset unchanged)',
+      'Torrent state colors section moved above Advanced colors in theme settings'
+    ],
+  },
+  {
     version: '2.0.2',
-    date: '2026-02-26',
+    date: '2025-02-26',
     changes: [
       'Fixed default save path updates not being applied on the qBittorrent server',
     ],

--- a/app/settings/theme.tsx
+++ b/app/settings/theme.tsx
@@ -97,6 +97,104 @@ export default function ThemeSettingsScreen() {
           </View>
         </View>
 
+        {/* Torrent state colors (badge & border by activity) */}
+        <View style={styles.section}>
+          <View style={styles.sectionHeaderRow}>
+            <Text style={[styles.sectionHeader, { color: colors.textSecondary }]}>TORRENT STATE COLORS</Text>
+            <TouchableOpacity
+              onPress={async () => {
+                try {
+                  await colorThemeManager.resetTorrentStateColors(isDark);
+                  await reloadCustomColors();
+                  showToast('Torrent state colors reset to defaults', 'success');
+                } catch (error) {
+                  showToast('Failed to reset torrent state colors', 'error');
+                }
+              }}
+            >
+              <Ionicons name="refresh" size={20} color={colors.textSecondary} />
+            </TouchableOpacity>
+          </View>
+          <View style={[styles.card, { backgroundColor: colors.surface }]}>
+            <ColorSettingRow
+              label="Downloading"
+              color={colors.stateDownloading}
+              onPress={() => handleColorSelect('stateDownloading')}
+              colors={colors}
+            />
+            <View style={[styles.separator, { backgroundColor: colors.background }]} />
+            <ColorSettingRow
+              label="Seeding (idle)"
+              color={colors.stateSeeding}
+              onPress={() => handleColorSelect('stateSeeding')}
+              colors={colors}
+            />
+            <View style={[styles.separator, { backgroundColor: colors.background }]} />
+            <ColorSettingRow
+              label="Download + Upload"
+              color={colors.stateUploadAndDownload}
+              onPress={() => handleColorSelect('stateUploadAndDownload')}
+              colors={colors}
+            />
+            <View style={[styles.separator, { backgroundColor: colors.background }]} />
+            <ColorSettingRow
+              label="Upload only"
+              color={colors.stateUploadOnly}
+              onPress={() => handleColorSelect('stateUploadOnly')}
+              colors={colors}
+            />
+            <View style={[styles.separator, { backgroundColor: colors.background }]} />
+            <ColorSettingRow
+              label="Error / Stalled DL"
+              color={colors.stateError}
+              onPress={() => handleColorSelect('stateError')}
+              colors={colors}
+            />
+            <View style={[styles.separator, { backgroundColor: colors.background }]} />
+            <ColorSettingRow
+              label="Stalled (upload)"
+              color={colors.stateStalled}
+              onPress={() => handleColorSelect('stateStalled')}
+              colors={colors}
+            />
+            <View style={[styles.separator, { backgroundColor: colors.background }]} />
+            <ColorSettingRow
+              label="Paused / Stopped"
+              color={colors.statePaused}
+              onPress={() => handleColorSelect('statePaused')}
+              colors={colors}
+            />
+            <View style={[styles.separator, { backgroundColor: colors.background }]} />
+            <ColorSettingRow
+              label="Checking"
+              color={colors.stateChecking}
+              onPress={() => handleColorSelect('stateChecking')}
+              colors={colors}
+            />
+            <View style={[styles.separator, { backgroundColor: colors.background }]} />
+            <ColorSettingRow
+              label="Metadata"
+              color={colors.stateMetadata}
+              onPress={() => handleColorSelect('stateMetadata')}
+              colors={colors}
+            />
+            <View style={[styles.separator, { backgroundColor: colors.background }]} />
+            <ColorSettingRow
+              label="Queued"
+              color={colors.stateQueued}
+              onPress={() => handleColorSelect('stateQueued')}
+              colors={colors}
+            />
+            <View style={[styles.separator, { backgroundColor: colors.background }]} />
+            <ColorSettingRow
+              label="Other"
+              color={colors.stateOther}
+              onPress={() => handleColorSelect('stateOther')}
+              colors={colors}
+            />
+          </View>
+        </View>
+
         {/* Advanced Color Customization */}
         <View style={styles.section}>
           <View style={styles.sectionHeaderRow}>

--- a/components/ExpandableTorrentCard.tsx
+++ b/components/ExpandableTorrentCard.tsx
@@ -50,6 +50,32 @@ export function ExpandableTorrentCard({ torrent, onPress }: ExpandableTorrentCar
 
   const progress = (torrent.progress || 0) * 100;
   const isPaused = torrent.state.includes('paused') || torrent.state.includes('stopped');
+  const dlspeed = torrent.dlspeed ?? 0;
+  const upspeed = torrent.upspeed ?? 0;
+  const downloading = dlspeed > 0;
+  const uploading = upspeed > 0;
+  const stateColor =
+    downloading && uploading
+      ? colors.stateDownloading
+      : uploading
+        ? colors.stateUploadOnly
+        : downloading
+          ? colors.stateDownloading
+          : torrent.state === 'stalledUP' && torrent.progress >= 1
+            ? colors.stateSeeding
+            : torrent.state === 'error' || torrent.state === 'missingFiles' || torrent.state === 'stalledDL'
+              ? colors.stateError
+              : torrent.state === 'stalledUP'
+                ? colors.stateStalled
+                : torrent.state === 'pausedDL' || torrent.state === 'pausedUP' || torrent.state === 'stoppedDL' || torrent.state === 'stoppedUP'
+                  ? colors.statePaused
+                  : torrent.state === 'checkingDL' || torrent.state === 'checkingUP'
+                    ? colors.stateChecking
+                    : torrent.state === 'metaDL' || torrent.state === 'forcedMetaDL'
+                      ? colors.stateMetadata
+                      : torrent.state === 'queuedDL' || torrent.state === 'queuedUP'
+                        ? colors.stateQueued
+                        : colors.stateOther;
 
   return (
     <Animated.View
@@ -77,7 +103,7 @@ export function ExpandableTorrentCard({ torrent, onPress }: ExpandableTorrentCar
             <View
               style={[
                 styles.progressFill,
-                { width: `${progress}%`, backgroundColor: colors.primary },
+                { width: `${progress}%`, backgroundColor: stateColor },
               ]}
             />
           </View>
@@ -92,7 +118,7 @@ export function ExpandableTorrentCard({ torrent, onPress }: ExpandableTorrentCar
             {/* Stats Grid */}
             <View style={styles.statsGrid}>
               <View style={styles.statItem}>
-                <Ionicons name="arrow-down" size={16} color={colors.primary} />
+                <Ionicons name="arrow-down" size={16} color={colors.stateDownloading} />
                 <Text style={[styles.statValue, { color: colors.text }]}>
                   {formatSpeed(torrent.dlspeed)}
                 </Text>
@@ -102,7 +128,7 @@ export function ExpandableTorrentCard({ torrent, onPress }: ExpandableTorrentCar
               </View>
 
               <View style={styles.statItem}>
-                <Ionicons name="arrow-up" size={16} color={colors.success} />
+                <Ionicons name="arrow-up" size={16} color={colors.stateUploadOnly} />
                 <Text style={[styles.statValue, { color: colors.text }]}>
                   {formatSpeed(torrent.upspeed)}
                 </Text>

--- a/components/TorrentDetails.tsx
+++ b/components/TorrentDetails.tsx
@@ -774,13 +774,13 @@ export function TorrentDetails({
               icon="speedometer"
               label="Download"
               value={formatSpeed(torrent.dlspeed)}
-              color={colors.primary}
+              color={colors.stateDownloading}
             />
             <StatCard
               icon="cloud-upload"
               label="Upload"
               value={formatSpeed(torrent.upspeed)}
-              color={colors.success}
+              color={colors.stateUploadOnly}
             />
           </View>
         </View>

--- a/context/ThemeContext.tsx
+++ b/context/ThemeContext.tsx
@@ -17,6 +17,17 @@ interface ThemeContextType {
     error: string;
     success: string;
     warning: string;
+    stateDownloading: string;
+    stateSeeding: string;
+    stateUploadAndDownload: string;
+    stateUploadOnly: string;
+    stateError: string;
+    stateStalled: string;
+    statePaused: string;
+    stateChecking: string;
+    stateMetadata: string;
+    stateQueued: string;
+    stateOther: string;
   };
 }
 
@@ -31,6 +42,17 @@ const lightColors = {
   error: 'rgb(255, 13, 0,0.5)',
   success: 'rgb(4, 134, 37,0.5)', // Better contrast than pure gray
   warning: 'rgba(255, 153, 0, 0.5)', // Brighter orange
+  stateDownloading: 'rgb(0, 123, 255,0.8)',
+  stateSeeding: 'rgb(4, 134, 37,0.5)',
+  stateUploadAndDownload: '#6B7B8C',
+  stateUploadOnly: '#93C5E4',
+  stateError: 'rgb(255, 13, 0,0.5)',
+  stateStalled: 'rgb(255, 69, 0,0.6)',
+  statePaused: 'rgb(142, 142, 147,0.8)',
+  stateChecking: 'rgba(255, 153, 0, 0.6)',
+  stateMetadata: 'rgba(255, 153, 0, 0.6)',
+  stateQueued: 'rgb(142, 142, 147,0.7)',
+  stateOther: 'rgb(142, 142, 147,0.7)',
 };
 
 const darkColors = {
@@ -44,6 +66,17 @@ const darkColors = {
   error: 'rgb(255, 13, 0,0.8)',
   success: 'rgb(4, 134, 37,0.8)', // Better contrast than pure gray
   warning: 'rgba(255, 153, 0, 0.8)', // Brighter orange
+  stateDownloading: 'rgb(0, 123, 255,0.8)',
+  stateSeeding: 'rgb(4, 134, 37,0.8)',
+  stateUploadAndDownload: '#6B7B8C',
+  stateUploadOnly: '#93C5E4',
+  stateError: 'rgb(255, 13, 0,0.8)',
+  stateStalled: 'rgb(255, 69, 0,0.8)',
+  statePaused: 'rgb(60, 60, 60)',
+  stateChecking: 'rgba(255, 153, 0, 0.8)',
+  stateMetadata: 'rgba(255, 153, 0, 0.8)',
+  stateQueued: 'rgb(100, 100, 100)',
+  stateOther: 'rgb(100, 100, 100)',
 };
 
 // True black theme for OLED displays
@@ -58,6 +91,17 @@ const trueBlackColors = {
   error: 'rgb(255, 69, 58)', // Brighter red
   success: 'rgb(52, 199, 89)',
   warning: 'rgb(252, 151, 0)', // Brighter orange
+  stateDownloading: 'rgb(10, 132, 255)',
+  stateSeeding: 'rgb(52, 199, 89)',
+  stateUploadAndDownload: '#6B7B8C',
+  stateUploadOnly: '#93C5E4',
+  stateError: 'rgb(255, 69, 58)',
+  stateStalled: 'rgb(255, 159, 67)',
+  statePaused: 'rgb(90, 90, 90)',
+  stateChecking: 'rgb(252, 151, 0)',
+  stateMetadata: 'rgb(252, 151, 0)',
+  stateQueued: 'rgb(110, 110, 110)',
+  stateOther: 'rgb(110, 110, 110)',
 };
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qRemote",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "main": "index.ts",
   "scripts": {
     "start": "expo start --go",

--- a/services/color-theme-manager.ts
+++ b/services/color-theme-manager.ts
@@ -10,6 +10,28 @@ export interface ColorTheme {
   surfaceOutline?: string;
   text?: string;
   textSecondary?: string;
+  /** Torrent state: downloading only */
+  stateDownloading?: string;
+  /** Torrent state: idle seeding (100% complete) */
+  stateSeeding?: string;
+  /** Torrent state: uploading and downloading at once */
+  stateUploadAndDownload?: string;
+  /** Torrent state: uploading only */
+  stateUploadOnly?: string;
+  /** Torrent state: error / missing files / stalled download */
+  stateError?: string;
+  /** Torrent state: stalled upload (not yet complete) */
+  stateStalled?: string;
+  /** Torrent state: paused or stopped */
+  statePaused?: string;
+  /** Torrent state: checking (hashing) */
+  stateChecking?: string;
+  /** Torrent state: metadata download */
+  stateMetadata?: string;
+  /** Torrent state: queued */
+  stateQueued?: string;
+  /** Torrent state: other (allocating, moving, unknown) */
+  stateOther?: string;
 }
 
 const CUSTOM_COLORS_KEY = 'customColors';
@@ -60,6 +82,27 @@ export const colorThemeManager = {
         ...preferences,
         [CUSTOM_COLORS_KEY]: customColors,
       });
+    } catch (error) {
+      throw error;
+    }
+  },
+
+  /** Keys used only for torrent state colors (can be reset independently) */
+  torrentStateColorKeys: [
+    'stateDownloading', 'stateSeeding', 'stateUploadAndDownload', 'stateUploadOnly',
+    'stateError', 'stateStalled', 'statePaused', 'stateChecking', 'stateMetadata', 'stateQueued', 'stateOther',
+  ] as const,
+
+  /**
+   * Reset only torrent state colors to defaults for a specific theme (keeps advanced colors)
+   */
+  async resetTorrentStateColors(isDark: boolean): Promise<void> {
+    try {
+      const custom = await this.getCustomColors(isDark);
+      if (!custom) return;
+      const updated = { ...custom };
+      this.torrentStateColorKeys.forEach((key) => delete updated[key]);
+      await this.saveCustomColors(isDark, updated);
     } catch (error) {
       throw error;
     }


### PR DESCRIPTION
## Summary
Changelog and theme updates for 2.0.2/2.0.3: default save path fix, transfer stats fix, and full customizable torrent state colors with consistent mapping and UI tweaks.

## Changes

### Fixes
- **Default save path** – Updates in Settings now call `applicationApi.setPreferences({ save_path })` when connected so the qBittorrent server default save path is updated (2.0.2).
- **Transfer stats** – Free disk space, queued size, and avg queue time no longer disappear after switching server (2.0.1).
- **DL+UL color** – When a torrent is both downloading and uploading, the state color is now the **Downloading** color instead of a separate blue-grey.

### Theme & Colors (2.0.3)
- **Customizable torrent state colors** – All 11 states are themeable in Settings → Theme & Colors → Torrent State Colors: Downloading, Seeding (idle), Download + Upload, Upload only, Error / Stalled DL, Stalled (upload), Paused / Stopped, Checking, Metadata, Queued, Other.
- **Reset for torrent state colors** – New refresh control in the Torrent State Colors section that resets only those 11 colors to defaults (Advanced colors and their reset are unchanged).
- **Section order** – Torrent State Colors is shown above Advanced Colors in theme settings.

### Consistency / Gaps
- Torrent state colors are used everywhere relevant: list cards (badge, border, progress), detail screen badge, compact view DL/UL arrows, TorrentDetails Download/Upload stat cards, ExpandableTorrentCard progress bar and arrows.
- Optimistic “Paused” on the detail screen uses `statePaused` instead of `surfaceOutline`.

### Changelog
- 2.0.3 entry added for the color options and related behavior.
- 2.0.2 entry: default save path fix.
- 2.0.1: transfer stats fix + What’s New updates.
- Release dates normalized (e.g. 2025-02-26 for 2.0.2).