### PR TITLE
feat(torrents): add category and tag filters (#90)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -50,12 +50,15 @@ import { useTorrentActions } from '@/hooks/useTorrentActions';
 import { getErrorMessage } from '@/utils/error';
 import { extractMagnetLink } from '@/utils/magnet';
 import { getAddTorrentDialogueVariant } from '@/utils/add-torrent-dialogue';
+import { OptionPicker, OptionPickerItem } from '@/components/OptionPicker';
+import { MultiSelectPicker, MultiSelectPickerItem } from '@/components/MultiSelectPicker';
+import { torrentHasAnyTag } from '@/utils/tags';
 
 export default function TorrentsScreen() {
   const { t } = useTranslation();
   const { showToast } = useToast();
   const router = useRouter();
-  const { torrents, isLoading, error, refresh, isRecoveringFromBackground, initialLoadComplete } = useTorrents();
+  const { torrents, categories, tags, isLoading, error, refresh, isRecoveringFromBackground, initialLoadComplete } = useTorrents();
   const { isConnected, currentServer, isLoading: serverIsLoading, connectToServer } = useServer();
   const { colors, isDark } = useTheme();
   const params = useLocalSearchParams<{ magnet?: string | string[] }>();
@@ -77,6 +80,12 @@ export default function TorrentsScreen() {
   const [expandedCardFields, setExpandedCardFields] = useState<Record<ExpandedCardField, boolean>>(
     DEFAULT_PREFERENCES.expandedCardFields
   );
+  // Category/tag filter state (null = all categories, '' = uncategorized)
+  const [categoryFilter, setCategoryFilter] = useState<string | null>(null);
+  const [tagFilters, setTagFilters] = useState<string[]>([]);
+  const [showCategoryPicker, setShowCategoryPicker] = useState(false);
+  const [showTagPicker, setShowTagPicker] = useState(false);
+
   const lastAppliedMagnetRef = useRef<{ value: string; at: number } | null>(null);
 
   // Action menu state
@@ -143,6 +152,12 @@ export default function TorrentsScreen() {
         }
         if (prefs.defaultFilter) {
           setFilter(prefs.defaultFilter);
+        }
+        if (prefs.lastCategoryFilter !== undefined) {
+          setCategoryFilter(prefs.lastCategoryFilter);
+        }
+        if (prefs.lastTagFilters && prefs.lastTagFilters.length > 0) {
+          setTagFilters(prefs.lastTagFilters);
         }
         setCardViewMode(prefs.cardViewMode ?? 'compact');
         if (prefs.expandedCardFields) {
@@ -262,6 +277,18 @@ export default function TorrentsScreen() {
       });
     }
 
+    // Category filter: null = all, '' = uncategorized (no category set)
+    if (categoryFilter !== null) {
+      filtered = filtered.filter((torrent) =>
+        categoryFilter === '' ? !torrent.category : torrent.category === categoryFilter
+      );
+    }
+
+    // Tag filter: OR semantics — torrent matches if it has any selected tag
+    if (tagFilters.length > 0) {
+      filtered = filtered.filter((torrent) => torrentHasAnyTag(torrent.tags, tagFilters));
+    }
+
     if (searchQuery.trim()) {
       const query = searchQuery.toLowerCase();
       filtered = filtered.filter(
@@ -306,7 +333,7 @@ export default function TorrentsScreen() {
     });
 
     return filtered;
-  }, [torrents, filter, searchQuery, sortBy, sortDirection]);
+  }, [torrents, filter, categoryFilter, tagFilters, searchQuery, sortBy, sortDirection]);
 
   // Selection handlers
   const toggleSelectMode = () => {
@@ -658,6 +685,61 @@ export default function TorrentsScreen() {
     lastScrollY.current = currentScrollY;
   }, []);
 
+  // Whether any secondary (category/tag) filter is active
+  const hasSecondaryFilter = categoryFilter !== null || tagFilters.length > 0;
+
+  const clearAllFilters = useCallback(async () => {
+    setFilter('all');
+    setCategoryFilter(null);
+    setTagFilters([]);
+    try {
+      const prefs = await storageService.getPreferences();
+      await storageService.savePreferences({ ...prefs, lastCategoryFilter: null, lastTagFilters: [] });
+    } catch {
+      // best-effort
+    }
+  }, []);
+
+  // Category picker options: All + Uncategorized + sorted server categories
+  const categoryPickerOptions = useMemo<OptionPickerItem[]>(() => {
+    const sorted = Object.keys(categories).sort((a, b) => a.localeCompare(b));
+    return [
+      { label: t('filters.allCategories'), value: '__all__', icon: 'grid-outline' as const },
+      { label: t('filters.uncategorized'), value: '', icon: 'remove-circle-outline' as const },
+      ...sorted.map((name) => ({ label: name, value: name, icon: 'folder-outline' as const })),
+    ];
+  }, [categories, t]);
+
+  // Tag multi-select options: sorted server tags
+  const tagPickerOptions = useMemo<MultiSelectPickerItem[]>(() => {
+    return [...tags]
+      .sort((a, b) => a.localeCompare(b))
+      .map((tag) => ({ label: tag, value: tag, icon: 'pricetag-outline' as const }));
+  }, [tags]);
+
+  const handleCategorySelect = useCallback(async (value: string) => {
+    const newFilter = value === '__all__' ? null : value;
+    setCategoryFilter(newFilter);
+    setShowCategoryPicker(false);
+    haptics.light();
+    try {
+      const prefs = await storageService.getPreferences();
+      await storageService.savePreferences({ ...prefs, lastCategoryFilter: newFilter });
+    } catch {
+      // best-effort
+    }
+  }, []);
+
+  const handleTagsChange = useCallback(async (values: string[]) => {
+    setTagFilters(values);
+    try {
+      const prefs = await storageService.getPreferences();
+      await storageService.savePreferences({ ...prefs, lastTagFilters: values });
+    } catch {
+      // best-effort
+    }
+  }, []);
+
   // Filter options
   const filterOptions = [
     { key: 'all', labelKey: 'filters.all', icon: 'grid-outline' as const },
@@ -903,6 +985,81 @@ export default function TorrentsScreen() {
                   </TouchableOpacity>
                 ))}
                 
+              {!selectMode && (
+                <>
+                  {/* Visual separator */}
+                  <View style={[styles.filterChipSeparator, { backgroundColor: colors.surfaceOutline }]} />
+
+                  {/* Category filter chip */}
+                  <TouchableOpacity
+                    style={[
+                      styles.filterChipCompact,
+                      categoryFilter !== null && styles.filterChipElevated,
+                      {
+                        backgroundColor: categoryFilter !== null ? colors.primary : colors.surface,
+                        borderColor: categoryFilter !== null ? colors.primary : colors.surfaceOutline,
+                        borderWidth: categoryFilter !== null ? 0 : 0.2,
+                      },
+                    ]}
+                    onPress={() => { haptics.light(); setShowCategoryPicker(true); }}
+                    activeOpacity={0.7}
+                    accessibilityLabel={t('filters.category')}
+                    accessibilityState={{ selected: categoryFilter !== null }}
+                  >
+                    <Ionicons
+                      name="folder-outline"
+                      size={14}
+                      color={categoryFilter !== null ? '#FFFFFF' : colors.text}
+                    />
+                    <Text
+                      style={[
+                        styles.filterChipTextCompact,
+                        { color: categoryFilter !== null ? '#FFFFFF' : colors.text },
+                      ]}
+                    >
+                      {categoryFilter === null
+                        ? t('filters.category')
+                        : categoryFilter === ''
+                          ? t('filters.uncategorized')
+                          : categoryFilter}
+                    </Text>
+                  </TouchableOpacity>
+
+                  {/* Tags filter chip */}
+                  <TouchableOpacity
+                    style={[
+                      styles.filterChipCompact,
+                      tagFilters.length > 0 && styles.filterChipElevated,
+                      {
+                        backgroundColor: tagFilters.length > 0 ? colors.primary : colors.surface,
+                        borderColor: tagFilters.length > 0 ? colors.primary : colors.surfaceOutline,
+                        borderWidth: tagFilters.length > 0 ? 0 : 0.2,
+                      },
+                    ]}
+                    onPress={() => { haptics.light(); setShowTagPicker(true); }}
+                    activeOpacity={0.7}
+                    accessibilityLabel={t('filters.tags')}
+                    accessibilityState={{ selected: tagFilters.length > 0 }}
+                  >
+                    <Ionicons
+                      name="pricetag-outline"
+                      size={14}
+                      color={tagFilters.length > 0 ? '#FFFFFF' : colors.text}
+                    />
+                    <Text
+                      style={[
+                        styles.filterChipTextCompact,
+                        { color: tagFilters.length > 0 ? '#FFFFFF' : colors.text },
+                      ]}
+                    >
+                      {tagFilters.length > 0
+                        ? t('filters.tagsCount', { count: tagFilters.length })
+                        : t('filters.tags')}
+                    </Text>
+                  </TouchableOpacity>
+                </>
+              )}
+
               {selectMode && (
                 <TouchableOpacity
                   onPress={toggleSelectMode}
@@ -987,22 +1144,48 @@ export default function TorrentsScreen() {
           </View>
         </Animated.View>
 
+        {/* Category filter picker */}
+        <OptionPicker
+          visible={showCategoryPicker}
+          title={t('filters.category')}
+          options={categoryPickerOptions}
+          selectedValue={categoryFilter === null ? '__all__' : categoryFilter}
+          onSelect={(value) => void handleCategorySelect(value)}
+          onClose={() => setShowCategoryPicker(false)}
+        />
+
+        {/* Tags filter picker */}
+        <MultiSelectPicker
+          visible={showTagPicker}
+          title={t('filters.tags')}
+          options={tagPickerOptions}
+          selectedValues={tagFilters}
+          onChange={(values) => void handleTagsChange(values)}
+          onClose={() => setShowTagPicker(false)}
+        />
+
         {filteredTorrents.length === 0 ? (
           <View style={[styles.center, { backgroundColor: colors.background }]}>
             <Ionicons 
-              name={filter === 'all' ? 'cloud-download-outline' : 'funnel-outline'} 
+              name={(filter === 'all' && !hasSecondaryFilter) ? 'cloud-download-outline' : 'funnel-outline'} 
               size={64} 
               color={colors.textSecondary} 
             />
             <Text style={[styles.emptyTitle, { color: colors.text }]}>
-              {filter === 'all' ? t('screens.torrents.noTorrents') : t('screens.torrents.noResults')}
+              {(filter === 'all' && !hasSecondaryFilter) ? t('screens.torrents.noTorrents') : t('screens.torrents.noResults')}
             </Text>
             <Text style={[styles.emptySubtitle, { color: colors.textSecondary }]}>
-              {filter === 'all' 
-                ? t('screens.torrents.addMagnetSubtitle') 
-                : filter === 'stuck' ? t('screens.torrents.noStuckResults') : t('screens.torrents.noFilterResults', { filter })}
+              {(filter === 'all' && !hasSecondaryFilter)
+                ? t('screens.torrents.addMagnetSubtitle')
+                : categoryFilter !== null && tagFilters.length === 0 && filter === 'all'
+                  ? t('screens.torrents.noCategoryResults')
+                  : tagFilters.length > 0 && categoryFilter === null && filter === 'all'
+                    ? t('screens.torrents.noTagResults')
+                    : filter === 'stuck'
+                      ? t('screens.torrents.noStuckResults')
+                      : t('screens.torrents.noFilterResults', { filter })}
             </Text>
-            {filter === 'all' ? (
+            {(filter === 'all' && !hasSecondaryFilter) ? (
               <TouchableOpacity
                 style={[styles.emptyButton, { backgroundColor: colors.primary }]}
                 onPress={() => {
@@ -1017,9 +1200,9 @@ export default function TorrentsScreen() {
             ) : (
               <TouchableOpacity
                 style={[styles.emptyButton, { backgroundColor: colors.surface, borderWidth: 1, borderColor: colors.surfaceOutline }]}
-                onPress={() => setFilter('all')}
+                onPress={() => void clearAllFilters()}
               >
-                <Text style={[styles.emptyButtonText, { color: colors.text }]}>{t('screens.torrents.clearFilter')}</Text>
+                <Text style={[styles.emptyButtonText, { color: colors.text }]}>{t('screens.torrents.clearAllFilters')}</Text>
               </TouchableOpacity>
             )}
           </View>
@@ -1624,6 +1807,13 @@ const styles = StyleSheet.create({
   },
   filterChipTextCompact: {
     ...buttonText.chip,
+  },
+  filterChipSeparator: {
+    width: 1,
+    height: 18,
+    marginHorizontal: spacing.xs,
+    alignSelf: 'center',
+    opacity: 0.5,
   },
   listContent: {
     paddingTop: 100,

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -21,6 +21,10 @@ export const CHANGELOG: ChangelogRelease[] = [
       'Creating a new category from the torrent detail screen is now fixed — categories are properly saved to the server before being assigned',
       'Tags displayed in the torrent detail screen now appear as individual chips matching the Category badge style',
       'Improved qBittorrent v4.x compatibility',
+      'Added category and tag filters to the torrents tab — tap the Category or Tags chip in the filter row to narrow the list',
+      'Tag filters use OR semantics: a torrent matches if it has any of the selected tags',
+      'Filter selections are remembered across sessions',
+      'Search plugin support (feature flag - disabled for App Store builds)',
     ],
   },
   {
@@ -40,7 +44,7 @@ export const CHANGELOG: ChangelogRelease[] = [
   {
     version: '3.2.0',
     date: '2026-05-29',
-    changes: ['Search plugin support (feature flag - disabled for App Store builds)'],
+    changes: ['Search plugin support'],
   },
   {
     version: '3.1.2',

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -36,6 +36,9 @@
       "addTorrent": "Torrent hinzufügen",
       "noFilterResults": "Keine {{filter}}-Torrents gefunden",
       "noStuckResults": "Keine feststeckenden Torrents gefunden",
+      "noCategoryResults": "Keine Torrents in dieser Kategorie",
+      "noTagResults": "Keine Torrents mit den ausgewählten Tags",
+      "clearAllFilters": "Alle Filter löschen",
       "urlOrMagnet": "Torrent-URL oder Magnet-Link",
       "selectTorrentFile": "Torrent-Datei auswählen",
       "yourServers": "DEINE SERVER",
@@ -645,7 +648,12 @@
     "paused": "Pausiert",
     "stuck": "Feststeckend",
     "downloading": "DL",
-    "uploading": "UL"
+    "uploading": "UL",
+    "category": "Kategorie",
+    "allCategories": "Alle Kategorien",
+    "uncategorized": "Ohne Kategorie",
+    "tags": "Tags",
+    "tagsCount": "Tags ({{count}})"
   },
   "sort": {
     "dateAdded": "Datum",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -56,6 +56,9 @@
       "addTorrent": "Add Torrent",
       "noFilterResults": "No {{filter}} torrents found",
       "noStuckResults": "No stuck torrents found",
+      "noCategoryResults": "No torrents in this category",
+      "noTagResults": "No torrents with the selected tag(s)",
+      "clearAllFilters": "Clear All Filters",
       "urlOrMagnet": "Torrent URL or Magnet Link",
       "selectTorrentFile": "Select .torrent file",
       "yourServers": "YOUR SERVERS",
@@ -665,7 +668,12 @@
     "paused": "Paused",
     "stuck": "Stuck",
     "downloading": "DL",
-    "uploading": "UL"
+    "uploading": "UL",
+    "category": "Category",
+    "allCategories": "All Categories",
+    "uncategorized": "Uncategorized",
+    "tags": "Tags",
+    "tagsCount": "Tags ({{count}})"
   },
   "sort": {
     "dateAdded": "Date Added",

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -36,6 +36,9 @@
       "addTorrent": "Añadir Torrent",
       "noFilterResults": "No se encontraron torrents {{filter}}",
       "noStuckResults": "No se encontraron torrents bloqueados",
+      "noCategoryResults": "No hay torrents en esta categoría",
+      "noTagResults": "No hay torrents con las etiquetas seleccionadas",
+      "clearAllFilters": "Borrar Todos los Filtros",
       "urlOrMagnet": "URL de torrent o enlace magnético",
       "selectTorrentFile": "Seleccionar archivo .torrent",
       "yourServers": "TUS SERVIDORES",
@@ -645,7 +648,12 @@
     "paused": "Pausados",
     "stuck": "Bloqueados",
     "downloading": "DL",
-    "uploading": "UL"
+    "uploading": "UL",
+    "category": "Categoría",
+    "allCategories": "Todas las categorías",
+    "uncategorized": "Sin categoría",
+    "tags": "Etiquetas",
+    "tagsCount": "Etiquetas ({{count}})"
   },
   "sort": {
     "dateAdded": "Fecha",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -37,6 +37,9 @@
       "addTorrent": "Ajouter un torrent",
       "noFilterResults": "Aucun torrent {{filter}} trouvé",
       "noStuckResults": "Aucun torrent bloqué trouvé",
+      "noCategoryResults": "Aucun torrent dans cette catégorie",
+      "noTagResults": "Aucun torrent avec les étiquettes sélectionnées",
+      "clearAllFilters": "Effacer tous les filtres",
       "urlOrMagnet": "URL de torrent ou lien magnétique",
       "selectTorrentFile": "Sélectionner un fichier .torrent",
       "yourServers": "VOS SERVEURS",
@@ -653,7 +656,12 @@
     "paused": "En pause",
     "stuck": "Bloqués",
     "downloading": "DL",
-    "uploading": "UL"
+    "uploading": "UL",
+    "category": "Catégorie",
+    "allCategories": "Toutes les catégories",
+    "uncategorized": "Non catégorisé",
+    "tags": "Étiquettes",
+    "tagsCount": "Étiquettes ({{count}})"
   },
   "sort": {
     "dateAdded": "Date",

--- a/locales/ru/translation.json
+++ b/locales/ru/translation.json
@@ -57,6 +57,9 @@
       "addTorrent": "Добавить торрент",
       "noFilterResults": "Торрентов «{{filter}}» не найдено",
       "noStuckResults": "Простаивающих торрентов не найдено",
+      "noCategoryResults": "В этой категории нет торрентов",
+      "noTagResults": "Нет торрентов с выбранными тегами",
+      "clearAllFilters": "Сбросить все фильтры",
       "urlOrMagnet": "URL торрента или magnet-ссылка",
       "selectTorrentFile": "Выбрать .torrent-файл",
       "yourServers": "ВАШИ СЕРВЕРЫ",
@@ -664,7 +667,12 @@
     "paused": "Пауза",
     "stuck": "Простаивает",
     "downloading": "Загр.",
-    "uploading": "Отд."
+    "uploading": "Отд.",
+    "category": "Категория",
+    "allCategories": "Все категории",
+    "uncategorized": "Без категории",
+    "tags": "Теги",
+    "tagsCount": "Теги ({{count}})"
   },
   "sort": {
     "dateAdded": "Дата добавления",

--- a/locales/zh/translation.json
+++ b/locales/zh/translation.json
@@ -37,6 +37,9 @@
       "addTorrent": "添加种子",
       "noFilterResults": "未找到 {{filter}} 种子",
       "noStuckResults": "未找到卡住的种子",
+      "noCategoryResults": "此分类下没有种子",
+      "noTagResults": "没有带所选标签的种子",
+      "clearAllFilters": "清除所有筛选",
       "urlOrMagnet": "种子 URL 或磁力链接",
       "selectTorrentFile": "选择 .torrent 文件",
       "yourServers": "你的服务器",
@@ -668,7 +671,12 @@
     "paused": "已暂停",
     "stuck": "卡住",
     "downloading": "下载",
-    "uploading": "上传"
+    "uploading": "上传",
+    "category": "分类",
+    "allCategories": "所有分类",
+    "uncategorized": "未分类",
+    "tags": "标签",
+    "tagsCount": "标签 ({{count}})"
   },
   "sort": {
     "dateAdded": "添加日期",

--- a/types/preferences.ts
+++ b/types/preferences.ts
@@ -138,6 +138,15 @@ export interface AppPreferences {
 
   /** Last selected search category ("all" or a plugin-supported category id) */
   lastSearchCategory?: string;
+
+  /**
+   * Last active category filter on the torrents tab.
+   * null = All categories; '' = Uncategorized (torrents with no category set).
+   */
+  lastCategoryFilter?: string | null;
+
+  /** Last active tag filters on the torrents tab (OR semantics). */
+  lastTagFilters?: string[];
 }
 
 export const DEFAULT_PREFERENCES: AppPreferences = {
@@ -203,4 +212,6 @@ export const DEFAULT_PREFERENCES: AppPreferences = {
   lastSearchQuery: '',
   lastSearchPlugin: 'enabled',
   lastSearchCategory: 'all',
+  lastCategoryFilter: null,
+  lastTagFilters: [],
 };

--- a/utils/tags.ts
+++ b/utils/tags.ts
@@ -1,0 +1,25 @@
+/**
+ * tags.ts — Shared helpers for parsing qBittorrent's comma-separated tag strings.
+ *
+ * qBittorrent stores tags on TorrentInfo as a single CSV string (e.g. "linux,iso,seedbox").
+ * These utilities centralise the split logic used across filter, display, and edit surfaces.
+ */
+
+/** Parse a torrent's CSV tag string into a trimmed, non-empty array. */
+export function parseTagsCsv(csv: string): string[] {
+  if (!csv) return [];
+  return csv
+    .split(',')
+    .map((t) => t.trim())
+    .filter((t) => t.length > 0);
+}
+
+/**
+ * Returns true if the torrent's tags string contains at least one of the
+ * selected filter tags (OR semantics — matching any selected tag is sufficient).
+ */
+export function torrentHasAnyTag(torrentTagsCsv: string, selectedTags: string[]): boolean {
+  if (selectedTags.length === 0) return true;
+  const torrentTags = parseTagsCsv(torrentTagsCsv);
+  return selectedTags.some((sel) => torrentTags.includes(sel));
+}


### PR DESCRIPTION
## Summary
- Adds **Category** and **Tags** filter chips to the torrents tab filter row, opening existing picker modals to narrow the list
- Category filter supports All, Uncategorized, and any server category; tag filter uses OR semantics (match any selected tag)
- Filter selections persist via `lastCategoryFilter` / `lastTagFilters` preferences and restore on launch
- Changelog updated under 3.3.1 (includes search plugin note relocation)

Closes #90

## Test plan
- [ ] Tap Category chip → pick a category → list narrows; chip shows selected name
- [ ] Tap Tags chip → select one or more tags → list shows torrents with any selected tag
- [ ] Combine state filter (e.g. Active) + category + tags + search — all apply together
- [ ] Empty state shows appropriate message; Clear All Filters resets state, category, and tags
- [ ] Kill and relaunch app — category/tag filters restore from preferences
- [ ] Verify i18n strings in at least one non-English locale
- [ ] `npx tsc --noEmit` passes