### PR TITLE
feat(files): rename files and folders from the file browser

### DIFF
--- a/app/torrent/files.tsx
+++ b/app/torrent/files.tsx
@@ -23,6 +23,7 @@ import { useServer } from '@/context/ServerContext';
 import { useTheme } from '@/context/ThemeContext';
 import { useToast } from '@/context/ToastContext';
 import { FocusAwareStatusBar } from '@/components/FocusAwareStatusBar';
+import { InputModal } from '@/components/InputModal';
 import { torrentsApi } from '@/services/api/torrents';
 import { TorrentFile, FilePriority } from '@/types/api';
 import { spacing, borderRadius } from '@/constants/spacing';
@@ -58,6 +59,13 @@ export default function TorrentFilesScreen() {
   const [menuVisible, setMenuVisible] = useState(false);
   const [menuFile, setMenuFile] = useState<TorrentFile | null>(null);
   const [bulkPriorityMenuVisible, setBulkPriorityMenuVisible] = useState(false);
+  const [inputModalVisible, setInputModalVisible] = useState(false);
+  const [inputModalConfig, setInputModalConfig] = useState<{
+    title: string;
+    message?: string;
+    defaultValue?: string;
+    onConfirm: (value: string) => void;
+  }>({ title: '', onConfirm: () => {} });
 
   useEffect(() => {
     if (hash && isConnected) {
@@ -222,6 +230,73 @@ export default function TorrentFilesScreen() {
       setUpdating(false);
       setMenuFile(null);
     }
+  };
+
+  const promptRenameFile = (file: TorrentFile) => {
+    setMenuVisible(false);
+    const parts = file.name.split('/');
+    const currentName = parts[parts.length - 1];
+    const parentPath = parts.slice(0, -1).join('/');
+    setInputModalConfig({
+      title: t('screens.files.renameFile'),
+      message: t('screens.files.enterNewName'),
+      defaultValue: currentName,
+      onConfirm: async (newName: string) => {
+        setInputModalVisible(false);
+        const trimmed = newName.trim();
+        if (!trimmed) {
+          showToast(t('errors.validName'), 'error');
+          return;
+        }
+        if (trimmed === currentName) return;
+        const newPath = parentPath ? `${parentPath}/${trimmed}` : trimmed;
+        try {
+          setUpdating(true);
+          await torrentsApi.renameFile(hash, file.name, newPath);
+          await loadFiles();
+          showToast(t('toast.fileRenamed'), 'success');
+        } catch (error: unknown) {
+          showToast(getErrorMessage(error), 'error');
+        } finally {
+          setUpdating(false);
+          setMenuFile(null);
+        }
+      },
+    });
+    setInputModalVisible(true);
+  };
+
+  const promptRenameFolder = (folderPath: string) => {
+    if (updating) return;
+    const parts = folderPath.split('/');
+    const currentName = parts[parts.length - 1];
+    const parentPath = parts.slice(0, -1).join('/');
+    setInputModalConfig({
+      title: t('screens.files.renameFolder'),
+      message: t('screens.files.enterNewName'),
+      defaultValue: currentName,
+      onConfirm: async (newName: string) => {
+        setInputModalVisible(false);
+        const trimmed = newName.trim();
+        if (!trimmed) {
+          showToast(t('errors.validName'), 'error');
+          return;
+        }
+        if (trimmed === currentName) return;
+        const newPath = parentPath ? `${parentPath}/${trimmed}` : trimmed;
+        try {
+          setUpdating(true);
+          await torrentsApi.renameFolder(hash, folderPath, newPath);
+          await loadFiles();
+          showToast(t('toast.folderRenamed'), 'success');
+        } catch (error: unknown) {
+          showToast(getErrorMessage(error), 'error');
+        } finally {
+          setUpdating(false);
+        }
+      },
+    });
+    setInputModalVisible(true);
   };
 
   const selectedIndices = useMemo(
@@ -463,6 +538,8 @@ export default function TorrentFilesScreen() {
                       <TouchableOpacity
                         style={styles.folderContent}
                         onPress={() => handleFolderExpand(item.path)}
+                        onLongPress={() => promptRenameFolder(item.path)}
+                        delayLongPress={350}
                       >
                         <Ionicons 
                           name={isCollapsed ? 'chevron-forward' : 'chevron-down'} 
@@ -478,6 +555,16 @@ export default function TorrentFilesScreen() {
                             {t('screens.files.filesCount', { count: item.fileCount })} • {formatSize(item.size || 0)}
                           </Text>
                         </View>
+                      </TouchableOpacity>
+
+                      <TouchableOpacity
+                        style={styles.folderRenameButton}
+                        onPress={() => promptRenameFolder(item.path)}
+                        disabled={updating}
+                        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                        accessibilityLabel={t('screens.files.renameFolder')}
+                      >
+                        <Ionicons name="pencil-outline" size={18} color={colors.textSecondary} />
                       </TouchableOpacity>
                     </View>
                   );
@@ -502,6 +589,11 @@ export default function TorrentFilesScreen() {
                     <TouchableOpacity
                       style={[styles.fileCard, { backgroundColor: colors.surface }]}
                       onPress={() => showPriorityMenu(file)}
+                      onLongPress={() => {
+                        setMenuFile(file);
+                        promptRenameFile(file);
+                      }}
+                      delayLongPress={350}
                       disabled={updating}
                     >
                       <View style={styles.fileHeader}>
@@ -584,11 +676,19 @@ export default function TorrentFilesScreen() {
                 },
               ]}
             >
-              <Text style={[styles.menuTitle, { color: colors.text }]}>{t('screens.files.setPriority')}</Text>
+              <Text style={[styles.menuTitle, { color: colors.text }]}>{t('screens.files.fileActions')}</Text>
               <Text style={[styles.menuSubtitle, { color: colors.textSecondary }]} numberOfLines={1}>
                 {menuFile?.name.split('/').pop()}
               </Text>
-              
+
+              <TouchableOpacity
+                style={[styles.menuOption, { borderBottomColor: colors.surfaceOutline }]}
+                onPress={() => menuFile && promptRenameFile(menuFile)}
+              >
+                <Ionicons name="pencil-outline" size={20} color={colors.primary} />
+                <Text style={[styles.menuOptionText, { color: colors.text }]}>{t('screens.files.renameFile')}</Text>
+              </TouchableOpacity>
+
               <TouchableOpacity
                 style={[styles.menuOption, { borderBottomColor: colors.surfaceOutline }]}
                 onPress={() => handleSetPriority(0)}
@@ -684,6 +784,16 @@ export default function TorrentFilesScreen() {
             </View>
           </TouchableOpacity>
         </Modal>
+
+        {/* Rename Input Modal */}
+        <InputModal
+          visible={inputModalVisible}
+          title={inputModalConfig.title}
+          message={inputModalConfig.message}
+          defaultValue={inputModalConfig.defaultValue}
+          onCancel={() => setInputModalVisible(false)}
+          onConfirm={inputModalConfig.onConfirm}
+        />
       </SafeAreaView>
     </>
   );
@@ -775,6 +885,12 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     padding: spacing.sm,
+  },
+  folderRenameButton: {
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.sm,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   folderInfo: {
     flex: 1,

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -272,7 +272,11 @@
       "prioritySkip": "Überspringen",
       "priorityNormal": "Normal",
       "priorityHigh": "Hoch",
-      "priorityMaximum": "Maximum"
+      "priorityMaximum": "Maximum",
+      "fileActions": "Dateiaktionen",
+      "renameFile": "Datei umbenennen",
+      "renameFolder": "Ordner umbenennen",
+      "enterNewName": "Neuen Namen eingeben"
     },
     "logs": {
       "title": "Protokolle",
@@ -647,7 +651,9 @@
     "stateColorsReset": "Torrent state colors reset to defaults",
     "colorsReset": "Colors reset to defaults",
     "serverNotFound": "Server not found",
-    "connectionFailedCheck": "Connection failed. Please check your settings and try connecting manually."
+    "connectionFailedCheck": "Connection failed. Please check your settings and try connecting manually.",
+    "fileRenamed": "Datei umbenannt",
+    "folderRenamed": "Ordner umbenannt"
   },
   "errors": {
     "generic": "Ein Fehler ist aufgetreten",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -292,7 +292,11 @@
       "prioritySkip": "Skip",
       "priorityNormal": "Normal",
       "priorityHigh": "High",
-      "priorityMaximum": "Maximum"
+      "priorityMaximum": "Maximum",
+      "fileActions": "File Actions",
+      "renameFile": "Rename File",
+      "renameFolder": "Rename Folder",
+      "enterNewName": "Enter a new name"
     },
     "logs": {
       "title": "Logs",
@@ -667,7 +671,9 @@
     "prioritySet": "Priority set to {{label}}",
     "prioritySetForCount": "Priority set to {{label}} for {{count}} file(s)",
     "fileSelected": "File selected: {{name}}",
-    "dlLimitSetKb": "Download limit set to {{value}} KB/s"
+    "dlLimitSetKb": "Download limit set to {{value}} KB/s",
+    "fileRenamed": "File renamed",
+    "folderRenamed": "Folder renamed"
   },
   "errors": {
     "generic": "An error occurred",

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -272,7 +272,11 @@
       "prioritySkip": "Omitir",
       "priorityNormal": "Normal",
       "priorityHigh": "Alta",
-      "priorityMaximum": "Máxima"
+      "priorityMaximum": "Máxima",
+      "fileActions": "Acciones de archivo",
+      "renameFile": "Renombrar archivo",
+      "renameFolder": "Renombrar carpeta",
+      "enterNewName": "Introduce un nuevo nombre"
     },
     "logs": {
       "title": "Registros",
@@ -647,7 +651,9 @@
     "stateColorsReset": "Torrent state colors reset to defaults",
     "colorsReset": "Colors reset to defaults",
     "serverNotFound": "Server not found",
-    "connectionFailedCheck": "Connection failed. Please check your settings and try connecting manually."
+    "connectionFailedCheck": "Connection failed. Please check your settings and try connecting manually.",
+    "fileRenamed": "Archivo renombrado",
+    "folderRenamed": "Carpeta renombrada"
   },
   "errors": {
     "generic": "Ocurrió un error",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -272,7 +272,11 @@
       "prioritySkip": "Ignorer",
       "priorityNormal": "Normal",
       "priorityHigh": "Haute",
-      "priorityMaximum": "Maximum"
+      "priorityMaximum": "Maximum",
+      "fileActions": "Actions du fichier",
+      "renameFile": "Renommer le fichier",
+      "renameFolder": "Renommer le dossier",
+      "enterNewName": "Entrez un nouveau nom"
     },
     "logs": {
       "title": "Journaux",
@@ -647,7 +651,9 @@
     "stateColorsReset": "Torrent state colors reset to defaults",
     "colorsReset": "Colors reset to defaults",
     "serverNotFound": "Server not found",
-    "connectionFailedCheck": "Connection failed. Please check your settings and try connecting manually."
+    "connectionFailedCheck": "Connection failed. Please check your settings and try connecting manually.",
+    "fileRenamed": "Fichier renommé",
+    "folderRenamed": "Dossier renommé"
   },
   "errors": {
     "generic": "Une erreur s'est produite",

--- a/locales/ru/translation.json
+++ b/locales/ru/translation.json
@@ -270,7 +270,11 @@
       "prioritySkip": "Пропуск",
       "priorityNormal": "Обычный",
       "priorityHigh": "Высокий",
-      "priorityMaximum": "Максимум"
+      "priorityMaximum": "Максимум",
+      "fileActions": "Действия с файлом",
+      "renameFile": "Переименовать файл",
+      "renameFolder": "Переименовать папку",
+      "enterNewName": "Введите новое имя"
     },
     "logs": {
       "title": "Журнал",
@@ -645,7 +649,9 @@
     "prioritySet": "Приоритет: {{label}}",
     "prioritySetForCount": "Приоритет {{label}} для {{count}} файл(ов)",
     "fileSelected": "Выбран файл: {{name}}",
-    "dlLimitSetKb": "Лимит загрузки: {{value}} КБ/с"
+    "dlLimitSetKb": "Лимит загрузки: {{value}} КБ/с",
+    "fileRenamed": "Файл переименован",
+    "folderRenamed": "Папка переименована"
   },
   "errors": {
     "generic": "Произошла ошибка",

--- a/locales/zh/translation.json
+++ b/locales/zh/translation.json
@@ -272,7 +272,11 @@
       "prioritySkip": "跳过",
       "priorityNormal": "普通",
       "priorityHigh": "高",
-      "priorityMaximum": "最高"
+      "priorityMaximum": "最高",
+      "fileActions": "文件操作",
+      "renameFile": "重命名文件",
+      "renameFolder": "重命名文件夹",
+      "enterNewName": "输入新名称"
     },
     "logs": {
       "title": "日志",
@@ -647,7 +651,9 @@
     "stateColorsReset": "Torrent state colors reset to defaults",
     "colorsReset": "Colors reset to defaults",
     "serverNotFound": "Server not found",
-    "connectionFailedCheck": "Connection failed. Please check your settings and try connecting manually."
+    "connectionFailedCheck": "Connection failed. Please check your settings and try connecting manually.",
+    "fileRenamed": "文件已重命名",
+    "folderRenamed": "文件夹已重命名"
   },
   "errors": {
     "generic": "发生错误",


### PR DESCRIPTION
## Summary

Adds rename support to the torrent file browser (`app/torrent/files.tsx`), mirroring the qBittorrent WebUI content panel. Until now, the screen only let you toggle file priorities; you couldn't rename files or folders.

## Changes

**Files**
- Tap a file card now opens a "File Actions" modal with **Rename** at the top followed by the existing four priority options (Skip / Normal / High / Maximum).
- Long-press a file card opens the rename input directly.

**Folders**
- Tap on the folder name still expands/collapses (unchanged).
- A small trailing pencil button on every folder row opens the rename input.
- Long-press the folder area opens the same rename input.

Both use the existing `InputModal` component (per `AGENTS.md`) and call the already-defined `torrentsApi.renameFile` / `torrentsApi.renameFolder` wrappers around `/api/v2/torrents/renameFile` and `/api/v2/torrents/renameFolder`.

The input pre-fills with just the basename and the parent path is spliced back in before the API call, so users only need to type the new name. Entering slashes is allowed (mirrors WebUI behavior — lets you nest into subpaths if you really want to). After success, `loadFiles()` re-fetches and the existing `hasInitializedCollapse` ref prevents the tree from collapsing.

## i18n

New keys added to all six locales (en, es, fr, de, zh, ru):
- `screens.files.fileActions`
- `screens.files.renameFile`
- `screens.files.renameFolder`
- `screens.files.enterNewName`
- `toast.fileRenamed`
- `toast.folderRenamed`

Empty/invalid input reuses the existing `errors.validName` key.

## Notes

- `renameFolder` is qBittorrent WebAPI 2.8.0+. Older servers will surface the server error in a toast. No version-gating was added (consistent with the rest of the codebase).
- After a folder rename, the `collapsedFolders` set (which is keyed by full path) loses the renamed subtree, so the renamed folder and its descendants briefly appear expanded after reload. Minor UX wrinkle; left as-is.

## Validation

- `npx tsc --noEmit` passes.
- Manually tested on iOS against a live qBittorrent server: file rename, folder rename, nested folder rename, and rename of a folder at the torrent root.

This is independent of my open auth-fix PR — neither depends on the other.
