### PR TITLE
fix(eta): hide ETA when torrent is seeding/complete

### DIFF
--- a/app/torrent/[hash].tsx
+++ b/app/torrent/[hash].tsx
@@ -35,7 +35,7 @@ import { InputModal } from '@/components/InputModal';
 import { OptionPicker } from '@/components/OptionPicker';
 import { TagsModal } from '@/components/TagsModal';
 import { CategoryModal } from '@/components/CategoryModal';
-import { getStateColor, getStateLabel } from '@/utils/torrent-state';
+import { getStateColor, getStateLabel, hasEta } from '@/utils/torrent-state';
 import { torrentsApi } from '@/services/api/torrents';
 import { syncApi } from '@/services/api/sync';
 import { tagsApi } from '@/services/api/tags';
@@ -903,7 +903,7 @@ export default function TorrentDetail() {
             </View>
             <View style={styles.heroStatsRow}>
               <Text style={[styles.heroStatText, { color: colors.textSecondary }]}>
-                {torrent.eta > 0 && torrent.eta < 8640000
+                {hasEta(torrent.eta, torrent.progress)
                   ? t('torrentDetail.remaining', { time: formatTime(torrent.eta) })
                   : progress >= 100
                   ? t('torrentDetail.complete')
@@ -968,7 +968,7 @@ export default function TorrentDetail() {
             {renderRows([
               staticRow(t('torrentDetail.dlSpeed'), formatSpeed(dlspeed)),
               staticRow(t('torrentDetail.ulSpeed'), formatSpeed(upspeed)),
-              staticRow(t('torrentDetail.eta'), torrent.eta > 0 && torrent.eta < 8640000 ? formatTime(torrent.eta) : '∞'),
+              hasEta(torrent.eta, torrent.progress) && staticRow(t('torrentDetail.eta'), formatTime(torrent.eta)),
               tappableRow(
                 t('torrentDetail.dlLimit'),
                 properties && properties.dl_limit > 0 ? formatSpeed(properties.dl_limit) : t('common.unlimited'),

--- a/components/TorrentCard.tsx
+++ b/components/TorrentCard.tsx
@@ -4,7 +4,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 import { TorrentInfo } from '@/types/api';
 import { useTheme } from '@/context/ThemeContext';
-import { getStateColor, getStateLabel } from '@/utils/torrent-state';
+import { getStateColor, getStateLabel, hasEta } from '@/utils/torrent-state';
 import { formatSpeed, formatSize, formatTime } from '@/utils/format';
 import { spacing, borderRadius } from '@/constants/spacing';
 import { shadows } from '@/constants/shadows';
@@ -139,7 +139,7 @@ function TorrentCardInner({
 
   const totalSize = torrent.total_size > 0 ? torrent.total_size : torrent.size || 0;
   const downloaded = torrent.completed || 0;
-  const hasEta = torrent.eta > 0 && torrent.eta < 8640000;
+  const etaVisible = hasEta(torrent.eta, torrent.progress ?? 0);
 
   const speedParts: string[] = [];
   if (dlspeed > 0) speedParts.push(`${formatSpeed(dlspeed)} ↓`);
@@ -151,7 +151,7 @@ function TorrentCardInner({
     stateLabel,
     speedText,
     `${progress.toFixed(0)}%`,
-    hasEta ? formatTime(torrent.eta) : null,
+    etaVisible ? formatTime(torrent.eta) : null,
   ].filter(Boolean).join('  ·  ');
 
   // Build two-column detail items: short fields get 50% width, long ones span full width.
@@ -185,7 +185,7 @@ function TorrentCardInner({
     if (show('progress')) addItem('progress', t('screens.settings.expandedCardFieldsList.progress'), `${progress.toFixed(1)}%`);
     if (show('dlSpeed')) addItem('dlSpeed', t('screens.settings.expandedCardFieldsList.dlSpeed'), dlspeed > 0 ? formatSpeed(dlspeed) : '—');
     if (show('ulSpeed')) addItem('ulSpeed', t('screens.settings.expandedCardFieldsList.ulSpeed'), upspeed > 0 ? formatSpeed(upspeed) : '—');
-    if (show('eta')) addItem('eta', t('screens.settings.expandedCardFieldsList.eta'), hasEta ? formatTime(torrent.eta) : '—');
+    if (show('eta') && etaVisible) addItem('eta', t('screens.settings.expandedCardFieldsList.eta'), formatTime(torrent.eta));
     if (show('seeds')) addItem('seeds', t('screens.settings.expandedCardFieldsList.seeds'), `${torrent.num_seeds} / ${torrent.num_complete}`);
     if (show('peers')) addItem('peers', t('screens.settings.expandedCardFieldsList.peers'), `${torrent.num_leechs} / ${torrent.num_incomplete}`);
     if (show('ratio')) addItem('ratio', t('screens.settings.expandedCardFieldsList.ratio'), torrent.ratio != null ? torrent.ratio.toFixed(2) : '—');

--- a/components/TorrentDetails.tsx
+++ b/components/TorrentDetails.tsx
@@ -47,6 +47,7 @@ import { InputModal } from './InputModal';
 import { TagsModal } from './TagsModal';
 import { CategoryModal } from './CategoryModal';
 import { getErrorMessage } from '@/utils/error';
+import { hasEta } from '@/utils/torrent-state';
 
 interface TorrentDetailsProps {
   torrent: TorrentInfo;
@@ -1239,7 +1240,7 @@ export function TorrentDetails({
             <Ionicons name="swap-horizontal" size={20} color={colors.primary} />
             <Text style={[styles.sectionTitle, { color: colors.text }]}>{t('torrentDetail.transferStatistics')}</Text>
           </View>
-          {torrent.eta > 0 && torrent.eta < 8640000 && (
+          {hasEta(torrent.eta, torrent.progress) && (
             <InfoRow icon="time" label={t('torrentDetail.eta')} value={formatTime(torrent.eta)} />
           )}
           <InfoRow icon="time-outline" label={t('torrentDetail.timeActive')} value={formatTime(torrent.time_active)} />

--- a/tests/utils/torrent-state.test.ts
+++ b/tests/utils/torrent-state.test.ts
@@ -1,4 +1,4 @@
-import { getStateColor, getStateLabel } from '@/utils/torrent-state';
+import { getStateColor, getStateLabel, hasEta } from '@/utils/torrent-state';
 
 const mockColors = {
   stateUploadAndDownload: '#upload-and-download',
@@ -231,5 +231,23 @@ describe('getStateLabel', () => {
     it('unknown state returns the raw state string', () => {
       expect(getStateLabel('somethingNew', 0, 0, 0)).toBe('somethingNew');
     });
+  });
+});
+
+describe('hasEta', () => {
+  it('returns true while downloading with a finite eta', () => {
+    expect(hasEta(3600, 0.5)).toBe(true);
+  });
+
+  it('returns false when complete (progress === 1)', () => {
+    expect(hasEta(3600, 1)).toBe(false);
+  });
+
+  it('returns false for the infinite-eta sentinel (8640000)', () => {
+    expect(hasEta(8640000, 0.5)).toBe(false);
+  });
+
+  it('returns false when eta is 0', () => {
+    expect(hasEta(0, 0.5)).toBe(false);
   });
 });

--- a/utils/torrent-state.ts
+++ b/utils/torrent-state.ts
@@ -72,6 +72,15 @@ export function getStateColor(
   }
 }
 
+/**
+ * ETA is only meaningful while a torrent is still downloading.
+ * `8640000` is qBittorrent's sentinel for an infinite/unknown ETA.
+ * `progress` is the raw fraction (0–1); a complete torrent (>= 1) has no ETA.
+ */
+export function hasEta(eta: number, progress: number): boolean {
+  return eta > 0 && eta < 8640000 && progress < 1;
+}
+
 type TranslateFn = (key: string) => string;
 
 export function getStateLabel(


### PR DESCRIPTION
## What

ETA is now hidden everywhere once a torrent is complete/seeding (100% downloaded).

A single shared helper decides whether an ETA is meaningful, and every ETA display site is routed through it:

```ts
// utils/torrent-state.ts
export function hasEta(eta: number, progress: number): boolean {
  return eta > 0 && eta < 8640000 && progress < 1;
}
```

- **Torrent list card** — ETA drops out of the inline status line, and the optional ETA detail field is omitted entirely (no more `—` placeholder).
- **Detail screen** — hero shows "Complete" instead of `∞`; the transfer ETA row is removed via the existing falsy-row filtering in `renderRows`.
- **Transfer statistics** — the ETA row hides automatically (already conditionally rendered).

## Why

Once a torrent finishes downloading, ETA has no meaning, but it still leaked into the UI — the detail-screen transfer row showed `∞` and the optional card field showed `—`. The old guard only filtered qBittorrent's "infinite" sentinel (`eta < 8640000`); the new `progress < 1` check covers the seeding/complete case. Per the design decision, dedicated ETA rows/fields are hidden entirely rather than shown with a placeholder.

## Notes for reviewers

- Still-downloading torrents show ETA exactly as before.
- Added 4 unit tests for `hasEta` in `tests/utils/torrent-state.test.ts` (downloading → true; complete → false; `8640000` sentinel → false; `0` → false). All 55 tests pass and `tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)