### PR TITLE
fix(tabs): use background color for top safe area so status bar matches

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -12,7 +12,7 @@ export default function TabsLayout() {
     <SafeAreaView
       style={{
         flex: 1,
-        backgroundColor: colors.surface,
+        backgroundColor: colors.background,
       }}
       edges={['top']}
     >


### PR DESCRIPTION
## Summary
On tab screens, the status bar area appeared as a different color than the rest of the screen:
- **Dark mode:** grey status bar (`#1C1C1E`) over black content (`#000000`)
- **Light mode:** pure-white status bar (`#FFFFFF`) over off-white content (`#F2F2F7`)

The cause was `app/(tabs)/_layout.tsx`: the top `SafeAreaView` was filled with `colors.surface`, while each tab screen renders its body with `colors.background`.

## Fix
Set the tabs layout `SafeAreaView` background to `colors.background` so the status bar area blends seamlessly with the page below. The `edges={['top']}` constraint means this only affects the top safe area; the bottom tab bar keeps its own `colors.surface` styling via `tabBarStyle.backgroundColor` and is unaffected.

## Tested
- Torrents / Transfer / Search / Settings tabs in both light and dark — status bar now matches the content background.
- Non-tab screens (settings detail screens, modals, etc.) were already using `colors.background` for their own top safe area and are unchanged.