### PR TITLE
feat(server): add optional Basic Auth for reverse proxy servers

### DIFF
--- a/app/server/[id].tsx
+++ b/app/server/[id].tsx
@@ -50,6 +50,9 @@ export default function EditServerScreen() {
   const [password, setPassword] = useState('');
   const [useHttps, setUseHttps] = useState(false);
   const [bypassAuth, setBypassAuth] = useState(false);
+  const [useBasicAuth, setUseBasicAuth] = useState(false);
+  const [basicAuthUsername, setBasicAuthUsername] = useState('');
+  const [basicAuthPassword, setBasicAuthPassword] = useState('');
   const [useFallback, setUseFallback] = useState(false);
   const [fallbackHost, setFallbackHost] = useState('');
   const [fallbackPort, setFallbackPort] = useState('');
@@ -197,6 +200,9 @@ App Version: ${APP_VERSION}`;
         setPassword(server.password || '');
         setUseHttps(server.useHttps || false);
         setBypassAuth(server.bypassAuth || false);
+        setUseBasicAuth(server.useBasicAuth || false);
+        setBasicAuthUsername(server.basicAuthUsername || '');
+        setBasicAuthPassword(server.basicAuthPassword || '');
         // Preserve existing basePath for backward compatibility
         setPreservedBasePath(server.basePath || '/');
         // Round-trip fallback fields
@@ -226,6 +232,11 @@ App Version: ${APP_VERSION}`;
 
     if (!bypassAuth && (!username.trim() || !password.trim())) {
       showToast(t('errors.fillUsernamePassword'), 'error');
+      return;
+    }
+
+    if (useBasicAuth && !basicAuthUsername.trim()) {
+      showToast(t('errors.fillBasicAuthUsername'), 'error');
       return;
     }
 
@@ -265,6 +276,9 @@ App Version: ${APP_VERSION}`;
         password: bypassAuth ? '' : password.trim(),
         useHttps,
         bypassAuth,
+        useBasicAuth,
+        basicAuthUsername: useBasicAuth ? basicAuthUsername.trim() : '',
+        basicAuthPassword: useBasicAuth ? basicAuthPassword : '',
         useFallback,
         fallbackHost: useFallback ? stripProtocol(fallbackHost.trim()) : '',
         fallbackPort: useFallback ? fallbackPortNum : undefined,
@@ -316,6 +330,11 @@ App Version: ${APP_VERSION}`;
       return;
     }
 
+    if (useBasicAuth && !basicAuthUsername.trim()) {
+      showToast(t('errors.fillBasicAuthUsername'), 'error');
+      return;
+    }
+
     const portNum = port.trim() ? parseInt(port, 10) : undefined;
     if (portNum !== undefined && (isNaN(portNum) || portNum < 1 || portNum > 65535)) {
       showToast(t('errors.validPort'), 'error');
@@ -347,6 +366,9 @@ App Version: ${APP_VERSION}`;
         password: bypassAuth ? '' : password.trim(),
         useHttps,
         bypassAuth,
+        useBasicAuth,
+        basicAuthUsername: useBasicAuth ? basicAuthUsername.trim() : '',
+        basicAuthPassword: useBasicAuth ? basicAuthPassword : '',
         useFallback,
         fallbackHost: useFallback ? stripProtocol(fallbackHost.trim()) : '',
         fallbackPort: useFallback ? fallbackPortNum : undefined,
@@ -547,6 +569,64 @@ App Version: ${APP_VERSION}`;
                       onValueChange={setFallbackUseHttps}
                       trackColor={{ false: colors.surfaceOutline, true: colors.primary }}
                       thumbColor="#FFFFFF"
+                    />
+                  </View>
+                </>
+              )}
+            </View>
+          </View>
+
+          {/* Proxy Authentication Section */}
+          <View style={styles.section}>
+            <Text style={[styles.sectionHeader, { color: colors.textSecondary }]}>{t('server.proxyAuthentication')}</Text>
+            <View style={[styles.card, { backgroundColor: colors.surface }]}>
+              <View style={styles.settingRow}>
+                <View style={styles.settingLeft}>
+                  <Ionicons name="globe-outline" size={20} color={colors.primary} style={styles.inputIcon} />
+                  <View>
+                    <Text style={[styles.settingLabel, { color: colors.text }]}>{t('server.useBasicAuth')}</Text>
+                    <Text style={[styles.settingHint, { color: colors.textSecondary }]}>{t('server.useBasicAuthHint')}</Text>
+                  </View>
+                </View>
+                <Switch
+                  value={useBasicAuth}
+                  onValueChange={setUseBasicAuth}
+                  trackColor={{ false: colors.surfaceOutline, true: colors.primary }}
+                  thumbColor="#FFFFFF"
+                />
+              </View>
+              {useBasicAuth && (
+                <>
+                  <View style={[styles.separator, { backgroundColor: colors.surfaceOutline }]} />
+                  <View style={styles.inputRow}>
+                    <Ionicons name="person-outline" size={20} color={colors.primary} style={styles.inputIcon} />
+                    <TextInput
+                      style={[styles.input, { color: colors.text }]}
+                      value={basicAuthUsername}
+                      onChangeText={setBasicAuthUsername}
+                      placeholder={t('placeholders.proxyUsername')}
+                      placeholderTextColor={colors.textSecondary}
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      textContentType="none"
+                      autoComplete="off"
+                    />
+                  </View>
+                  <View style={[styles.separator, { backgroundColor: colors.surfaceOutline }]} />
+                  <View style={styles.inputRow}>
+                    <Ionicons name="lock-closed-outline" size={20} color={colors.primary} style={styles.inputIcon} />
+                    <TextInput
+                      style={[styles.input, { color: colors.text }]}
+                      value={basicAuthPassword}
+                      onChangeText={setBasicAuthPassword}
+                      placeholder={t('placeholders.proxyPassword')}
+                      placeholderTextColor={colors.textSecondary}
+                      secureTextEntry
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      textContentType="password"
+                      autoComplete="off"
+                      passwordRules=""
                     />
                   </View>
                 </>
@@ -774,6 +854,9 @@ App Version: ${APP_VERSION}`;
                 username={username}
                 password={password}
                 bypassAuth={bypassAuth}
+                useBasicAuth={useBasicAuth}
+                basicAuthUsername={basicAuthUsername}
+                basicAuthPassword={basicAuthPassword}
               />
             </View>
           )}

--- a/app/server/add.tsx
+++ b/app/server/add.tsx
@@ -48,6 +48,9 @@ export default function AddServerScreen() {
   const [password, setPassword] = useState('');
   const [useHttps, setUseHttps] = useState(false);
   const [bypassAuth, setBypassAuth] = useState(false);
+  const [useBasicAuth, setUseBasicAuth] = useState(false);
+  const [basicAuthUsername, setBasicAuthUsername] = useState('');
+  const [basicAuthPassword, setBasicAuthPassword] = useState('');
   const [useFallback, setUseFallback] = useState(false);
   const [fallbackHost, setFallbackHost] = useState('');
   const [fallbackPort, setFallbackPort] = useState('');
@@ -185,6 +188,11 @@ App Version: ${APP_VERSION}`;
       return;
     }
 
+    if (useBasicAuth && !basicAuthUsername.trim()) {
+      showToast(t('errors.fillBasicAuthUsername'), 'error');
+      return;
+    }
+
     const portNum = (port.trim() ? parseInt(port, 10) : undefined);
     if (portNum !== undefined && (isNaN(portNum) || portNum < 1 || portNum > 65535)) {
       showToast(t('errors.validPort'), 'error');
@@ -220,6 +228,9 @@ App Version: ${APP_VERSION}`;
         password: bypassAuth ? '' : password.trim(),
         useHttps,
         bypassAuth,
+        useBasicAuth,
+        basicAuthUsername: useBasicAuth ? basicAuthUsername.trim() : '',
+        basicAuthPassword: useBasicAuth ? basicAuthPassword : '',
         useFallback,
         fallbackHost: useFallback ? stripProtocol(fallbackHost.trim()) : '',
         fallbackPort: useFallback ? fallbackPortNum : undefined,
@@ -260,6 +271,11 @@ App Version: ${APP_VERSION}`;
       return;
     }
 
+    if (useBasicAuth && !basicAuthUsername.trim()) {
+      showToast(t('errors.fillBasicAuthUsername'), 'error');
+      return;
+    }
+
     const portNum = (port.trim() ? parseInt(port, 10) : undefined);
     if (portNum !== undefined && (isNaN(portNum) || portNum < 1 || portNum > 65535)) {
       showToast(t('errors.validPort'), 'error');
@@ -291,6 +307,9 @@ App Version: ${APP_VERSION}`;
         password: bypassAuth ? '' : password.trim(),
         useHttps,
         bypassAuth,
+        useBasicAuth,
+        basicAuthUsername: useBasicAuth ? basicAuthUsername.trim() : '',
+        basicAuthPassword: useBasicAuth ? basicAuthPassword : '',
         useFallback,
         fallbackHost: useFallback ? stripProtocol(fallbackHost.trim()) : '',
         fallbackPort: useFallback ? fallbackPortNum : undefined,
@@ -483,6 +502,64 @@ App Version: ${APP_VERSION}`;
                       onValueChange={setFallbackUseHttps}
                       trackColor={{ false: colors.surfaceOutline, true: colors.primary }}
                       thumbColor="#FFFFFF"
+                    />
+                  </View>
+                </>
+              )}
+            </View>
+          </View>
+
+          {/* Proxy Authentication Section */}
+          <View style={styles.section}>
+            <Text style={[styles.sectionHeader, { color: colors.textSecondary }]}>{t('server.proxyAuthentication')}</Text>
+            <View style={[styles.card, { backgroundColor: colors.surface }]}>
+              <View style={styles.settingRow}>
+                <View style={styles.settingLeft}>
+                  <Ionicons name="globe-outline" size={20} color={colors.primary} style={styles.inputIcon} />
+                  <View>
+                    <Text style={[styles.settingLabel, { color: colors.text }]}>{t('server.useBasicAuth')}</Text>
+                    <Text style={[styles.settingHint, { color: colors.textSecondary }]}>{t('server.useBasicAuthHint')}</Text>
+                  </View>
+                </View>
+                <Switch
+                  value={useBasicAuth}
+                  onValueChange={setUseBasicAuth}
+                  trackColor={{ false: colors.surfaceOutline, true: colors.primary }}
+                  thumbColor="#FFFFFF"
+                />
+              </View>
+              {useBasicAuth && (
+                <>
+                  <View style={[styles.separator, { backgroundColor: colors.surfaceOutline }]} />
+                  <View style={styles.inputRow}>
+                    <Ionicons name="person-outline" size={20} color={colors.primary} style={styles.inputIcon} />
+                    <TextInput
+                      style={[styles.input, { color: colors.text }]}
+                      value={basicAuthUsername}
+                      onChangeText={setBasicAuthUsername}
+                      placeholder={t('placeholders.proxyUsername')}
+                      placeholderTextColor={colors.textSecondary}
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      textContentType="none"
+                      autoComplete="off"
+                    />
+                  </View>
+                  <View style={[styles.separator, { backgroundColor: colors.surfaceOutline }]} />
+                  <View style={styles.inputRow}>
+                    <Ionicons name="lock-closed-outline" size={20} color={colors.primary} style={styles.inputIcon} />
+                    <TextInput
+                      style={[styles.input, { color: colors.text }]}
+                      value={basicAuthPassword}
+                      onChangeText={setBasicAuthPassword}
+                      placeholder={t('placeholders.proxyPassword')}
+                      placeholderTextColor={colors.textSecondary}
+                      secureTextEntry
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      textContentType="password"
+                      autoComplete="off"
+                      passwordRules=""
                     />
                   </View>
                 </>
@@ -710,6 +787,9 @@ App Version: ${APP_VERSION}`;
                 username={username}
                 password={password}
                 bypassAuth={bypassAuth}
+                useBasicAuth={useBasicAuth}
+                basicAuthUsername={basicAuthUsername}
+                basicAuthPassword={basicAuthPassword}
               />
             </View>
           )}

--- a/app/settings/advanced.tsx
+++ b/app/settings/advanced.tsx
@@ -88,6 +88,9 @@ export default function AdvancedSettingsScreen() {
           username: s.username,
           useHttps: s.useHttps,
           bypassAuth: s.bypassAuth,
+          useBasicAuth: s.useBasicAuth,
+          basicAuthUsername: s.basicAuthUsername,
+          // basicAuthPassword intentionally excluded — re-enter after import
         })),
         exportDate: new Date().toISOString(),
         appVersion: APP_VERSION,

--- a/components/SuperDebugPanel.tsx
+++ b/components/SuperDebugPanel.tsx
@@ -39,6 +39,10 @@ export interface SuperDebugPanelProps {
   username: string;
   password: string;
   bypassAuth: boolean;
+  /** Optional proxy Basic Auth fields — when absent, no Authorization header is sent. */
+  useBasicAuth?: boolean;
+  basicAuthUsername?: string;
+  basicAuthPassword?: string;
 }
 
 type DiagnosticStep = 'REACH' | 'LOGIN' | 'COOKIE' | 'API' | 'INFO' | 'WARN' | 'ERROR';
@@ -64,6 +68,9 @@ export function SuperDebugPanel({
   username,
   password,
   bypassAuth,
+  useBasicAuth = false,
+  basicAuthUsername = '',
+  basicAuthPassword = '',
 }: SuperDebugPanelProps) {
   const { colors } = useTheme();
   const [log, setLog] = useState<DiagnosticEntry[]>([]);
@@ -87,6 +94,29 @@ export function SuperDebugPanel({
     const portPart = portNum && portNum > 0 && !isNaN(portNum) ? `:${portNum}` : '';
     return `${protocol}://${clean}${portPart}`;
   }, [host, port, useHttps]);
+
+  /** Build the Authorization header value when proxy Basic Auth is enabled. */
+  const buildBasicAuthHeader = useCallback((): string | null => {
+    if (!useBasicAuth || !basicAuthUsername.trim()) return null;
+    const BASE64 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+    const input = `${basicAuthUsername.trim()}:${basicAuthPassword}`;
+    const bytes: number[] = [];
+    for (let i = 0; i < input.length; i++) {
+      const code = input.charCodeAt(i);
+      if (code < 0x80) { bytes.push(code); }
+      else if (code < 0x800) { bytes.push(0xc0 | (code >> 6), 0x80 | (code & 0x3f)); }
+      else { bytes.push(0xe0 | (code >> 12), 0x80 | ((code >> 6) & 0x3f), 0x80 | (code & 0x3f)); }
+    }
+    let b64 = '';
+    for (let i = 0; i < bytes.length; i += 3) {
+      const b0 = bytes[i], b1 = bytes[i + 1] ?? 0, b2 = bytes[i + 2] ?? 0;
+      b64 += BASE64[b0 >> 2];
+      b64 += BASE64[((b0 & 3) << 4) | (b1 >> 4)];
+      b64 += i + 1 < bytes.length ? BASE64[((b1 & 15) << 2) | (b2 >> 6)] : '=';
+      b64 += i + 2 < bytes.length ? BASE64[b2 & 63] : '=';
+    }
+    return 'Basic ' + b64;
+  }, [useBasicAuth, basicAuthUsername, basicAuthPassword]);
 
   const addEntry = useCallback(
     (step: DiagnosticStep, message: string, status: DiagnosticStatus, detail?: string) => {
@@ -129,10 +159,14 @@ export function SuperDebugPanel({
     const start = Date.now();
 
     try {
+      const basicAuth = buildBasicAuthHeader();
+      const reachHeaders: Record<string, string> = {};
+      if (basicAuth) reachHeaders['Authorization'] = basicAuth;
       let response: Response;
       try {
         response = await fetch(url, {
           method: 'HEAD',
+          headers: reachHeaders,
           signal: controller.signal,
         });
       } catch {
@@ -140,6 +174,7 @@ export function SuperDebugPanel({
         if (controller.signal.aborted) throw new Error('Timed out after 15s');
         response = await fetch(url, {
           method: 'GET',
+          headers: reachHeaders,
           signal: controller.signal,
         });
       }
@@ -148,7 +183,11 @@ export function SuperDebugPanel({
       if (response.status < 400) {
         addEntry('REACH', `Host reachable — HTTP ${response.status} in ${latency}ms`, 'success');
       } else if (response.status === 401 || response.status === 403) {
-        addEntry('REACH', `Host reachable — HTTP ${response.status} in ${latency}ms (auth required, this is normal)`, 'success');
+        if (useBasicAuth && response.status === 401) {
+          addEntry('REACH', `Host reachable — HTTP ${response.status} in ${latency}ms (proxy credentials rejected or not accepted)`, 'warning');
+        } else {
+          addEntry('REACH', `Host reachable — HTTP ${response.status} in ${latency}ms (auth required, this is normal)`, 'success');
+        }
       } else {
         addEntry('REACH', `Host responded with HTTP ${response.status} in ${latency}ms`, 'warning');
       }
@@ -247,7 +286,7 @@ export function SuperDebugPanel({
     addEntry('INFO', `Target: ${baseUrl}`, 'info');
     addEntry('INFO', `Platform: ${Platform.OS} ${Platform.Version}`, 'info');
     addEntry('INFO', `App: ${APP_VERSION}`, 'info');
-    addEntry('INFO', `HTTPS: ${useHttps ? 'Yes' : 'No'} | Auth Bypass: ${bypassAuth ? 'Yes' : 'No'}`, 'info');
+    addEntry('INFO', `HTTPS: ${useHttps ? 'Yes' : 'No'} | Auth Bypass: ${bypassAuth ? 'Yes' : 'No'} | Basic Auth: ${useBasicAuth ? 'Yes' : 'No'}`, 'info');
 
     let passed = 0;
     const totalSteps = bypassAuth ? 2 : 4;
@@ -261,18 +300,27 @@ export function SuperDebugPanel({
         if (!controller.signal.aborted) controller.abort();
       }, 15000);
 
+      const basicAuth = buildBasicAuthHeader();
+      const diagHeaders: Record<string, string> = {};
+      if (basicAuth) diagHeaders['Authorization'] = basicAuth;
+
       try {
         let reachResp: Response;
         try {
-          reachResp = await fetch(baseUrl, { method: 'HEAD', signal: controller.signal });
+          reachResp = await fetch(baseUrl, { method: 'HEAD', headers: diagHeaders, signal: controller.signal });
         } catch {
           if (controller.signal.aborted) throw new Error('Timed out after 15s');
-          reachResp = await fetch(baseUrl, { method: 'GET', signal: controller.signal });
+          reachResp = await fetch(baseUrl, { method: 'GET', headers: diagHeaders, signal: controller.signal });
         }
         clearTimeout(reachTimeout);
         const reachLatency = Date.now() - reachStart;
-        addEntry('REACH', `Server responded — HTTP ${reachResp.status} in ${reachLatency}ms`, 'success');
-        passed++;
+        if (reachResp.status === 401 && useBasicAuth) {
+          addEntry('REACH', `Server responded — HTTP ${reachResp.status} in ${reachLatency}ms (proxy credentials rejected — check Basic Auth username/password)`, 'warning');
+          passed++;
+        } else {
+          addEntry('REACH', `Server responded — HTTP ${reachResp.status} in ${reachLatency}ms`, 'success');
+          passed++;
+        }
       } catch (err: unknown) {
         clearTimeout(reachTimeout);
         if (controller.signal.aborted && !getErrorMessage(err).includes('Timed out')) throw err;
@@ -303,7 +351,10 @@ export function SuperDebugPanel({
         try {
           const loginResp = await fetch(loginUrl, {
             method: 'POST',
-            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded',
+              ...(basicAuth ? { 'Authorization': basicAuth } : {}),
+            },
             body: `username=${encodeURIComponent(username.trim())}&password=${encodeURIComponent(password.trim())}`,
             signal: controller.signal,
             credentials: 'omit',
@@ -384,6 +435,9 @@ export function SuperDebugPanel({
         const headers: Record<string, string> = {};
         if (sidCookie) {
           headers['Cookie'] = sidCookie;
+        }
+        if (basicAuth) {
+          headers['Authorization'] = basicAuth;
         }
         const apiResp = await fetch(versionUrl, {
           method: 'GET',
@@ -466,6 +520,7 @@ export function SuperDebugPanel({
       `Port: ${portNum || 'default (80/443)'}`,
       `HTTPS: ${useHttps ? 'Yes' : 'No'}`,
       `Auth Bypass: ${bypassAuth ? 'Yes' : 'No'}`,
+      `Basic Auth: ${useBasicAuth ? 'Yes' : 'No'}`,
       '',
       '--- Diagnostic Log ---',
       ...log.map((e) => `${formatTime(e.timestamp)} [${e.step}] ${e.message}`),
@@ -530,6 +585,7 @@ export function SuperDebugPanel({
         `Port: ${portNum || 'default (80/443)'}`,
         `HTTPS: ${useHttps ? 'Yes' : 'No'}`,
         `Auth Bypass: ${bypassAuth ? 'Yes' : 'No'}`,
+        `Basic Auth: ${useBasicAuth ? 'Yes' : 'No'}`,
         `Username: ${username ? '(set)' : '(empty)'}`,
         '',
       ];

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -12,7 +12,7 @@ export interface ChangelogRelease {
 
 export const CHANGELOG: ChangelogRelease[] = [
   {
-    version: '3.3.1',
+    version: '3.4.0',
     date: '2026-06-27',
     changes: [
       'Expanded torrent card now shows details in a two-column grid, cutting card height roughly in half',
@@ -25,6 +25,7 @@ export const CHANGELOG: ChangelogRelease[] = [
       'Tag filters use OR semantics: a torrent matches if it has any of the selected tags',
       'Filter selections are remembered across sessions',
       'Search plugin support (feature flag - disabled for App Store builds)',
+      'Added optional Basic Auth credentials for servers behind a reverse proxy',
     ],
   },
   {

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -379,7 +379,9 @@
     "password": "Passwort",
     "trackerUrl": "https://tracker.example.com/announce",
     "enterKbs": "KiB/s eingeben",
-    "fallbackHost": "Fallback-Host oder IP"
+    "fallbackHost": "Fallback-Host oder IP",
+    "proxyUsername": "Proxy-Benutzername",
+    "proxyPassword": "Proxy-Passwort"
   },
   "actions": {
     "resume": "Fortsetzen",
@@ -463,7 +465,10 @@
     "testEndpointOk": "{{endpoint}}: OK",
     "testEndpointFail": "{{endpoint}}: Fehler",
     "connectedViaPrimary": "Verbunden über Primär",
-    "connectedViaFallback": "Verbunden über Fallback"
+    "connectedViaFallback": "Verbunden über Fallback",
+    "proxyAuthentication": "PROXY-AUTHENTIFIZIERUNG",
+    "useBasicAuth": "Basic Auth (Proxy)",
+    "useBasicAuthHint": "Erforderlich wenn ein Reverse Proxy den Server schützt"
   },
   "torrentDetail": {
     "notFound": "Torrent nicht gefunden",
@@ -737,6 +742,7 @@
     "connectionFailedManual": "Connection failed: {{error}}. Please try connecting manually.",
     "fillNameAndHost": "Bitte Server-Name und Host ausfüllen",
     "fillUsernamePassword": "Bitte Benutzername und Passwort eingeben oder Auth-Umgehung aktivieren",
+    "fillBasicAuthUsername": "Bitte Proxy-Benutzername für Basic Auth eingeben",
     "validPort": "Bitte gültige Portnummer eingeben (1-65535)",
     "fillFallbackHost": "Bitte einen Fallback-Host angeben",
     "selectTorrentFile": "Bitte eine .torrent-Datei auswählen",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -399,7 +399,9 @@
     "password": "Password",
     "trackerUrl": "https://tracker.example.com/announce",
     "enterKbs": "Enter KiB/s",
-    "fallbackHost": "Fallback host or IP"
+    "fallbackHost": "Fallback host or IP",
+    "proxyUsername": "Proxy Username",
+    "proxyPassword": "Proxy Password"
   },
   "actions": {
     "resume": "Resume",
@@ -483,7 +485,10 @@
     "testEndpointOk": "{{endpoint}}: OK",
     "testEndpointFail": "{{endpoint}}: failed",
     "connectedViaPrimary": "Connected via primary",
-    "connectedViaFallback": "Connected via fallback"
+    "connectedViaFallback": "Connected via fallback",
+    "proxyAuthentication": "PROXY AUTHENTICATION",
+    "useBasicAuth": "Basic Auth (Proxy)",
+    "useBasicAuthHint": "Required when a reverse proxy protects the server"
   },
   "torrentDetail": {
     "notFound": "Torrent not found",
@@ -757,6 +762,7 @@
     "connectionFailedManual": "Connection failed: {{error}}. Please try connecting manually.",
     "fillNameAndHost": "Please fill in server name and host",
     "fillUsernamePassword": "Please fill in username and password, or enable bypass authentication",
+    "fillBasicAuthUsername": "Please fill in the proxy username for Basic Auth",
     "validPort": "Please enter a valid port number (1-65535)",
     "fillFallbackHost": "Please enter a fallback host",
     "selectTorrentFile": "Please select a .torrent file",

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -379,7 +379,9 @@
     "password": "Contraseña",
     "trackerUrl": "https://tracker.example.com/announce",
     "enterKbs": "Introducir KiB/s",
-    "fallbackHost": "Host o IP de respaldo"
+    "fallbackHost": "Host o IP de respaldo",
+    "proxyUsername": "Usuario del proxy",
+    "proxyPassword": "Contraseña del proxy"
   },
   "actions": {
     "resume": "Reanudar",
@@ -463,7 +465,10 @@
     "testEndpointOk": "{{endpoint}}: OK",
     "testEndpointFail": "{{endpoint}}: error",
     "connectedViaPrimary": "Conectado por principal",
-    "connectedViaFallback": "Conectado por respaldo"
+    "connectedViaFallback": "Conectado por respaldo",
+    "proxyAuthentication": "AUTENTICACIÓN DE PROXY",
+    "useBasicAuth": "Auth Básica (Proxy)",
+    "useBasicAuthHint": "Necesario cuando un proxy inverso protege el servidor"
   },
   "torrentDetail": {
     "notFound": "Torrent no encontrado",
@@ -737,6 +742,7 @@
     "connectionFailedManual": "Connection failed: {{error}}. Please try connecting manually.",
     "fillNameAndHost": "Rellena el nombre y host del servidor",
     "fillUsernamePassword": "Rellena usuario y contraseña, o activa bypass de autenticación",
+    "fillBasicAuthUsername": "Introduce el usuario del proxy para la Auth Básica",
     "validPort": "Introduce un número de puerto válido (1-65535)",
     "fillFallbackHost": "Introduce un host de respaldo",
     "selectTorrentFile": "Selecciona un archivo .torrent",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -380,7 +380,9 @@
     "password": "Mot de passe",
     "trackerUrl": "https://tracker.example.com/announce",
     "enterKbs": "Entrer KiB/s",
-    "fallbackHost": "Hôte ou IP de secours"
+    "fallbackHost": "Hôte ou IP de secours",
+    "proxyUsername": "Nom d'utilisateur proxy",
+    "proxyPassword": "Mot de passe proxy"
   },
   "actions": {
     "resume": "Reprendre",
@@ -466,7 +468,10 @@
     "testEndpointOk": "{{endpoint}} : OK",
     "testEndpointFail": "{{endpoint}} : échec",
     "connectedViaPrimary": "Connecté via le principal",
-    "connectedViaFallback": "Connecté via le secours"
+    "connectedViaFallback": "Connecté via le secours",
+    "proxyAuthentication": "AUTHENTIFICATION PROXY",
+    "useBasicAuth": "Auth Basique (Proxy)",
+    "useBasicAuthHint": "Requis quand un proxy inverse protège le serveur"
   },
   "torrentDetail": {
     "notFound": "Torrent introuvable",
@@ -749,6 +754,7 @@
     "connectionFailedManual": "Connection failed: {{error}}. Please try connecting manually.",
     "fillNameAndHost": "Remplissez le nom et l'hôte du serveur",
     "fillUsernamePassword": "Remplissez le nom d'utilisateur et le mot de passe, ou activez le contournement d'authentification",
+    "fillBasicAuthUsername": "Remplissez le nom d'utilisateur proxy pour l'Auth Basique",
     "validPort": "Entrez un numéro de port valide (1-65535)",
     "fillFallbackHost": "Saisissez un hôte de secours",
     "selectTorrentFile": "Sélectionnez un fichier .torrent",

--- a/locales/ru/translation.json
+++ b/locales/ru/translation.json
@@ -391,7 +391,9 @@
     "password": "Пароль",
     "trackerUrl": "https://tracker.example.com/announce",
     "enterKbs": "КиБ/с",
-    "fallbackHost": "Резервный хост или IP"
+    "fallbackHost": "Резервный хост или IP",
+    "proxyUsername": "Имя пользователя прокси",
+    "proxyPassword": "Пароль прокси"
   },
   "actions": {
     "resume": "Запустить",
@@ -477,7 +479,10 @@
     "testEndpointOk": "{{endpoint}}: OK",
     "testEndpointFail": "{{endpoint}}: ошибка",
     "connectedViaPrimary": "Подключено через основной",
-    "connectedViaFallback": "Подключено через резервный"
+    "connectedViaFallback": "Подключено через резервный",
+    "proxyAuthentication": "АУТЕНТИФИКАЦИЯ ПРОКСИ",
+    "useBasicAuth": "Basic Auth (Прокси)",
+    "useBasicAuthHint": "Требуется если сервер защищён обратным прокси"
   },
   "torrentDetail": {
     "notFound": "Торрент не найден",
@@ -760,6 +765,7 @@
     "connectionFailedManual": "Ошибка подключения: {{error}}. Попробуйте подключиться вручную.",
     "fillNameAndHost": "Укажите имя сервера и хост",
     "fillUsernamePassword": "Укажите имя пользователя и пароль или включите обход авторизации",
+    "fillBasicAuthUsername": "Укажите имя пользователя прокси для Basic Auth",
     "validPort": "Укажите порт от 1 до 65535",
     "fillFallbackHost": "Введите резервный хост",
     "selectTorrentFile": "Выберите .torrent-файл",

--- a/locales/zh/translation.json
+++ b/locales/zh/translation.json
@@ -395,7 +395,9 @@
     "password": "密码",
     "trackerUrl": "https://tracker.example.com/announce",
     "enterKbs": "输入 KiB/s",
-    "fallbackHost": "备用主机或 IP"
+    "fallbackHost": "备用主机或 IP",
+    "proxyUsername": "代理用户名",
+    "proxyPassword": "代理密码"
   },
   "actions": {
     "resume": "恢复",
@@ -481,7 +483,10 @@
     "testEndpointOk": "{{endpoint}}：成功",
     "testEndpointFail": "{{endpoint}}：失败",
     "connectedViaPrimary": "通过主 URL 连接",
-    "connectedViaFallback": "通过备用 URL 连接"
+    "connectedViaFallback": "通过备用 URL 连接",
+    "proxyAuthentication": "代理身份验证",
+    "useBasicAuth": "Basic 认证（代理）",
+    "useBasicAuthHint": "当反向代理保护服务器时需要启用"
   },
   "torrentDetail": {
     "notFound": "未找到种子",
@@ -764,6 +769,7 @@
     "connectionFailedManual": "Connection failed: {{error}}. Please try connecting manually.",
     "fillNameAndHost": "请填写服务器名称和主机",
     "fillUsernamePassword": "请填写用户名和密码，或启用绕过认证",
+    "fillBasicAuthUsername": "请填写 Basic 认证的代理用户名",
     "validPort": "请输入有效端口号 (1-65535)",
     "fillFallbackHost": "请输入备用主机",
     "selectTorrentFile": "请选择 .torrent 文件",

--- a/services/api/client.ts
+++ b/services/api/client.ts
@@ -7,6 +7,7 @@ import axios, { AxiosInstance, AxiosError, AxiosHeaders } from 'axios';
 import { ServerConfig } from '@/types/api';
 import { clogDebug, clogInfo, clogWarn, clogError } from '@/services/connectivity-log';
 import { ApiFeatures, getApiFeatures } from '@/utils/apiVersion';
+import { basicAuthHeader } from '@/utils/basicAuth';
 
 class ApiClient {
   private client: AxiosInstance;
@@ -58,6 +59,14 @@ class ApiClient {
         
         clogDebug('HTTP', `${config.method?.toUpperCase() || 'REQ'} ${config.baseURL}${config.url || ''}`);
         
+        // Add proxy Basic Auth header when configured
+        if (this.currentServer.useBasicAuth && this.currentServer.basicAuthUsername) {
+          config.headers.Authorization = basicAuthHeader(
+            this.currentServer.basicAuthUsername,
+            this.currentServer.basicAuthPassword ?? ''
+          );
+        }
+
         // Add cookies if available
         if (this.cookies) {
           config.headers.Cookie = this.cookies;

--- a/services/storage.ts
+++ b/services/storage.ts
@@ -48,12 +48,17 @@ export const storageService = {
         fallbackPort: (s.fallbackPort && s.fallbackPort > 0) ? s.fallbackPort : undefined,
         fallbackUseHttps: s.fallbackUseHttps || false,
         fallbackBasePath: s.fallbackBasePath || undefined,
+        // Proxy Basic Auth (password stored separately in SecureStore)
+        useBasicAuth: s.useBasicAuth || false,
+        basicAuthUsername: s.basicAuthUsername || '',
+        basicAuthPassword: '', // Don't store password in AsyncStorage
       }));
       
       await AsyncStorage.setItem(STORAGE_KEYS.SERVERS, JSON.stringify(serversWithoutPasswords));
       
-      // Store password securely
+      // Store passwords securely
       await SecureStore.setItemAsync(`server_password_${server.id}`, server.password);
+      await SecureStore.setItemAsync(`server_basic_auth_password_${server.id}`, server.basicAuthPassword ?? '');
     } catch (error) {
       throw error;
     }
@@ -73,9 +78,11 @@ export const storageService = {
       const serversWithPasswords = await Promise.all(
         servers.map(async (server) => {
           const password = await SecureStore.getItemAsync(`server_password_${server.id}`) || '';
+          const basicAuthPassword = await SecureStore.getItemAsync(`server_basic_auth_password_${server.id}`) || '';
           return {
             ...server,
             password,
+            basicAuthPassword,
             host: stripProtocol(server.host || ''),
             fallbackHost: server.fallbackHost ? stripProtocol(server.fallbackHost) : server.fallbackHost,
           };
@@ -105,8 +112,9 @@ export const storageService = {
     
     await AsyncStorage.setItem(STORAGE_KEYS.SERVERS, JSON.stringify(filtered.map(s => ({ ...s, password: '' }))));
     
-    // Remove password from SecureStore
+    // Remove passwords from SecureStore
     await SecureStore.deleteItemAsync(`server_password_${id}`);
+    await SecureStore.deleteItemAsync(`server_basic_auth_password_${id}`);
     
     // If this was the current server, clear it
     const currentId = await this.getCurrentServerId();

--- a/tests/services/client-basic-auth.test.ts
+++ b/tests/services/client-basic-auth.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Tests that the apiClient request interceptor adds (or omits) the
+ * Authorization header based on the ServerConfig.useBasicAuth flag.
+ */
+
+// --------------------------------------------------------------------------
+// Mock connectivity-log (used by client.ts at import time)
+// --------------------------------------------------------------------------
+jest.mock('@/services/connectivity-log', () => ({
+  clogDebug: jest.fn(),
+  clogInfo: jest.fn(),
+  clogWarn: jest.fn(),
+  clogError: jest.fn(),
+}));
+
+// --------------------------------------------------------------------------
+// Mock axios so the interceptor runs without a real network
+// --------------------------------------------------------------------------
+type RequestInterceptorFn = (config: Record<string, unknown>) => Record<string, unknown>;
+type ResponseInterceptorSuccessFn = (response: unknown) => unknown;
+type ResponseInterceptorErrorFn = (error: unknown) => unknown; // used in mock signature
+
+let capturedRequestInterceptor: RequestInterceptorFn | null = null;
+let capturedResponseInterceptorSuccess: ResponseInterceptorSuccessFn | null = null;
+
+const mockAxiosInstance = {
+  interceptors: {
+    request: {
+      use: jest.fn((fn: RequestInterceptorFn) => {
+        capturedRequestInterceptor = fn;
+      }),
+    },
+    response: {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      use: jest.fn((success: ResponseInterceptorSuccessFn, _error: ResponseInterceptorErrorFn) => {
+        capturedResponseInterceptorSuccess = success;
+      }),
+    },
+  },
+  defaults: { timeout: 10000 },
+  post: jest.fn(),
+  get: jest.fn(),
+};
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    create: jest.fn(() => mockAxiosInstance),
+  },
+  AxiosHeaders: class {
+    private headers: Record<string, string> = {};
+    constructor(initial?: Record<string, string>) {
+      if (initial) Object.assign(this.headers, initial);
+    }
+    set(key: string, value: string) { this.headers[key] = value; }
+    get(key: string) { return this.headers[key]; }
+  },
+  AxiosError: class extends Error {},
+}));
+
+// --------------------------------------------------------------------------
+// Mock apiVersion util
+// --------------------------------------------------------------------------
+jest.mock('@/utils/apiVersion', () => ({
+  getApiFeatures: jest.fn(() => ({})),
+}));
+
+// --------------------------------------------------------------------------
+// Import after mocks are established
+// --------------------------------------------------------------------------
+import { apiClient } from '@/services/api/client';
+import type { ServerConfig } from '@/types/api';
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
+
+function makeServer(overrides: Partial<ServerConfig> = {}): ServerConfig {
+  return {
+    id: 'test-server',
+    name: 'Test',
+    host: 'example.com',
+    port: 8080,
+    username: 'admin',
+    password: 'adminadmin',
+    useHttps: false,
+    bypassAuth: false,
+    ...overrides,
+  };
+}
+
+function runRequestInterceptor(server: ServerConfig): Record<string, unknown> {
+  apiClient.setServer(server);
+  if (!capturedRequestInterceptor) throw new Error('Request interceptor not captured');
+  const config = { headers: {} as Record<string, string>, method: 'get', url: '/test' };
+  return capturedRequestInterceptor(config) as Record<string, unknown>;
+}
+
+// --------------------------------------------------------------------------
+// Tests
+// --------------------------------------------------------------------------
+
+describe('apiClient request interceptor — Basic Auth', () => {
+  afterEach(() => {
+    apiClient.setServer(null);
+  });
+
+  it('does NOT add Authorization header when useBasicAuth is false', () => {
+    const config = runRequestInterceptor(makeServer({ useBasicAuth: false }));
+    const headers = config.headers as Record<string, string>;
+    expect(headers['Authorization']).toBeUndefined();
+  });
+
+  it('does NOT add Authorization header when useBasicAuth is undefined', () => {
+    const config = runRequestInterceptor(makeServer());
+    const headers = config.headers as Record<string, string>;
+    expect(headers['Authorization']).toBeUndefined();
+  });
+
+  it('does NOT add Authorization header when useBasicAuth is true but username is empty', () => {
+    const config = runRequestInterceptor(makeServer({ useBasicAuth: true, basicAuthUsername: '' }));
+    const headers = config.headers as Record<string, string>;
+    expect(headers['Authorization']).toBeUndefined();
+  });
+
+  it('adds a Basic Authorization header when useBasicAuth is true with credentials', () => {
+    const config = runRequestInterceptor(
+      makeServer({ useBasicAuth: true, basicAuthUsername: 'proxyuser', basicAuthPassword: 'proxypass' })
+    );
+    const headers = config.headers as Record<string, string>;
+    expect(headers['Authorization']).toMatch(/^Basic /);
+  });
+
+  it('Authorization header encodes the correct credentials', () => {
+    const config = runRequestInterceptor(
+      makeServer({ useBasicAuth: true, basicAuthUsername: 'admin', basicAuthPassword: 'secret' })
+    );
+    const headers = config.headers as Record<string, string>;
+    const encoded = (headers['Authorization'] as string).slice(6);
+    const decoded = Buffer.from(encoded, 'base64').toString('utf8');
+    expect(decoded).toBe('admin:secret');
+  });
+
+  it('coalesces undefined basicAuthPassword to empty string (no crash)', () => {
+    const server = makeServer({ useBasicAuth: true, basicAuthUsername: 'user', basicAuthPassword: undefined });
+    expect(() => runRequestInterceptor(server)).not.toThrow();
+    const config = runRequestInterceptor(server);
+    const headers = config.headers as Record<string, string>;
+    expect(headers['Authorization']).toMatch(/^Basic /);
+    const encoded = (headers['Authorization'] as string).slice(6);
+    const decoded = Buffer.from(encoded, 'base64').toString('utf8');
+    expect(decoded).toBe('user:');
+  });
+
+  it('still sets Cookie header alongside Authorization when both are present', () => {
+    apiClient.setServer(
+      makeServer({ useBasicAuth: true, basicAuthUsername: 'u', basicAuthPassword: 'p' })
+    );
+    // Manually inject a cookie by simulating a captured response
+    if (capturedResponseInterceptorSuccess) {
+      capturedResponseInterceptorSuccess({
+        headers: { 'set-cookie': 'SID=testcookie123; Path=/' },
+        data: 'Ok.',
+        status: 200,
+      });
+    }
+    if (!capturedRequestInterceptor) throw new Error('Request interceptor not captured');
+    const config = { headers: {} as Record<string, string>, method: 'get', url: '/test' };
+    const result = capturedRequestInterceptor(config) as { headers: Record<string, string> };
+    expect(result.headers['Authorization']).toMatch(/^Basic /);
+    expect(result.headers['Cookie']).toContain('SID=testcookie123');
+  });
+});

--- a/tests/utils/basicAuth.test.ts
+++ b/tests/utils/basicAuth.test.ts
@@ -1,0 +1,50 @@
+import { basicAuthHeader } from '@/utils/basicAuth';
+
+describe('basicAuthHeader', () => {
+  it('encodes ASCII credentials to a valid Basic header', () => {
+    // RFC 7617: "user:pass" → "dXNlcjpwYXNz"
+    expect(basicAuthHeader('user', 'pass')).toBe('Basic dXNlcjpwYXNz');
+  });
+
+  it('encodes the classic admin:adminadmin pair correctly', () => {
+    // "admin:adminadmin" → "YWRtaW46YWRtaW5hZG1pbg=="
+    expect(basicAuthHeader('admin', 'adminadmin')).toBe('Basic YWRtaW46YWRtaW5hZG1pbg==');
+  });
+
+  it('handles an empty password', () => {
+    // "user:" → "dXNlcjo="
+    expect(basicAuthHeader('user', '')).toBe('Basic dXNlcjo=');
+  });
+
+  it('handles an empty username', () => {
+    // ":pass" → "OnBhc3M="
+    expect(basicAuthHeader('', 'pass')).toBe('Basic OnBhc3M=');
+  });
+
+  it('handles both empty username and password', () => {
+    // ":" → "Og=="
+    expect(basicAuthHeader('', '')).toBe('Basic Og==');
+  });
+
+  it('encodes non-ASCII (UTF-8) characters without throwing', () => {
+    const header = basicAuthHeader('usér', 'pässwörd');
+    expect(header).toMatch(/^Basic [A-Za-z0-9+/]+=*$/);
+    // Verify it decodes correctly via Buffer (Node.js test env has Buffer)
+    const encoded = header.slice(6); // strip "Basic "
+    const decoded = Buffer.from(encoded, 'base64').toString('utf8');
+    expect(decoded).toBe('usér:pässwörd');
+  });
+
+  it('encodes emoji in credentials without throwing', () => {
+    const header = basicAuthHeader('user🔑', 'p@ss');
+    expect(header).toMatch(/^Basic [A-Za-z0-9+/]+=*$/);
+    const encoded = header.slice(6);
+    const decoded = Buffer.from(encoded, 'base64').toString('utf8');
+    expect(decoded).toBe('user🔑:p@ss');
+  });
+
+  it('produces valid base64 (no illegal characters)', () => {
+    const header = basicAuthHeader('hello', 'world');
+    expect(header).toMatch(/^Basic [A-Za-z0-9+/]+=*$/);
+  });
+});

--- a/types/api.ts
+++ b/types/api.ts
@@ -33,6 +33,13 @@ export interface ServerConfig {
   fallbackUseHttps?: boolean;
   /** Reserved for future fallback base path UI; not surfaced in settings yet. */
   fallbackBasePath?: string;
+
+  /** When true, send an HTTP Basic Auth header on every request (for reverse-proxy frontends). */
+  useBasicAuth?: boolean;
+  /** Proxy Basic Auth username (in-memory + AsyncStorage; separate from qBittorrent WebUI username). */
+  basicAuthUsername?: string;
+  /** Proxy Basic Auth password (in-memory only; stored in SecureStore). */
+  basicAuthPassword?: string;
 }
 
 export type ServerEndpointKind = 'primary' | 'fallback';

--- a/utils/basicAuth.ts
+++ b/utils/basicAuth.ts
@@ -1,0 +1,62 @@
+/**
+ * basicAuth.ts — HTTP Basic Auth header encoder.
+ *
+ * Uses a byte-level base64 implementation to correctly handle non-ASCII
+ * characters in usernames/passwords. Hermes' native `btoa` is latin1-only
+ * and throws on any codepoint > 255; this avoids that limitation.
+ *
+ * Key exports: basicAuthHeader
+ */
+
+const BASE64_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+/**
+ * Encode a UTF-8 string to base64 without relying on btoa.
+ * Works on Hermes (React Native) with any Unicode input.
+ */
+function encodeBase64(input: string): string {
+  // Encode to UTF-8 bytes
+  const bytes: number[] = [];
+  for (let i = 0; i < input.length; i++) {
+    const code = input.charCodeAt(i);
+    if (code < 0x80) {
+      bytes.push(code);
+    } else if (code < 0x800) {
+      bytes.push(0xc0 | (code >> 6), 0x80 | (code & 0x3f));
+    } else if (code >= 0xd800 && code <= 0xdbff && i + 1 < input.length) {
+      // Surrogate pair — decode full code point
+      const hi = code;
+      const lo = input.charCodeAt(++i);
+      const cp = 0x10000 + ((hi - 0xd800) << 10) + (lo - 0xdc00);
+      bytes.push(
+        0xf0 | (cp >> 18),
+        0x80 | ((cp >> 12) & 0x3f),
+        0x80 | ((cp >> 6) & 0x3f),
+        0x80 | (cp & 0x3f)
+      );
+    } else {
+      bytes.push(0xe0 | (code >> 12), 0x80 | ((code >> 6) & 0x3f), 0x80 | (code & 0x3f));
+    }
+  }
+
+  // Encode bytes to base64
+  let result = '';
+  for (let i = 0; i < bytes.length; i += 3) {
+    const b0 = bytes[i];
+    const b1 = bytes[i + 1] ?? 0;
+    const b2 = bytes[i + 2] ?? 0;
+    result += BASE64_CHARS[b0 >> 2];
+    result += BASE64_CHARS[((b0 & 3) << 4) | (b1 >> 4)];
+    result += i + 1 < bytes.length ? BASE64_CHARS[((b1 & 15) << 2) | (b2 >> 6)] : '=';
+    result += i + 2 < bytes.length ? BASE64_CHARS[b2 & 63] : '=';
+  }
+  return result;
+}
+
+/**
+ * Build the value for an HTTP `Authorization: Basic …` header.
+ * The credentials are encoded as `username:password` in base64 (RFC 7617).
+ */
+export function basicAuthHeader(username: string, password: string): string {
+  return 'Basic ' + encodeBase64(`${username}:${password}`);
+}


### PR DESCRIPTION
Servers behind a reverse proxy can configure HTTP Basic Auth credentials separate from qBittorrent WebUI login, with SecureStore persistence and Unicode-safe header encoding.