### PR TITLE
fix: settings disconnect badge contrast

### DIFF
--- a/app/(tabs)/settings.tsx
+++ b/app/(tabs)/settings.tsx
@@ -24,6 +24,7 @@ import { APP_VERSION } from '@/utils/version';
 import { spacing, borderRadius } from '@/constants/spacing';
 import { shadows } from '@/constants/shadows';
 import { typography } from '@/constants/typography';
+import { colorThemeManager } from '@/services/color-theme-manager';
 
 type IconName = React.ComponentProps<typeof Ionicons>['name'];
 
@@ -56,6 +57,10 @@ export default function SettingsScreen() {
   const router = useRouter();
   const { currentServer, isConnected, disconnect } = useServer();
   const { isDark, colors } = useTheme();
+  const disconnectBadgeBackground = colorThemeManager.hexToRgba(
+    colorThemeManager.rgbaToHex(colors.error),
+    0.18
+  );
 
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
@@ -111,8 +116,16 @@ export default function SettingsScreen() {
                   </Text>
                 </View>
                 {isConnected && (
-                  <View style={[styles.disconnectBadge, { backgroundColor: colors.error + '20' }]}>
-                    <Text style={[styles.disconnectText, { color: colors.error }]}>
+                  <View
+                    style={[
+                      styles.disconnectBadge,
+                      {
+                        backgroundColor: disconnectBadgeBackground,
+                        borderColor: colors.error,
+                      },
+                    ]}
+                  >
+                    <Text style={[styles.disconnectText, { color: colors.text }]}>
                       {t('screens.settings.disconnect')}
                     </Text>
                   </View>
@@ -238,6 +251,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 6,
     borderRadius: borderRadius.small,
+    borderWidth: 1,
   },
   disconnectText: {
     fontSize: 14,


### PR DESCRIPTION
## Summary

Fix the Settings screen disconnect badge so its label stays readable.

The previous implementation built the badge background with `colors.error + '20'`, which breaks when the theme color is stored as `rgba(...)`. That caused the badge to render as a solid red block and made the text effectively invisible.

This change:
- derives a proper translucent error background from the theme color
- keeps the error-colored border
- uses the normal theme text color for reliable label contrast

## Before

<img width="568" height="1084" alt="SCR-20260403-kaaw" src="https://github.com/user-attachments/assets/fcfea16d-ca80-434a-8c55-6a9a8c44d5e3" />

## After

<img width="568" height="1084" alt="SCR-20260403-kaeh" src="https://github.com/user-attachments/assets/7c18a020-0389-4db5-bae1-5b0fc2f18735" />


## Verification

- `npx tsc --noEmit`
