### PR TITLE
qBittorrent 5.2+ compatibility and API Key support

### DIFF
--- a/app/server/[id].tsx
+++ b/app/server/[id].tsx
@@ -48,6 +48,8 @@ export default function EditServerScreen() {
   const [port, setPort] = useState('');
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [useApiKey, setUseApiKey] = useState(false);
   const [useHttps, setUseHttps] = useState(false);
   const [bypassAuth, setBypassAuth] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -121,8 +123,11 @@ export default function EditServerScreen() {
     }
     
     // Missing credentials
-    if (!bypassAuth && (!username.trim() || !password.trim())) {
+    if (!bypassAuth && !useApiKey && (!username.trim() || !password.trim())) {
       warnings.push({ type: 'error', message: "Username and password required (or enable Bypass Authentication)." });
+    }
+    if (!bypassAuth && useApiKey && !apiKey.trim()) {
+      warnings.push({ type: 'error', message: "API Key required (or enable Bypass Authentication)." });
     }
     
     return {
@@ -140,7 +145,7 @@ export default function EditServerScreen() {
       hasErrors: warnings.some(w => w.type === 'error'),
       hasWarnings: warnings.some(w => w.type === 'warning'),
     };
-  }, [host, port, useHttps, bypassAuth, username, password]);
+  }, [host, port, useHttps, bypassAuth, username, password, apiKey, useApiKey]);
 
   // Copy debug info to clipboard
   const copyDebugInfo = async () => {
@@ -151,6 +156,7 @@ Host: ${debugInfo.cleanHost || '(empty)'}
 Port: ${debugInfo.portNum || 'default (80/443)'}
 HTTPS: ${useHttps ? 'Yes' : 'No'}
 Auth Bypass: ${bypassAuth ? 'Yes' : 'No'}
+API Key: ${useApiKey ? 'Yes' : 'No'}
 
 Login Endpoint: ${debugInfo.loginEndpoint}
 Version Endpoint: ${debugInfo.versionEndpoint}
@@ -190,6 +196,8 @@ App Version: ${APP_VERSION}`;
         setPort(hasPort ? server.port!.toString() : '');
         setUsername(server.username || '');
         setPassword(server.password || '');
+        setApiKey(server.apiKey || '');
+        setUseApiKey(server.useApiKey || false)
         setUseHttps(server.useHttps || false);
         setBypassAuth(server.bypassAuth || false);
         // Preserve existing basePath for backward compatibility
@@ -212,8 +220,12 @@ App Version: ${APP_VERSION}`;
       return;
     }
 
-    if (!bypassAuth && (!username.trim() || !password.trim())) {
+    if (!bypassAuth && !useApiKey && (!username.trim() || !password.trim())) {
       showToast(t('errors.fillUsernamePassword'), 'error');
+      return;
+    }
+    if (!bypassAuth && useApiKey && !apiKey.trim()) {
+      showToast(t('errors.fillApiKey'), 'error');
       return;
     }
 
@@ -237,8 +249,10 @@ App Version: ${APP_VERSION}`;
         host: stripProtocol(host.trim()),
         port: portNum,
         basePath: preservedBasePath, // Preserve existing basePath for backward compatibility
-        username: bypassAuth ? '' : username.trim(),
-        password: bypassAuth ? '' : password.trim(),
+        username: bypassAuth || useApiKey ? '' : username.trim(),
+        password: bypassAuth || useApiKey ? '' : password.trim(),
+        apiKey: bypassAuth || !useApiKey ? '' : apiKey.trim(),
+        useApiKey,
         useHttps,
         bypassAuth,
       };
@@ -282,8 +296,12 @@ App Version: ${APP_VERSION}`;
       return;
     }
 
-    if (!bypassAuth && (!username.trim() || !password.trim())) {
+    if (!bypassAuth && !useApiKey && (!username.trim() || !password.trim())) {
       showToast(t('errors.fillUsernamePassword'), 'error');
+      return;
+    }
+    if (!bypassAuth && useApiKey && !apiKey.trim()) {
+      showToast(t('errors.fillApiKey'), 'error');
       return;
     }
 
@@ -302,8 +320,10 @@ App Version: ${APP_VERSION}`;
         name: name.trim(),
         host: stripProtocol(host.trim()),
         port: portNum,
-        username: bypassAuth ? '' : username.trim(),
-        password: bypassAuth ? '' : password.trim(),
+        username: bypassAuth || useApiKey ? '' : username.trim(),
+        password: bypassAuth || useApiKey ? '' : password.trim(),
+        apiKey: bypassAuth || !useApiKey ? '' : apiKey.trim(),
+        useApiKey,
         useHttps,
         bypassAuth,
       };
@@ -437,43 +457,80 @@ App Version: ${APP_VERSION}`;
 
           {/* Authentication Section */}
           {!bypassAuth && (
-            <View style={styles.section}>
-              <Text style={[styles.sectionHeader, { color: colors.textSecondary }]}>{t('server.authentication')}</Text>
-              <View style={[styles.card, { backgroundColor: colors.surface }]}>
-                <View style={styles.inputRow}>
-                  <Ionicons name="person-outline" size={20} color={colors.primary} style={styles.inputIcon} />
-                <TextInput
-                  style={[styles.input, { color: colors.text }]}
-                  value={username}
-                  onChangeText={setUsername}
-                  placeholder={t('placeholders.username')}
-                  placeholderTextColor={colors.textSecondary}
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  textContentType="none"
-                  autoComplete="off"
-                />
-                </View>
-                <View style={[styles.separator, { backgroundColor: colors.surfaceOutline }]} />
-                <View style={styles.inputRow}>
-                  <Ionicons name="lock-closed-outline" size={20} color={colors.primary} style={styles.inputIcon} />
-                <TextInput
-                  style={[styles.input, { color: colors.text }]}
-                  value={password}
-                  onChangeText={setPassword}
-                  placeholder={t('placeholders.password')}
-                  placeholderTextColor={colors.textSecondary}
-                  secureTextEntry
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  textContentType="password"
-                  autoComplete="off"
-                  passwordRules=""
-                />
-                </View>
-              </View>
-            </View>
-          )}
+           <View style={styles.section}>
+             <Text style={[styles.sectionHeader, { color: colors.textSecondary }]}>{t('server.authentication')}</Text>
+             <View style={[styles.card, { backgroundColor: colors.surface }]}>
+               <View style={styles.settingRow}>
+                 <View style={styles.settingLeft}>
+                   <Ionicons name="key-outline" size={20} color={colors.primary} style={styles.inputIcon} />
+                   <View>
+                     <Text style={[styles.settingLabel, { color: colors.text }]}>{t('server.useApiKey')}</Text>
+                     <Text style={[styles.settingHint, { color: colors.textSecondary }]}>{t('server.useApiKeyHint')}</Text>
+                   </View>
+                 </View>
+                 <Switch
+                   value={useApiKey}
+                   onValueChange={setUseApiKey}
+                   trackColor={{ false: colors.surfaceOutline, true: colors.primary }}
+                   thumbColor="#FFFFFF"
+                 />
+               </View>
+               <View style={[styles.separator, { backgroundColor: colors.surfaceOutline }]} />
+               {useApiKey ? (
+                 <View style={styles.inputRow}>
+                   <Ionicons name="lock-closed-outline" size={20} color={colors.primary} style={styles.inputIcon} />
+                   <TextInput
+                     style={[styles.input, { color: colors.text }]}
+                     value={apiKey}
+                     onChangeText={setApiKey}
+                     placeholder={t('placeholders.apiKey')}
+                     placeholderTextColor={colors.textSecondary}
+                     secureTextEntry
+                     autoCapitalize="none"
+                     autoCorrect={false}
+                     textContentType="password"
+                     autoComplete="off"
+                     passwordRules=""
+                   />
+                 </View>
+               ) : (
+                 <>
+                   <View style={styles.inputRow}>
+                     <Ionicons name="person-outline" size={20} color={colors.primary} style={styles.inputIcon} />
+                     <TextInput
+                       style={[styles.input, { color: colors.text }]}
+                       value={username}
+                       onChangeText={setUsername}
+                       placeholder={t('placeholders.username')}
+                       placeholderTextColor={colors.textSecondary}
+                       autoCapitalize="none"
+                       autoCorrect={false}
+                       textContentType="none"
+                       autoComplete="off"
+                     />
+                   </View>
+                   <View style={[styles.separator, { backgroundColor: colors.surfaceOutline }]} />
+                   <View style={styles.inputRow}>
+                     <Ionicons name="lock-closed-outline" size={20} color={colors.primary} style={styles.inputIcon} />
+                     <TextInput
+                       style={[styles.input, { color: colors.text }]}
+                       value={password}
+                       onChangeText={setPassword}
+                       placeholder={t('placeholders.password')}
+                       placeholderTextColor={colors.textSecondary}
+                       secureTextEntry
+                       autoCapitalize="none"
+                       autoCorrect={false}
+                       textContentType="password"
+                       autoComplete="off"
+                       passwordRules=""
+                     />
+                   </View>
+                 </>
+               )}
+             </View>
+           </View>
+         )}
 
           {/* Security Section */}
           <View style={styles.section}>
@@ -654,6 +711,8 @@ App Version: ${APP_VERSION}`;
                 useHttps={useHttps}
                 username={username}
                 password={password}
+                apiKey={apiKey}
+                useApiKey={useApiKey}
                 bypassAuth={bypassAuth}
               />
             </View>

--- a/app/server/add.tsx
+++ b/app/server/add.tsx
@@ -46,6 +46,8 @@ export default function AddServerScreen() {
   const [port, setPort] = useState('');
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [useApiKey, setUseApiKey] = useState(false);
   const [useHttps, setUseHttps] = useState(false);
   const [bypassAuth, setBypassAuth] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -116,8 +118,11 @@ export default function AddServerScreen() {
     }
     
     // Missing credentials
-    if (!bypassAuth && (!username.trim() || !password.trim())) {
+    if (!bypassAuth && !useApiKey && (!username.trim() || !password.trim())) {
       warnings.push({ type: 'error', message: "Username and password required (or enable Bypass Authentication)." });
+    }
+    if (!bypassAuth && useApiKey && !apiKey.trim()) {
+      warnings.push({ type: 'error', message: "API Key required (or enable Bypass Authentication)." });
     }
     
     return {
@@ -135,7 +140,7 @@ export default function AddServerScreen() {
       hasErrors: warnings.some(w => w.type === 'error'),
       hasWarnings: warnings.some(w => w.type === 'warning'),
     };
-  }, [host, port, useHttps, bypassAuth, username, password]);
+  }, [host, port, useHttps, bypassAuth, username, password, apiKey, useApiKey]);
 
   // Copy debug info to clipboard
   const copyDebugInfo = async () => {
@@ -146,6 +151,7 @@ Host: ${debugInfo.cleanHost || '(empty)'}
 Port: ${debugInfo.portNum || 'default (80/443)'}
 HTTPS: ${useHttps ? 'Yes' : 'No'}
 Auth Bypass: ${bypassAuth ? 'Yes' : 'No'}
+API Key: ${useApiKey ? 'Yes' : 'No'}
 
 Login Endpoint: ${debugInfo.loginEndpoint}
 Version Endpoint: ${debugInfo.versionEndpoint}
@@ -176,8 +182,12 @@ App Version: ${APP_VERSION}`;
       return;
     }
 
-    if (!bypassAuth && (!username.trim() || !password.trim())) {
+    if (!bypassAuth && !useApiKey && (!username.trim() || !password.trim())) {
       showToast(t('errors.fillUsernamePassword'), 'error');
+      return;
+    }
+    if (!bypassAuth && useApiKey && !apiKey.trim()) {
+      showToast(t('errors.fillApiKey'), 'error');
       return;
     }
 
@@ -200,8 +210,10 @@ App Version: ${APP_VERSION}`;
         host: stripProtocol(host.trim()),
         port: portNum,
         basePath: '/',
-        username: bypassAuth ? '' : username.trim(),
-        password: bypassAuth ? '' : password.trim(),
+        username: bypassAuth || useApiKey ? '' : username.trim(),
+        password: bypassAuth || useApiKey ? '' : password.trim(),
+        apiKey: bypassAuth || !useApiKey ? '' : apiKey.trim(),
+        useApiKey,
         useHttps,
         bypassAuth,
       };
@@ -235,8 +247,12 @@ App Version: ${APP_VERSION}`;
       return;
     }
 
-    if (!bypassAuth && (!username.trim() || !password.trim())) {
+    if (!bypassAuth && !useApiKey && (!username.trim() || !password.trim())) {
       showToast(t('errors.fillUsernamePassword'), 'error');
+      return;
+    }
+    if (!bypassAuth && useApiKey && !apiKey.trim()) {
+      showToast(t('errors.fillApiKey'), 'error');
       return;
     }
 
@@ -255,8 +271,10 @@ App Version: ${APP_VERSION}`;
         name: name.trim(),
         host: stripProtocol(host.trim()),
         port: portNum,
-        username: bypassAuth ? '' : username.trim(),
-        password: bypassAuth ? '' : password.trim(),
+        username: bypassAuth || useApiKey ? '' : username.trim(),
+        password: bypassAuth || useApiKey ? '' : password.trim(),
+        apiKey: bypassAuth || !useApiKey ? '' : apiKey.trim(),
+        useApiKey,
         useHttps,
         bypassAuth,
       };
@@ -381,43 +399,80 @@ App Version: ${APP_VERSION}`;
 
           {/* Authentication Section */}
           {!bypassAuth && (
-            <View style={styles.section}>
-              <Text style={[styles.sectionHeader, { color: colors.textSecondary }]}>{t('server.authentication')}</Text>
-              <View style={[styles.card, { backgroundColor: colors.surface }]}>
-                <View style={styles.inputRow}>
-                  <Ionicons name="person-outline" size={20} color={colors.primary} style={styles.inputIcon} />
-                <TextInput
-                  style={[styles.input, { color: colors.text }]}
-                  value={username}
-                  onChangeText={setUsername}
-                  placeholder={t('placeholders.username')}
-                  placeholderTextColor={colors.textSecondary}
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  textContentType="none"
-                  autoComplete="off"
-                />
-                </View>
-                <View style={[styles.separator, { backgroundColor: colors.surfaceOutline }]} />
-                <View style={styles.inputRow}>
-                  <Ionicons name="lock-closed-outline" size={20} color={colors.primary} style={styles.inputIcon} />
-                <TextInput
-                  style={[styles.input, { color: colors.text }]}
-                  value={password}
-                  onChangeText={setPassword}
-                  placeholder={t('placeholders.password')}
-                  placeholderTextColor={colors.textSecondary}
-                  secureTextEntry
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  textContentType="password"
-                  autoComplete="off"
-                  passwordRules=""
-                />
-                </View>
-              </View>
-            </View>
-          )}
+           <View style={styles.section}>
+             <Text style={[styles.sectionHeader, { color: colors.textSecondary }]}>{t('server.authentication')}</Text>
+             <View style={[styles.card, { backgroundColor: colors.surface }]}>
+               <View style={styles.settingRow}>
+                 <View style={styles.settingLeft}>
+                   <Ionicons name="key-outline" size={20} color={colors.primary} style={styles.inputIcon} />
+                   <View>
+                     <Text style={[styles.settingLabel, { color: colors.text }]}>{t('server.useApiKey')}</Text>
+                     <Text style={[styles.settingHint, { color: colors.textSecondary }]}>{t('server.useApiKeyHint')}</Text>
+                   </View>
+                 </View>
+                 <Switch
+                   value={useApiKey}
+                   onValueChange={setUseApiKey}
+                   trackColor={{ false: colors.surfaceOutline, true: colors.primary }}
+                   thumbColor="#FFFFFF"
+                 />
+               </View>
+               <View style={[styles.separator, { backgroundColor: colors.surfaceOutline }]} />
+               {useApiKey ? (
+                 <View style={styles.inputRow}>
+                   <Ionicons name="lock-closed-outline" size={20} color={colors.primary} style={styles.inputIcon} />
+                   <TextInput
+                     style={[styles.input, { color: colors.text }]}
+                     value={apiKey}
+                     onChangeText={setApiKey}
+                     placeholder={t('placeholders.apiKey')}
+                     placeholderTextColor={colors.textSecondary}
+                     secureTextEntry
+                     autoCapitalize="none"
+                     autoCorrect={false}
+                     textContentType="password"
+                     autoComplete="off"
+                     passwordRules=""
+                   />
+                 </View>
+               ) : (
+                 <>
+                   <View style={styles.inputRow}>
+                     <Ionicons name="person-outline" size={20} color={colors.primary} style={styles.inputIcon} />
+                     <TextInput
+                       style={[styles.input, { color: colors.text }]}
+                       value={username}
+                       onChangeText={setUsername}
+                       placeholder={t('placeholders.username')}
+                       placeholderTextColor={colors.textSecondary}
+                       autoCapitalize="none"
+                       autoCorrect={false}
+                       textContentType="none"
+                       autoComplete="off"
+                     />
+                   </View>
+                   <View style={[styles.separator, { backgroundColor: colors.surfaceOutline }]} />
+                   <View style={styles.inputRow}>
+                     <Ionicons name="lock-closed-outline" size={20} color={colors.primary} style={styles.inputIcon} />
+                     <TextInput
+                       style={[styles.input, { color: colors.text }]}
+                       value={password}
+                       onChangeText={setPassword}
+                       placeholder={t('placeholders.password')}
+                       placeholderTextColor={colors.textSecondary}
+                       secureTextEntry
+                       autoCapitalize="none"
+                       autoCorrect={false}
+                       textContentType="password"
+                       autoComplete="off"
+                       passwordRules=""
+                     />
+                   </View>
+                 </>
+               )}
+             </View>
+           </View>
+         )}
 
           {/* Security Section */}
           <View style={styles.section}>
@@ -598,6 +653,8 @@ App Version: ${APP_VERSION}`;
                 useHttps={useHttps}
                 username={username}
                 password={password}
+                apiKey={apiKey}
+                useApiKey={useApiKey}
                 bypassAuth={bypassAuth}
               />
             </View>

--- a/app/settings/advanced.tsx
+++ b/app/settings/advanced.tsx
@@ -86,6 +86,7 @@ export default function AdvancedSettingsScreen() {
           port: s.port,
           basePath: s.basePath,
           username: s.username,
+          useApiKey: s.useApiKey,
           useHttps: s.useHttps,
           bypassAuth: s.bypassAuth,
         })),

--- a/components/SuperDebugPanel.tsx
+++ b/components/SuperDebugPanel.tsx
@@ -38,6 +38,8 @@ export interface SuperDebugPanelProps {
   useHttps: boolean;
   username: string;
   password: string;
+  apiKey: string;
+  useApiKey: boolean;
   bypassAuth: boolean;
 }
 
@@ -63,6 +65,8 @@ export function SuperDebugPanel({
   useHttps,
   username,
   password,
+  apiKey,
+  useApiKey,
   bypassAuth,
 }: SuperDebugPanelProps) {
   const { colors } = useTheme();
@@ -226,8 +230,8 @@ export function SuperDebugPanel({
       addEntry('ERROR', 'Host field is empty. Enter an IP or domain above first.', 'error');
       return;
     }
-    if (!bypassAuth && (!username.trim() || !password.trim())) {
-      addEntry('ERROR', 'Username and password are required. Fill them in above, or enable "Bypass Authentication".', 'error');
+    if (!bypassAuth && !apiKey.trim() && (!username.trim() || !password.trim())) {
+      addEntry('ERROR', 'Username and password or API Key are required. Fill them in above, or enable "Bypass Authentication".', 'error');
       return;
     }
 
@@ -247,10 +251,10 @@ export function SuperDebugPanel({
     addEntry('INFO', `Target: ${baseUrl}`, 'info');
     addEntry('INFO', `Platform: ${Platform.OS} ${Platform.Version}`, 'info');
     addEntry('INFO', `App: ${APP_VERSION}`, 'info');
-    addEntry('INFO', `HTTPS: ${useHttps ? 'Yes' : 'No'} | Auth Bypass: ${bypassAuth ? 'Yes' : 'No'}`, 'info');
+    addEntry('INFO', `HTTPS: ${useHttps ? 'Yes' : 'No'} | Auth Bypass: ${bypassAuth ? 'Yes' : 'No'} | API Key: ${useApiKey ? 'Yes' : 'No'}`, 'info');
 
     let passed = 0;
-    const totalSteps = bypassAuth ? 2 : 4;
+    const totalSteps = bypassAuth || apiKey.trim() ? 2 : 4;
     let sidCookie = '';
 
     try {
@@ -295,6 +299,10 @@ export function SuperDebugPanel({
 
       if (bypassAuth) {
         addEntry('INFO', 'Steps 2-3 skipped (auth bypass enabled).', 'info');
+      } else if (apiKey.trim()) {
+        addEntry('INFO', 'Steps 2-3 skipped (API key auth — no login needed).', 'info');
+        // Set Bearer token for Step 4
+        sidCookie = ''; // not used but clear it
       } else {
         // -- Step 2: Login ----------------------------------------------------
         addEntry('LOGIN', 'Step 2 — Can the app log in?', 'info');
@@ -312,7 +320,7 @@ export function SuperDebugPanel({
           const loginBody = await loginResp.text();
           const bodyTrimmed = loginBody.trim();
 
-          if (bodyTrimmed === 'Ok.' || bodyTrimmed === 'Ok') {
+          if (bodyTrimmed === 'Ok.' || bodyTrimmed === 'Ok' || bodyTrimmed === '' || loginResp.status === 204) {
             addEntry('LOGIN', `Login successful — "${bodyTrimmed}" (HTTP ${loginResp.status}, ${loginLatency}ms)`, 'success');
           } else if (bodyTrimmed === 'Fails.' || bodyTrimmed === 'Fails') {
             addEntry('LOGIN', `Login REJECTED — "${bodyTrimmed}" (HTTP ${loginResp.status}, ${loginLatency}ms)`, 'error');
@@ -349,13 +357,15 @@ export function SuperDebugPanel({
             loginResp.headers.get('SET-COOKIE');
 
           if (setCookieHeader) {
-            const sidMatch = setCookieHeader.match(/SID=([^;]+)/i);
+            const sidMatch = setCookieHeader.match(/QBT_SID_\d+=([^;]+)|SID=([^;]+)/i);
             if (sidMatch) {
-              sidCookie = `SID=${sidMatch[1]}`;
-              const truncated = sidMatch[1].length > 12
-                ? sidMatch[1].substring(0, 12) + '...'
-                : sidMatch[1];
-              addEntry('COOKIE', `Session cookie captured: SID=${truncated}`, 'success');
+              const cookieValue = sidMatch[1] || sidMatch[2];
+              const cookieName = sidMatch[0].split('=')[0];
+              sidCookie = `${cookieName}=${cookieValue}`;
+              const truncated = cookieValue.length > 12
+                ? cookieValue.substring(0, 12) + '...'
+                : cookieValue;
+              addEntry('COOKIE', `Session cookie captured: ${cookieName}=${truncated}`, 'success');
               passed++;
             } else {
               addEntry('COOKIE', `set-cookie header found but no SID: "${setCookieHeader.substring(0, 80)}"`, 'warning');
@@ -382,9 +392,12 @@ export function SuperDebugPanel({
       const apiStart = Date.now();
       try {
         const headers: Record<string, string> = {};
-        if (sidCookie) {
+        if (apiKey.trim()) {
+          headers['Authorization'] = `Bearer ${apiKey.trim()}`;
+        } else if (sidCookie) {
           headers['Cookie'] = sidCookie;
         }
+
         const apiResp = await fetch(versionUrl, {
           method: 'GET',
           headers,
@@ -399,7 +412,9 @@ export function SuperDebugPanel({
           passed++;
         } else if (apiResp.status === 403) {
           addEntry('API', `HTTP 403 Forbidden — Not authenticated (${apiLatency}ms)`, 'error');
-          if (!bypassAuth && !sidCookie) {
+          if (apiKey.trim()) {
+            addEntry('WARN', 'The API key was rejected by the server. This could mean:\n  1. The API key is incorrect\n  2. Your qBittorrent version does not support API key auth (requires 5.2.0+)\n  3. API key auth is not enabled in qBittorrent settings', 'warning');
+          } else if (!bypassAuth && !sidCookie) {
             addEntry('WARN', 'Login succeeded (Step 2) but no session cookie was captured (Step 3), so this API request was rejected.\n\nThis confirms the cookie issue. Solution:\n  1. In qBittorrent: Settings > WebUI > "Bypass authentication for clients in whitelisted IP subnets"\n  2. Add your device\'s IP or subnet\n  3. Enable "Bypass Authentication" toggle in qBitRemote', 'warning');
           } else if (bypassAuth) {
             addEntry('WARN', 'Auth bypass is enabled, but the server still requires authentication.\n\nIn qBittorrent: Settings > WebUI:\n  1. Enable "Bypass authentication for clients in whitelisted IP subnets"\n  2. Add your device\'s IP or subnet to the whitelist', 'warning');
@@ -466,6 +481,7 @@ export function SuperDebugPanel({
       `Port: ${portNum || 'default (80/443)'}`,
       `HTTPS: ${useHttps ? 'Yes' : 'No'}`,
       `Auth Bypass: ${bypassAuth ? 'Yes' : 'No'}`,
+      `API Key: ${useApiKey ? 'Yes' : 'No'}`,
       '',
       '--- Diagnostic Log ---',
       ...log.map((e) => `${formatTime(e.timestamp)} [${e.step}] ${e.message}`),
@@ -530,6 +546,7 @@ export function SuperDebugPanel({
         `Port: ${portNum || 'default (80/443)'}`,
         `HTTPS: ${useHttps ? 'Yes' : 'No'}`,
         `Auth Bypass: ${bypassAuth ? 'Yes' : 'No'}`,
+        `API Key: ${useApiKey ? 'Yes' : 'No'}`,
         `Username: ${username ? '(set)' : '(empty)'}`,
         '',
       ];

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -321,6 +321,7 @@
     "portOptional": "Port (optional)",
     "username": "Benutzername",
     "password": "Passwort",
+    "apiKey": "API Key",
     "trackerUrl": "https://tracker.example.com/announce",
     "enterKbs": "KB/s eingeben"
   },
@@ -383,6 +384,8 @@
   "server": {
     "serverInfo": "SERVER-INFO",
     "authentication": "AUTHENTIFIZIERUNG",
+    "useApiKey": "Use API Key",
+    "useApiKeyHint": "qBittorrent 5.2+",
     "security": "SICHERHEIT",
     "useHttps": "HTTPS verwenden",
     "bypassAuth": "Authentifizierung umgehen",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -341,6 +341,7 @@
     "portOptional": "Port (optional)",
     "username": "Username",
     "password": "Password",
+    "apiKey": "API Key",
     "trackerUrl": "https://tracker.example.com/announce",
     "enterKbs": "Enter KB/s"
   },
@@ -403,6 +404,8 @@
   "server": {
     "serverInfo": "SERVER INFO",
     "authentication": "AUTHENTICATION",
+    "useApiKey": "Use API Key",
+    "useApiKeyHint": "qBittorrent 5.2+",
     "security": "SECURITY",
     "useHttps": "Use HTTPS",
     "bypassAuth": "Bypass Authentication",
@@ -682,6 +685,7 @@
     "connectionFailedManual": "Connection failed: {{error}}. Please try connecting manually.",
     "fillNameAndHost": "Please fill in server name and host",
     "fillUsernamePassword": "Please fill in username and password, or enable bypass authentication",
+    "fillApiKey": "Please fill in API key, or enable bypass authentication",
     "validPort": "Please enter a valid port number (1-65535)",
     "selectTorrentFile": "Please select a .torrent file",
     "enterUrlOrMagnet": "Please enter a URL/magnet link or select a .torrent file",

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -321,6 +321,7 @@
     "portOptional": "Puerto (opcional)",
     "username": "Usuario",
     "password": "Contraseña",
+    "apiKey": "API Key",
     "trackerUrl": "https://tracker.example.com/announce",
     "enterKbs": "Introducir KB/s"
   },
@@ -383,6 +384,8 @@
   "server": {
     "serverInfo": "INFO DEL SERVIDOR",
     "authentication": "AUTENTICACIÓN",
+    "useApiKey": "Use API Key",
+    "useApiKeyHint": "qBittorrent 5.2+",
     "security": "SEGURIDAD",
     "useHttps": "Usar HTTPS",
     "bypassAuth": "Omitir autenticación",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -321,6 +321,7 @@
     "portOptional": "Port (optionnel)",
     "username": "Nom d'utilisateur",
     "password": "Mot de passe",
+    "apiKey": "API Key",
     "trackerUrl": "https://tracker.example.com/announce",
     "enterKbs": "Entrer KB/s"
   },
@@ -383,6 +384,8 @@
   "server": {
     "serverInfo": "INFO SERVEUR",
     "authentication": "AUTHENTIFICATION",
+    "useApiKey": "Use API Key",
+    "useApiKeyHint": "qBittorrent 5.2+",
     "security": "SÉCURITÉ",
     "useHttps": "Utiliser HTTPS",
     "bypassAuth": "Contourner authentification",

--- a/locales/ru/translation.json
+++ b/locales/ru/translation.json
@@ -319,6 +319,7 @@
     "portOptional": "Порт (необязательно)",
     "username": "Имя пользователя",
     "password": "Пароль",
+    "apiKey": "API Key",
     "trackerUrl": "https://tracker.example.com/announce",
     "enterKbs": "КБ/с"
   },
@@ -381,6 +382,8 @@
   "server": {
     "serverInfo": "СЕРВЕР",
     "authentication": "АВТОРИЗАЦИЯ",
+    "useApiKey": "Use API Key",
+    "useApiKeyHint": "qBittorrent 5.2+",
     "security": "БЕЗОПАСНОСТЬ",
     "useHttps": "Использовать HTTPS",
     "bypassAuth": "Без авторизации",

--- a/locales/zh/translation.json
+++ b/locales/zh/translation.json
@@ -321,6 +321,7 @@
     "portOptional": "端口（可选）",
     "username": "用户名",
     "password": "密码",
+    "apiKey": "API Key",
     "trackerUrl": "https://tracker.example.com/announce",
     "enterKbs": "输入 KB/s"
   },
@@ -383,6 +384,8 @@
   "server": {
     "serverInfo": "服务器信息",
     "authentication": "认证",
+    "useApiKey": "Use API Key",
+    "useApiKeyHint": "qBittorrent 5.2+",
     "security": "安全",
     "useHttps": "使用 HTTPS",
     "bypassAuth": "绕过认证",

--- a/services/api/auth.ts
+++ b/services/api/auth.ts
@@ -30,11 +30,11 @@ export const authApi = {
 
       clogDebug('AUTH', `Response: "${responsePreview}" | Cookies: ${cookies ? 'Yes (' + cookies.length + ' chars)' : 'No'}`);
       
-      // qBittorrent returns 'Ok.' on success, 'Fails.' on failure
+      // qBittorrent ≤5.1 returns 'Ok.' on success, 'Fails.' on failure; ≥5.2 returns HTTP 204 on success, 401 on failure
       // Handle both string and trimmed string responses
       const responseStr = typeof response === 'string' ? response.trim() : String(response).trim();
       
-      if (responseStr === 'Ok.' || responseStr === 'Ok') {
+      if (responseStr === 'Ok.' || responseStr === 'Ok' || responseStr === '') {
         // Successful login - verify we have session cookies
         if (!cookies || cookies.length === 0) {
           console.warn('[Auth] Warning: Login succeeded but no cookies received. This may cause issues with qBittorrent 5.x');
@@ -43,7 +43,7 @@ export const authApi = {
         clogInfo('AUTH', 'Login successful');
         return { status: 'Ok' };
       }
-      
+
       console.warn('[Auth] Login failed with response:', responseStr);
       clogWarn('AUTH', `Login failed — server responded: "${responseStr}"`);
       return { status: 'Fails' };
@@ -65,8 +65,8 @@ export const authApi = {
         throw error;
       }
       
-      if (axiosErr?.response?.status === 403) {
-        throw new Error('Authentication failed. Please check your username and password.');
+      if (axiosErr?.response?.status === 403 || axiosErr?.response?.status === 401) {
+         throw new Error('Authentication failed. Please check your username and password.');
       }
       
       return { status: 'Fails' };

--- a/services/api/client.ts
+++ b/services/api/client.ts
@@ -10,6 +10,7 @@ import { clogDebug, clogInfo, clogWarn, clogError } from '@/services/connectivit
 class ApiClient {
   private client: AxiosInstance;
   private currentServer: ServerConfig | null = null;
+  private apiKey: string = '';
   private cookies: string = '';
   private retryAttempts: number = 3;
 
@@ -55,11 +56,13 @@ class ApiClient {
         
         clogDebug('HTTP', `${config.method?.toUpperCase() || 'REQ'} ${config.baseURL}${config.url || ''}`);
         
-        // Add cookies if available
-        if (this.cookies) {
+        // API key takes priority over session cookies
+        if (this.apiKey) {
+          config.headers['Authorization'] = `Bearer ${this.apiKey}`;
+        } else if (this.cookies) {
           config.headers.Cookie = this.cookies;
         }
-        
+
         // Add Referer header for qBittorrent 5.x compatibility
         config.headers.Referer = config.baseURL + '/';
         
@@ -114,6 +117,13 @@ class ApiClient {
         const status = error.response?.status;
 
         // Handle authentication errors
+        if (status === 401) {
+          this.cookies = '';
+          this.apiKey = '';
+          clogError('HTTP', `401 Unauthorized — ${reqUrl}`);
+          throw new Error('Authentication failed. Please check your credentials.');
+        }
+
         if (status === 403) {
           this.cookies = '';
           clogError('HTTP', `403 Forbidden — ${reqUrl}`);
@@ -174,6 +184,7 @@ class ApiClient {
       this.cookies = '';
     }
     this.currentServer = server;
+    this.apiKey = server?.apiKey ?? '';
     if (server) {
       clogInfo('HTTP', `API client set to ${server.host}:${server.port || 'default'}`);
     } else {
@@ -199,10 +210,12 @@ class ApiClient {
     }
 
     const headers = new AxiosHeaders({ 'Content-Type': 'multipart/form-data' });
-    if (this.cookies) {
+    if (this.apiKey) {
+      headers.set('Authorization', `Bearer ${this.apiKey}`);
+    } else if (this.cookies) {
       headers.set('Cookie', this.cookies);
     }
-
+    
     const response = await this.client.post(url, data, { headers });
     return response.data;
   }
@@ -280,4 +293,3 @@ class ApiClient {
 }
 
 export const apiClient = new ApiClient();
-

--- a/services/server-manager.ts
+++ b/services/server-manager.ts
@@ -77,6 +77,22 @@ export class ServerManager {
       clogInfo('CONN', `Connecting to ${server.host}:${server.port || 'default'} (bypassAuth=${server.bypassAuth})`);
       // Set server in API client
       apiClient.setServer(server);
+      
+      // API key auth — no login needed, just verify the connection
+      if (server.apiKey) {
+        try {
+          await applicationApi.getVersion();
+          await storageService.setCurrentServerId(server.id);
+          clogInfo('CONN', 'Connected successfully (API key)');
+          return true;
+        } catch (error: unknown) {
+          apiClient.setServer(null);
+          const message = error instanceof Error ? error.message : String(error);
+          clogError('CONN', `API key connect failed: ${message}`);
+          if (isNetworkError(error)) throw error;
+          throw new Error('Failed to connect to server. Please check your API key.');
+        }
+      }
 
       // Skip authentication if bypassAuth is enabled
       if (server.bypassAuth) {
@@ -185,11 +201,14 @@ export class ServerManager {
 
       try {
         if (!server.bypassAuth) {
-          // Attempt login with abort signal
-          const loginResult = await authApi.login(server.username, server.password, signal);
-          if (loginResult.status !== 'Ok') {
-            clogWarn('CONN', 'testConnection: auth failed');
-            return { success: false, error: 'Authentication failed. Please check your username and password.' };
+          // Skip login if using API key
+          if (!server.apiKey) {
+            // Attempt login with abort signal
+            const loginResult = await authApi.login(server.username, server.password, signal);
+            if (loginResult.status !== 'Ok') {
+              clogWarn('CONN', 'testConnection: auth failed');
+              return { success: false, error: 'Authentication failed. Please check your username and password.' };
+            }
           }
         }
 

--- a/services/storage.ts
+++ b/services/storage.ts
@@ -39,6 +39,8 @@ export const storageService = {
         basePath: s.basePath || '/',
         username: s.username,
         password: '', // Don't store password in AsyncStorage
+        apiKey: '', // Don't store apiKey in AsyncStorage
+        useApiKey: s.useApiKey || false,
         useHttps: s.useHttps || false,
         bypassAuth: s.bypassAuth || false,
       }));
@@ -47,6 +49,7 @@ export const storageService = {
       
       // Store password securely
       await SecureStore.setItemAsync(`server_password_${server.id}`, server.password);
+      await SecureStore.setItemAsync(`server_apikey_${server.id}`, server.apiKey);
     } catch (error) {
       throw error;
     }
@@ -66,7 +69,8 @@ export const storageService = {
       const serversWithPasswords = await Promise.all(
         servers.map(async (server) => {
           const password = await SecureStore.getItemAsync(`server_password_${server.id}`) || '';
-          return { ...server, password, host: stripProtocol(server.host || '') };
+          const apiKey = await SecureStore.getItemAsync(`server_apikey_${server.id}`) || '';
+          return { ...server, password, apiKey, host: stripProtocol(server.host || '') };
         })
       );
 
@@ -95,6 +99,7 @@ export const storageService = {
     
     // Remove password from SecureStore
     await SecureStore.deleteItemAsync(`server_password_${id}`);
+    await SecureStore.deleteItemAsync(`server_apikey_${id}`);
     
     // If this was the current server, clear it
     const currentId = await this.getCurrentServerId();

--- a/types/api.ts
+++ b/types/api.ts
@@ -15,6 +15,8 @@ export interface ServerConfig {
   basePath?: string;
   username: string;
   password: string;
+  apiKey: string; // qBittorrent 5.2.0+ Bearer token auth
+  useApiKey: boolean;
   useHttps?: boolean;
   bypassAuth?: boolean; // Skip authentication when local network auth is disabled
 }


### PR DESCRIPTION
### Problem

qRemote stopped connecting to qBittorrent 5.2.0 due to breaking WebUI auth API changes (#91):

* Successful login now returns HTTP 204 with an empty body instead of `"Ok."`
* Failed login now returns HTTP 401 instead of `"Fails."`
* Session cookie changed from `SID` to `QBT_SID_<port>`

qRemote only checked for `"Ok."`, causing all logins to fail.

### Changes

* Added qBittorrent 5.2.0 auth compatibility while maintaining support for ≤5.1
* Added API key authentication using Bearer tokens
* API key auth bypasses login and validates via `app/version`
* Added proper 401/403 handling throughout auth flow
* Added secure API key storage and `useApiKey` server setting
* Added API key toggle/input in add/edit server screens
* Updated SuperDebugPanel to support API key auth and new cookie names

### Testing

Verified with qBittorrent 5.1.4 and 5.2.0 using:

* Username/password auth
* API key auth
* Bypass auth
* Full diagnostic panel
