### PR TITLE
fix(auth): accept qBittorrent 5.x 204 + Set-Cookie as successful login

### DIFF
--- a/services/api/auth.ts
+++ b/services/api/auth.ts
@@ -30,22 +30,26 @@ export const authApi = {
 
       clogDebug('AUTH', `Response: "${responsePreview}" | Cookies: ${cookies ? 'Yes (' + cookies.length + ' chars)' : 'No'}`);
       
-      // qBittorrent returns 'Ok.' on success, 'Fails.' on failure
-      // Handle both string and trimmed string responses
+      // Auth responses vary between qBittorrent versions:
+      //   v4.x: 200 OK with body "Ok." on success, "Fails." on failure
+      //   v5.x: 204 No Content with empty body + Set-Cookie on success,
+      //         401/403 on failure (handled in the catch block below)
+      // Treat the presence of a session cookie as the source of truth and
+      // fall back to the legacy body strings for backwards compatibility.
       const responseStr = typeof response === 'string' ? response.trim() : String(response).trim();
-      
-      if (responseStr === 'Ok.' || responseStr === 'Ok') {
-        // Successful login - verify we have session cookies
-        if (!cookies || cookies.length === 0) {
-          console.warn('[Auth] Warning: Login succeeded but no cookies received. This may cause issues with qBittorrent 5.x');
-          clogWarn('AUTH', 'Login succeeded but no session cookies received — may cause issues with qBittorrent 5.x');
-        }
-        clogInfo('AUTH', 'Login successful');
+      const hasCookie = !!cookies && cookies.length > 0;
+      const bodyOk = responseStr === 'Ok.' || responseStr === 'Ok';
+      const bodyFail = responseStr === 'Fails.' || responseStr === 'Fails';
+
+      if (bodyOk || (!bodyFail && hasCookie)) {
+        const via = bodyOk ? 'body "Ok."' : 'session cookie';
+        console.log(`[Auth] Login successful via ${via}`);
+        clogInfo('AUTH', `Login successful via ${via}`);
         return { status: 'Ok' };
       }
-      
-      console.warn('[Auth] Login failed with response:', responseStr);
-      clogWarn('AUTH', `Login failed — server responded: "${responseStr}"`);
+
+      console.warn('[Auth] Login failed with response:', responseStr, 'cookies:', hasCookie);
+      clogWarn('AUTH', `Login failed — body: "${responseStr}", cookies: ${hasCookie}`);
       return { status: 'Fails' };
     } catch (error: unknown) {
       if (error instanceof Error && (error.name === 'AbortError' || error.name === 'CanceledError')) {

--- a/tests/services/auth.test.ts
+++ b/tests/services/auth.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for the authApi.login flow.
+ *
+ * Specifically covers compatibility with both qBittorrent 4.x (200 + body)
+ * and 5.x (204 + Set-Cookie) login response shapes, as well as failure paths.
+ */
+import { AxiosError } from 'axios';
+
+const postUrlEncoded = jest.fn();
+const clearCookies = jest.fn();
+const getCookies = jest.fn();
+
+jest.mock('@/services/api/client', () => ({
+  apiClient: {
+    postUrlEncoded: (...args: unknown[]) => postUrlEncoded(...args),
+    clearCookies: (...args: unknown[]) => clearCookies(...args),
+    getCookies: (...args: unknown[]) => getCookies(...args),
+  },
+}));
+
+jest.mock('@/services/connectivity-log', () => ({
+  clogInfo: jest.fn(),
+  clogWarn: jest.fn(),
+  clogError: jest.fn(),
+  clogDebug: jest.fn(),
+}));
+
+import { authApi } from '@/services/api/auth';
+
+describe('authApi.login', () => {
+  beforeEach(() => {
+    postUrlEncoded.mockReset();
+    clearCookies.mockReset();
+    getCookies.mockReset();
+  });
+
+  it('returns Ok for qBittorrent 4.x style response ("Ok." body with cookie)', async () => {
+    postUrlEncoded.mockResolvedValue('Ok.');
+    getCookies.mockReturnValue('SID=abc123');
+
+    const result = await authApi.login('admin', 'adminadmin');
+
+    expect(result).toEqual({ status: 'Ok' });
+    expect(clearCookies).toHaveBeenCalledTimes(1);
+    expect(postUrlEncoded).toHaveBeenCalledWith(
+      '/api/v2/auth/login',
+      { username: 'admin', password: 'adminadmin' },
+      undefined,
+    );
+  });
+
+  it('returns Ok for qBittorrent 5.x style response (empty body + Set-Cookie -> 204)', async () => {
+    // qBittorrent 5.x returns 204 No Content; axios resolves with empty data
+    postUrlEncoded.mockResolvedValue('');
+    getCookies.mockReturnValue('QBT_SID_8085=j5+9VCL3vcRVIwrKJtFN4gp+3IIcINj5');
+
+    const result = await authApi.login('admin', 'workspace');
+
+    expect(result).toEqual({ status: 'Ok' });
+  });
+
+  it('returns Ok for "Ok" body without trailing period', async () => {
+    postUrlEncoded.mockResolvedValue('Ok');
+    getCookies.mockReturnValue('SID=abc123');
+
+    const result = await authApi.login('admin', 'pw');
+
+    expect(result).toEqual({ status: 'Ok' });
+  });
+
+  it('trims whitespace around response body before comparing', async () => {
+    postUrlEncoded.mockResolvedValue('  Ok.\n');
+    getCookies.mockReturnValue('SID=abc123');
+
+    const result = await authApi.login('admin', 'pw');
+
+    expect(result).toEqual({ status: 'Ok' });
+  });
+
+  it('returns Fails for qBittorrent 4.x failure ("Fails." body)', async () => {
+    postUrlEncoded.mockResolvedValue('Fails.');
+    getCookies.mockReturnValue('');
+
+    const result = await authApi.login('admin', 'wrong');
+
+    expect(result).toEqual({ status: 'Fails' });
+  });
+
+  it('returns Fails when body is "Fails." even if a cookie is somehow set', async () => {
+    // Defensive: an explicit "Fails." body always wins over a stray cookie.
+    postUrlEncoded.mockResolvedValue('Fails.');
+    getCookies.mockReturnValue('SID=stale');
+
+    const result = await authApi.login('admin', 'wrong');
+
+    expect(result).toEqual({ status: 'Fails' });
+  });
+
+  it('returns Fails when body is empty and no cookie was set', async () => {
+    postUrlEncoded.mockResolvedValue('');
+    getCookies.mockReturnValue('');
+
+    const result = await authApi.login('admin', 'wrong');
+
+    expect(result).toEqual({ status: 'Fails' });
+  });
+
+  it('returns Fails when the request throws a non-network error', async () => {
+    postUrlEncoded.mockRejectedValue(new Error('Unauthorized'));
+    getCookies.mockReturnValue('');
+
+    const result = await authApi.login('admin', 'wrong');
+
+    expect(result).toEqual({ status: 'Fails' });
+  });
+
+  it('re-throws cancellation errors instead of returning Fails', async () => {
+    const abortErr = new Error('aborted');
+    abortErr.name = 'AbortError';
+    postUrlEncoded.mockRejectedValue(abortErr);
+    getCookies.mockReturnValue('');
+
+    await expect(authApi.login('admin', 'pw')).rejects.toBe(abortErr);
+  });
+
+  it('re-throws network/timeout errors instead of returning Fails', async () => {
+    postUrlEncoded.mockRejectedValue(new Error('Connection timeout'));
+    getCookies.mockReturnValue('');
+
+    await expect(authApi.login('admin', 'pw')).rejects.toThrow('Connection timeout');
+  });
+
+  it('translates HTTP 403 into a user-facing authentication error', async () => {
+    const axiosErr = new AxiosError('Forbidden');
+    axiosErr.response = { status: 403 } as AxiosError['response'];
+    postUrlEncoded.mockRejectedValue(axiosErr);
+    getCookies.mockReturnValue('');
+
+    await expect(authApi.login('admin', 'pw')).rejects.toThrow(
+      'Authentication failed. Please check your username and password.',
+    );
+  });
+
+  it('clears existing cookies before attempting login', async () => {
+    postUrlEncoded.mockResolvedValue('Ok.');
+    getCookies.mockReturnValue('SID=abc');
+
+    await authApi.login('admin', 'pw');
+
+    // clearCookies must be called before postUrlEncoded.
+    const clearOrder = clearCookies.mock.invocationCallOrder[0];
+    const postOrder = postUrlEncoded.mock.invocationCallOrder[0];
+    expect(clearOrder).toBeLessThan(postOrder);
+  });
+});


### PR DESCRIPTION
## Problem

Login fails against any qBittorrent **5.x** server even with correct credentials. The diagnostic panel reports:

```
[LOGIN] Unexpected response — "" (HTTP 204, 50ms)
[ERROR] Stopping diagnostic — unexpected login response.
```

The server actually accepts the login (qBittorrent logs show `WebAPI login success` at the same instant) and issues a valid session cookie. The app just throws it away.

## Root cause

`services/api/auth.ts` only treats a literal `"Ok."`/`"Ok"` body as a successful login. qBittorrent 5.x changed the WebUI auth endpoint:

- **4.x:** `200 OK` + body `"Ok."` on success, body `"Fails."` on failure
- **5.x:** `204 No Content` + `Set-Cookie: QBT_SID_…` on success, `401 Unauthorized` on failure

So with 5.x, axios resolves successfully, the cookie is captured by the response interceptor, but `responseStr === ''` does not match `'Ok.'` and the function returns `{ status: 'Fails' }`. The existing comment in the file even hints at this:

```ts
console.warn('[Auth] Warning: Login succeeded but no cookies received. This may cause issues with qBittorrent 5.x');
```

…but the logic was never inverted to actually accept a cookie-only success.

## Fix

Treat the presence of a session cookie as the source of truth for success and fall back to the legacy body strings for backwards compatibility. An explicit `"Fails."` body still wins, so 4.x failures continue to be rejected.

```ts
const hasCookie = !!cookies && cookies.length > 0;
const bodyOk   = responseStr === 'Ok.' || responseStr === 'Ok';
const bodyFail = responseStr === 'Fails.' || responseStr === 'Fails';

if (bodyOk || (!bodyFail && hasCookie)) {
  return { status: 'Ok' };
}
return { status: 'Fails' };
```

## Tests

New `tests/services/auth.test.ts` covers:

- ✅ qBittorrent 4.x success (`"Ok."` body + cookie)
- ✅ qBittorrent 5.x success (empty body + cookie — previously broken)
- ✅ `"Ok"` without trailing period and whitespace-padded bodies
- ✅ qBittorrent 4.x failure (`"Fails."` body)
- ✅ `"Fails."` body wins even if a stray cookie is set
- ✅ empty body + no cookie → `Fails`
- ✅ generic thrown error → `Fails`
- ✅ `AbortError` / cancellation re-thrown
- ✅ timeout / network errors re-thrown
- ✅ HTTP 403 translated into the user-facing auth error
- ✅ `clearCookies()` is called before the login request

All 7 suites / 146 tests pass locally. `npx tsc --noEmit` is clean. `npm run lint` adds no new warnings (existing 128 are unchanged).

## Verified against

`linuxserver/qbittorrent:5.2.0_v2.0.12-ls455`, which returns:

```
HTTP/1.1 204 OK
content-length: 0
set-cookie: QBT_SID_8085=…; HttpOnly; SameSite=Strict; path=/
```
