### PR TITLE
feat: support magnet links on iOS/Android and open Add Torrent dialog (full or compact)

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -23,6 +23,12 @@ module.exports = {
         NSAppTransportSecurity: {
           NSAllowsArbitraryLoads: true,
         },
+        CFBundleURLTypes: [
+          {
+            CFBundleURLName: 'com.qRemote.app.magnet',
+            CFBundleURLSchemes: ['magnet'],
+          },
+        ],
       },
     },
     android: {
@@ -33,7 +39,19 @@ module.exports = {
       edgeToEdgeEnabled: true,
       predictiveBackGestureEnabled: false,
       package: 'com.qRemote.app',
-	  usesCleartextTraffic: true,
+      usesCleartextTraffic: true,
+      intentFilters: [
+        {
+          action: 'VIEW',
+          autoVerify: false,
+          data: [
+            {
+              scheme: 'magnet',
+            },
+          ],
+          category: ['BROWSABLE', 'DEFAULT'],
+        },
+      ],
     },
     web: {
       favicon: './assets/favicon.png',
@@ -48,4 +66,3 @@ module.exports = {
     owner: 'taylorcox75',
   },
 };
-

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -23,7 +23,7 @@ import {
 } from 'react-native';
 import { Swipeable, RectButton } from 'react-native-gesture-handler';
 import { useTranslation } from 'react-i18next';
-import { useRouter, useFocusEffect } from 'expo-router';
+import { useRouter, useFocusEffect, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import * as DocumentPicker from 'expo-document-picker';
 import { useTorrents } from '@/context/TorrentContext';
@@ -48,6 +48,8 @@ import { typography } from '@/constants/typography';
 import { QuickConnectPanel } from '@/components/QuickConnectPanel';
 import { useTorrentActions } from '@/hooks/useTorrentActions';
 import { getErrorMessage } from '@/utils/error';
+import { extractMagnetLink } from '@/utils/magnet';
+import { getAddTorrentDialogueVariant } from '@/utils/add-torrent-dialogue';
 
 export default function TorrentsScreen() {
   const { t } = useTranslation();
@@ -56,6 +58,7 @@ export default function TorrentsScreen() {
   const { torrents, isLoading, error, refresh, isRecoveringFromBackground, initialLoadComplete } = useTorrents();
   const { isConnected, currentServer, isLoading: serverIsLoading, connectToServer } = useServer();
   const { colors, isDark } = useTheme();
+  const params = useLocalSearchParams<{ magnet?: string | string[] }>();
 
   // State
   const [searchQuery, setSearchQuery] = useState('');
@@ -74,6 +77,7 @@ export default function TorrentsScreen() {
   const [expandedCardFields, setExpandedCardFields] = useState<Record<ExpandedCardField, boolean>>(
     DEFAULT_PREFERENCES.expandedCardFields
   );
+  const lastAppliedMagnetRef = useRef<{ value: string; at: number } | null>(null);
 
   // Action menu state
   const [selectedTorrent, setSelectedTorrent] = useState<TorrentInfo | null>(null);
@@ -173,6 +177,61 @@ export default function TorrentsScreen() {
       })();
     }
   }, [isConnected]);
+
+  const handleOpenAddTorrent = useCallback(async () => {
+    try {
+      const prefs = await storageService.getPreferences();
+      if (prefs.useFullAddTorrentDialogue) {
+        router.push('/torrents/add');
+        return;
+      }
+    } catch {
+      // Fall back to compact modal.
+    }
+    setShowAddModal(true);
+  }, [router]);
+
+  useEffect(() => {
+    const rawMagnet = Array.isArray(params.magnet) ? params.magnet[0] : params.magnet;
+    const magnetLink = extractMagnetLink(rawMagnet);
+    if (!magnetLink) return;
+
+    const now = Date.now();
+    if (
+      lastAppliedMagnetRef.current &&
+      lastAppliedMagnetRef.current.value === magnetLink &&
+      now - lastAppliedMagnetRef.current.at < 1500
+    ) {
+      return;
+    }
+    lastAppliedMagnetRef.current = { value: magnetLink, at: now };
+
+    const handleIncomingMagnet = async () => {
+      let variant: 'compact' | 'full' = 'compact';
+      try {
+        const prefs = await storageService.getPreferences();
+        variant = getAddTorrentDialogueVariant(prefs);
+      } catch {
+        // Keep compact fallback.
+      }
+
+      if (variant === 'full') {
+        router.push({
+          pathname: '/torrents/add',
+          params: { magnet: magnetLink },
+        });
+        router.replace('/');
+        return;
+      }
+
+      setTorrentUrl(magnetLink);
+      setSelectedFile(null);
+      setShowAddModal(true);
+      router.replace('/');
+    };
+
+    void handleIncomingMagnet();
+  }, [params.magnet, router]);
 
   // Filter, sort, and search logic
   const filteredTorrents = useMemo(() => {
@@ -749,17 +808,8 @@ export default function TorrentsScreen() {
               {!selectMode && (
                 <TouchableOpacity
                   style={[styles.headerAddButton, { backgroundColor: colors.primary }]}
-                  onPress={async () => {
-                    try {
-                      const prefs = await storageService.getPreferences();
-                      if (prefs.useFullAddTorrentDialogue) {
-                        router.push('/torrents/add');
-                        return;
-                      }
-                    } catch {
-                      // fall back to legacy modal
-                    }
-                    setShowAddModal(true);
+                  onPress={() => {
+                    void handleOpenAddTorrent();
                   }}
                   activeOpacity={0.7}
                 >
@@ -955,7 +1005,9 @@ export default function TorrentsScreen() {
             {filter === 'all' ? (
               <TouchableOpacity
                 style={[styles.emptyButton, { backgroundColor: colors.primary }]}
-                onPress={() => setShowAddModal(true)}
+                onPress={() => {
+                  void handleOpenAddTorrent();
+                }}
               >
                 <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
                   <Ionicons name="add" size={20} color="#FFFFFF" />

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,9 +1,9 @@
 import '@/i18n';
-import { Stack } from 'expo-router';
-import { Dimensions, View } from 'react-native';
+import { Stack, useRouter } from 'expo-router';
+import { Dimensions, Linking, View } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { queryClient } from '@/services/query-client';
 import { ServerProvider } from '@/context/ServerContext';
@@ -16,12 +16,53 @@ import { storageService } from '@/services/storage';
 import { apiClient } from '@/services/api/client';
 import { setHapticsEnabled } from '@/utils/haptics';
 import { setDebugMode as setConnectivityDebugMode } from '@/services/connectivity-log';
+import { extractMagnetLink } from '@/utils/magnet';
 
 const { width } = Dimensions.get('window');
 
 function StackNavigator() {
   const { colors } = useTheme();
-  
+  const router = useRouter();
+  const lastHandledMagnetRef = useRef<{ value: string; at: number } | null>(null);
+
+  useEffect(() => {
+    const handleIncomingUrl = (incomingUrl?: string | null) => {
+      const magnetLink = extractMagnetLink(incomingUrl);
+      if (!magnetLink) return;
+
+      const now = Date.now();
+      if (
+        lastHandledMagnetRef.current &&
+        lastHandledMagnetRef.current.value === magnetLink &&
+        now - lastHandledMagnetRef.current.at < 1500
+      ) {
+        return;
+      }
+      lastHandledMagnetRef.current = { value: magnetLink, at: now };
+
+      router.push({
+        pathname: '/',
+        params: { magnet: magnetLink },
+      });
+    };
+
+    const subscription = Linking.addEventListener('url', ({ url }) => {
+      handleIncomingUrl(url);
+    });
+
+    Linking.getInitialURL()
+      .then((url) => {
+        handleIncomingUrl(url);
+      })
+      .catch(() => {
+        // No initial URL — safe to ignore.
+      });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [router]);
+
   return (
     <View style={{ flex: 1, backgroundColor: colors.background }}>
       <Stack
@@ -94,4 +135,3 @@ export default function RootLayout() {
     </GestureHandlerRootView>
   );
 }
-

--- a/app/torrents/add.tsx
+++ b/app/torrents/add.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -12,7 +12,7 @@ import {
   Switch,
 } from 'react-native';
 import { useTranslation } from 'react-i18next';
-import { useRouter, useFocusEffect } from 'expo-router';
+import { useRouter, useFocusEffect, useLocalSearchParams } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as DocumentPicker from 'expo-document-picker';
@@ -32,6 +32,7 @@ import { DEFAULT_PREFERENCES, AddTorrentDialogField } from '@/types/preferences'
 import { spacing, borderRadius } from '@/constants/spacing';
 import { shadows } from '@/constants/shadows';
 import { typography } from '@/constants/typography';
+import { extractMagnetLink } from '@/utils/magnet';
 
 type AddTorrentOptions = Parameters<typeof torrentsApi.addTorrent>[1];
 type AddTorrentFileOptions = Parameters<typeof torrentsApi.addTorrentFile>[1];
@@ -44,6 +45,8 @@ export default function AddTorrentFullScreen() {
   const { showToast } = useToast();
   const { isConnected } = useServer();
   const { categories, tags } = useTorrents();
+  const params = useLocalSearchParams<{ magnet?: string | string[] }>();
+  const lastAppliedMagnetRef = useRef<string | null>(null);
 
   const [fieldVisibility, setFieldVisibility] = useState<Record<AddTorrentDialogField, boolean>>(
     DEFAULT_PREFERENCES.addTorrentDialogueFields
@@ -223,6 +226,17 @@ export default function AddTorrentFullScreen() {
   }, [t, tagValues]);
 
   const showField = (field: AddTorrentDialogField) => fieldVisibility[field] === true;
+
+  useEffect(() => {
+    const rawMagnet = Array.isArray(params.magnet) ? params.magnet[0] : params.magnet;
+    const magnetLink = extractMagnetLink(rawMagnet);
+    if (!magnetLink) return;
+    if (lastAppliedMagnetRef.current === magnetLink) return;
+
+    lastAppliedMagnetRef.current = magnetLink;
+    setTorrentUrl(magnetLink);
+    setSelectedFile(null);
+  }, [params.magnet]);
 
   return (
     <>
@@ -837,4 +851,3 @@ const styles = StyleSheet.create({
   },
   primaryButtonText: { color: '#FFFFFF', fontSize: 16, fontWeight: '700' },
 });
-

--- a/tests/utils/add-torrent-dialogue.test.ts
+++ b/tests/utils/add-torrent-dialogue.test.ts
@@ -1,0 +1,17 @@
+import { getAddTorrentDialogueVariant } from '@/utils/add-torrent-dialogue';
+
+describe('getAddTorrentDialogueVariant', () => {
+  it('returns compact by default', () => {
+    expect(getAddTorrentDialogueVariant(undefined)).toBe('compact');
+    expect(getAddTorrentDialogueVariant(null)).toBe('compact');
+    expect(getAddTorrentDialogueVariant({})).toBe('compact');
+  });
+
+  it('returns compact when full dialogue is disabled', () => {
+    expect(getAddTorrentDialogueVariant({ useFullAddTorrentDialogue: false })).toBe('compact');
+  });
+
+  it('returns full when full dialogue is enabled', () => {
+    expect(getAddTorrentDialogueVariant({ useFullAddTorrentDialogue: true })).toBe('full');
+  });
+});

--- a/tests/utils/app-config.test.ts
+++ b/tests/utils/app-config.test.ts
@@ -1,0 +1,26 @@
+describe('app.config magnet registration', () => {
+  const config = require('../../app.config.js');
+  const expoConfig = config.expo;
+
+  it('registers magnet URL scheme on iOS', () => {
+    const urlTypes = expoConfig?.ios?.infoPlist?.CFBundleURLTypes;
+    expect(Array.isArray(urlTypes)).toBe(true);
+
+    const hasMagnetScheme = urlTypes.some((entry: { CFBundleURLSchemes?: string[] }) =>
+      Array.isArray(entry.CFBundleURLSchemes) && entry.CFBundleURLSchemes.includes('magnet')
+    );
+
+    expect(hasMagnetScheme).toBe(true);
+  });
+
+  it('registers magnet intent filter on Android', () => {
+    const intentFilters = expoConfig?.android?.intentFilters;
+    expect(Array.isArray(intentFilters)).toBe(true);
+
+    const hasMagnetIntent = intentFilters.some((filter: { data?: Array<{ scheme?: string }> }) =>
+      Array.isArray(filter.data) && filter.data.some((d) => d.scheme === 'magnet')
+    );
+
+    expect(hasMagnetIntent).toBe(true);
+  });
+});

--- a/tests/utils/magnet.test.ts
+++ b/tests/utils/magnet.test.ts
@@ -1,0 +1,52 @@
+import { extractMagnetLink, isMagnetLink } from '@/utils/magnet';
+
+describe('isMagnetLink', () => {
+  it('returns true for valid magnet links', () => {
+    expect(isMagnetLink('magnet:?xt=urn:btih:abc123')).toBe(true);
+  });
+
+  it('is case-insensitive and ignores outer whitespace', () => {
+    expect(isMagnetLink('  MAGNET:?xt=urn:btih:abc123  ')).toBe(true);
+  });
+
+  it('returns false for non-magnet values', () => {
+    expect(isMagnetLink('https://example.com/file.torrent')).toBe(false);
+    expect(isMagnetLink('')).toBe(false);
+  });
+});
+
+describe('extractMagnetLink', () => {
+  const sampleMagnet = 'magnet:?xt=urn:btih:ABCDEF1234567890&dn=Ubuntu';
+  const encodedSampleMagnet = encodeURIComponent(sampleMagnet);
+
+  it('extracts direct magnet links', () => {
+    expect(extractMagnetLink(sampleMagnet)).toBe(sampleMagnet);
+  });
+
+  it('extracts URL-encoded direct magnet links', () => {
+    expect(extractMagnetLink(encodedSampleMagnet)).toBe(sampleMagnet);
+  });
+
+  it('extracts magnet from deep-link magnet param', () => {
+    const incomingUrl = `qRemote:///?magnet=${encodedSampleMagnet}`;
+    expect(extractMagnetLink(incomingUrl)).toBe(sampleMagnet);
+  });
+
+  it('extracts magnet from deep-link url param', () => {
+    const incomingUrl = `qRemote:///?url=${encodedSampleMagnet}`;
+    expect(extractMagnetLink(incomingUrl)).toBe(sampleMagnet);
+  });
+
+  it('returns null when no magnet link exists', () => {
+    expect(extractMagnetLink('qRemote:///?foo=bar')).toBeNull();
+    expect(extractMagnetLink('https://example.com/file.torrent')).toBeNull();
+    expect(extractMagnetLink('')).toBeNull();
+    expect(extractMagnetLink(undefined)).toBeNull();
+    expect(extractMagnetLink(null)).toBeNull();
+  });
+
+  it('falls back to regex extraction for free-form text', () => {
+    const incomingText = `Hey, use this ${sampleMagnet} thanks`;
+    expect(extractMagnetLink(incomingText)).toBe(sampleMagnet);
+  });
+});

--- a/utils/add-torrent-dialogue.ts
+++ b/utils/add-torrent-dialogue.ts
@@ -1,0 +1,9 @@
+import { AppPreferences } from '@/types/preferences';
+
+export type AddTorrentDialogueVariant = 'compact' | 'full';
+
+export const getAddTorrentDialogueVariant = (
+  preferences: Partial<AppPreferences> | null | undefined
+): AddTorrentDialogueVariant => {
+  return preferences?.useFullAddTorrentDialogue === true ? 'full' : 'compact';
+};

--- a/utils/magnet.ts
+++ b/utils/magnet.ts
@@ -1,0 +1,48 @@
+const MAGNET_PREFIX = 'magnet:?';
+
+const safeDecode = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+export const isMagnetLink = (value: string): boolean => value.trim().toLowerCase().startsWith(MAGNET_PREFIX);
+
+/**
+ * Extract a magnet URI from an arbitrary incoming URL.
+ * Supports direct `magnet:?` links and app deep links that carry it in query params.
+ */
+export const extractMagnetLink = (incomingUrl?: string | null): string | null => {
+  if (!incomingUrl) return null;
+
+  const raw = incomingUrl.trim();
+  if (!raw) return null;
+
+  const decodedRaw = safeDecode(raw);
+  if (isMagnetLink(decodedRaw)) {
+    return decodedRaw;
+  }
+
+  try {
+    const parsed = new URL(raw);
+    const candidates = [
+      parsed.searchParams.get('magnet'),
+      parsed.searchParams.get('url'),
+      parsed.searchParams.get('link'),
+    ].filter((value): value is string => !!value);
+
+    for (const candidate of candidates) {
+      const decodedCandidate = safeDecode(candidate.trim());
+      if (isMagnetLink(decodedCandidate)) {
+        return decodedCandidate;
+      }
+    }
+  } catch {
+    // Ignore parse errors and try regex fallback.
+  }
+
+  const fallback = decodedRaw.match(/magnet:\?[^\s]+/i)?.[0];
+  return fallback && isMagnetLink(fallback) ? fallback : null;
+};


### PR DESCRIPTION
## Summary
This PR adds end-to-end handling for `magnet:` links so qRemote can be opened directly from external magnet URLs on both iOS and Android, and then open the correct Add Torrent experience based on user preference:

- `useFullAddTorrentDialogue = true` -> opens **Full Add Torrent dialog**
- `useFullAddTorrentDialogue = false` -> opens **Compact Add Torrent dialog**

## What functionality was added
- OS-level magnet deep-link support:
  - iOS URL registration for `magnet:`
  - Android intent filter for `magnet:`
- App-level incoming URL handling:
  - Handles both cold-start (`getInitialURL`) and in-app URL events
  - Extracts magnet URI safely from incoming URLs/params
- Add-dialog routing behavior:
  - Incoming magnet is routed through the torrents screen
  - Preference-based decision opens full or compact add flow
- Prefill behavior:
  - Full dialog receives and pre-fills magnet
  - Compact dialog opens with magnet pre-filled
- Duplicate-event protection:
  - Short dedupe window prevents accidental double-open from repeated system URL events

## Implementation details
- Added shared magnet parsing utility:
  - `utils/magnet.ts`
- Added shared dialog variant decision helper:
  - `utils/add-torrent-dialogue.ts`
- Integrated deep-link handling at root navigation level:
  - `app/_layout.tsx`
- Integrated preference-aware routing + compact modal prefill:
  - `app/(tabs)/index.tsx`
- Integrated full dialog prefill from route params:
  - `app/torrents/add.tsx`
- Added native config:
  - `app.config.js` (iOS URL types + Android intent filters)

## Test coverage
Added unit tests for:
- Magnet parsing and extraction behavior:
  - `tests/utils/magnet.test.ts`
- Add dialog variant selection logic:
  - `tests/utils/add-torrent-dialogue.test.ts`
- Native config regression checks:
  - `tests/utils/app-config.test.ts`

These tests validate:
- Direct magnet links
- Encoded links
- Deep-link query param extraction
- Invalid/non-magnet input handling
- Full vs compact decision logic
- iOS/Android config entries remain present

## Manual QA
Verified manually on native simulator builds (not in Expo Go / Expo runner):
- Built and ran with native flows for both platforms
- Tested in **iOS Simulator** and **Android Emulator**
- Confirmed both dialog modes open correctly from magnet links and prefill the source field

## Screenshots
### iOS Simulator (magnet flow working)
<img width="568" height="1084" alt="SCR-20260403-iupy" src="https://github.com/user-attachments/assets/398f1f88-f7b9-4ff2-8483-6665d00bf5d4" />
<img width="568" height="1084" alt="SCR-20260403-iurm" src="https://github.com/user-attachments/assets/261c1088-a50d-41a7-994e-254c113ad315" />



### Android Emulator
(links work in chrome without asking)
<img width="527" height="1029" alt="SCR-20260403-jdty" src="https://github.com/user-attachments/assets/91b005c6-7936-453b-ac6c-46db21a268c6" />
