### PR TITLE
feat: register app as an "Open In" handler for .torrent files

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -29,6 +29,26 @@ module.exports = {
             CFBundleURLSchemes: ['magnet'],
           },
         ],
+        // Register as an "Open In" handler for .torrent files (issue #88)
+        CFBundleDocumentTypes: [
+          {
+            CFBundleTypeName: 'BitTorrent Document',
+            CFBundleTypeRole: 'Viewer',
+            LSHandlerRank: 'Alternate',
+            LSItemContentTypes: ['org.bittorrent.torrent', 'com.bittorrent.torrent'],
+          },
+        ],
+        UTImportedTypeDeclarations: [
+          {
+            UTTypeIdentifier: 'org.bittorrent.torrent',
+            UTTypeConformsTo: ['public.data'],
+            UTTypeDescription: 'BitTorrent Document',
+            UTTypeTagSpecification: {
+              'public.filename-extension': ['torrent'],
+              'public.mime-type': ['application/x-bittorrent'],
+            },
+          },
+        ],
       },
     },
     android: {
@@ -50,6 +70,17 @@ module.exports = {
             },
           ],
           category: ['BROWSABLE', 'DEFAULT'],
+        },
+        // Open .torrent files shared from other apps (issue #88)
+        {
+          action: 'VIEW',
+          autoVerify: false,
+          data: [
+            {
+              mimeType: 'application/x-bittorrent',
+            },
+          ],
+          category: ['DEFAULT'],
         },
       ],
     },

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -61,7 +61,11 @@ export default function TorrentsScreen() {
   const { torrents, categories, tags, isLoading, error, refresh, isRecoveringFromBackground, initialLoadComplete } = useTorrents();
   const { isConnected, currentServer, isLoading: serverIsLoading, connectToServer } = useServer();
   const { colors, isDark } = useTheme();
-  const params = useLocalSearchParams<{ magnet?: string | string[] }>();
+  const params = useLocalSearchParams<{
+    magnet?: string | string[];
+    torrentFileUri?: string | string[];
+    torrentFileName?: string | string[];
+  }>();
 
   // State
   const [searchQuery, setSearchQuery] = useState('');
@@ -87,6 +91,7 @@ export default function TorrentsScreen() {
   const [showTagPicker, setShowTagPicker] = useState(false);
 
   const lastAppliedMagnetRef = useRef<{ value: string; at: number } | null>(null);
+  const lastAppliedTorrentFileRef = useRef<{ value: string; at: number } | null>(null);
 
   // Action menu state
   const [selectedTorrent, setSelectedTorrent] = useState<TorrentInfo | null>(null);
@@ -247,6 +252,49 @@ export default function TorrentsScreen() {
 
     void handleIncomingMagnet();
   }, [params.magnet, router]);
+
+  useEffect(() => {
+    const fileUri = Array.isArray(params.torrentFileUri) ? params.torrentFileUri[0] : params.torrentFileUri;
+    if (!fileUri) return;
+    const rawName = Array.isArray(params.torrentFileName) ? params.torrentFileName[0] : params.torrentFileName;
+    const fileName = rawName || 'download.torrent';
+
+    const now = Date.now();
+    if (
+      lastAppliedTorrentFileRef.current &&
+      lastAppliedTorrentFileRef.current.value === fileUri &&
+      now - lastAppliedTorrentFileRef.current.at < 1500
+    ) {
+      return;
+    }
+    lastAppliedTorrentFileRef.current = { value: fileUri, at: now };
+
+    const handleIncomingTorrentFile = async () => {
+      let variant: 'compact' | 'full' = 'compact';
+      try {
+        const prefs = await storageService.getPreferences();
+        variant = getAddTorrentDialogueVariant(prefs);
+      } catch {
+        // Keep compact fallback.
+      }
+
+      if (variant === 'full') {
+        router.push({
+          pathname: '/torrents/add',
+          params: { torrentFileUri: fileUri, torrentFileName: fileName },
+        });
+        router.replace('/');
+        return;
+      }
+
+      setSelectedFile({ uri: fileUri, name: fileName, mimeType: 'application/x-bittorrent' });
+      setTorrentUrl('');
+      setShowAddModal(true);
+      router.replace('/');
+    };
+
+    void handleIncomingTorrentFile();
+  }, [params.torrentFileUri, params.torrentFileName, router]);
 
   // Filter, sort, and search logic
   const filteredTorrents = useMemo(() => {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -18,6 +18,7 @@ import { apiClient } from '@/services/api/client';
 import { setHapticsEnabled } from '@/utils/haptics';
 import { setDebugMode as setConnectivityDebugMode } from '@/services/connectivity-log';
 import { extractMagnetLink } from '@/utils/magnet';
+import { extractTorrentFile } from '@/utils/torrent-file';
 
 const { width } = Dimensions.get('window');
 
@@ -25,25 +26,45 @@ function StackNavigator() {
   const { colors } = useTheme();
   const router = useRouter();
   const lastHandledMagnetRef = useRef<{ value: string; at: number } | null>(null);
+  const lastHandledTorrentFileRef = useRef<{ value: string; at: number } | null>(null);
 
   useEffect(() => {
     const handleIncomingUrl = (incomingUrl?: string | null) => {
       const magnetLink = extractMagnetLink(incomingUrl);
-      if (!magnetLink) return;
+      if (magnetLink) {
+        const now = Date.now();
+        if (
+          lastHandledMagnetRef.current &&
+          lastHandledMagnetRef.current.value === magnetLink &&
+          now - lastHandledMagnetRef.current.at < 1500
+        ) {
+          return;
+        }
+        lastHandledMagnetRef.current = { value: magnetLink, at: now };
+
+        router.push({
+          pathname: '/',
+          params: { magnet: magnetLink },
+        });
+        return;
+      }
+
+      const torrentFile = extractTorrentFile(incomingUrl);
+      if (!torrentFile) return;
 
       const now = Date.now();
       if (
-        lastHandledMagnetRef.current &&
-        lastHandledMagnetRef.current.value === magnetLink &&
-        now - lastHandledMagnetRef.current.at < 1500
+        lastHandledTorrentFileRef.current &&
+        lastHandledTorrentFileRef.current.value === torrentFile.uri &&
+        now - lastHandledTorrentFileRef.current.at < 1500
       ) {
         return;
       }
-      lastHandledMagnetRef.current = { value: magnetLink, at: now };
+      lastHandledTorrentFileRef.current = { value: torrentFile.uri, at: now };
 
       router.push({
         pathname: '/',
-        params: { magnet: magnetLink },
+        params: { torrentFileUri: torrentFile.uri, torrentFileName: torrentFile.name },
       });
     };
 

--- a/app/torrents/add.tsx
+++ b/app/torrents/add.tsx
@@ -45,8 +45,13 @@ export default function AddTorrentFullScreen() {
   const { showToast } = useToast();
   const { isConnected } = useServer();
   const { categories, tags } = useTorrents();
-  const params = useLocalSearchParams<{ magnet?: string | string[] }>();
+  const params = useLocalSearchParams<{
+    magnet?: string | string[];
+    torrentFileUri?: string | string[];
+    torrentFileName?: string | string[];
+  }>();
   const lastAppliedMagnetRef = useRef<string | null>(null);
+  const lastAppliedTorrentFileRef = useRef<string | null>(null);
 
   const [fieldVisibility, setFieldVisibility] = useState<Record<AddTorrentDialogField, boolean>>(
     DEFAULT_PREFERENCES.addTorrentDialogueFields
@@ -237,6 +242,17 @@ export default function AddTorrentFullScreen() {
     setTorrentUrl(magnetLink);
     setSelectedFile(null);
   }, [params.magnet]);
+
+  useEffect(() => {
+    const fileUri = Array.isArray(params.torrentFileUri) ? params.torrentFileUri[0] : params.torrentFileUri;
+    if (!fileUri) return;
+    if (lastAppliedTorrentFileRef.current === fileUri) return;
+
+    lastAppliedTorrentFileRef.current = fileUri;
+    const rawName = Array.isArray(params.torrentFileName) ? params.torrentFileName[0] : params.torrentFileName;
+    setSelectedFile({ uri: fileUri, name: rawName || 'download.torrent', mimeType: 'application/x-bittorrent' });
+    setTorrentUrl('');
+  }, [params.torrentFileUri, params.torrentFileName]);
 
   return (
     <>

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -12,6 +12,13 @@ export interface ChangelogRelease {
 
 export const CHANGELOG: ChangelogRelease[] = [
   {
+    version: '3.5.1',
+    date: '2026-07-04',
+    changes: [
+      'qRemote now registers as an "Open In" handler for .torrent files — open a torrent file from another app to add it directly',
+    ],
+  },
+  {
     version: '3.5.0',
     date: '2026-06-27',
     changes: ['Enabled search feature flag'],

--- a/tests/utils/app-config.test.ts
+++ b/tests/utils/app-config.test.ts
@@ -24,3 +24,43 @@ describe('app.config magnet registration', () => {
     expect(hasMagnetIntent).toBe(true);
   });
 });
+
+describe('app.config torrent file registration', () => {
+  const config = require('../../app.config.js');
+  const expoConfig = config.expo;
+
+  it('registers .torrent document types on iOS', () => {
+    const documentTypes = expoConfig?.ios?.infoPlist?.CFBundleDocumentTypes;
+    expect(Array.isArray(documentTypes)).toBe(true);
+
+    const hasTorrentType = documentTypes.some((entry: { LSItemContentTypes?: string[] }) =>
+      Array.isArray(entry.LSItemContentTypes) && entry.LSItemContentTypes.includes('org.bittorrent.torrent')
+    );
+
+    expect(hasTorrentType).toBe(true);
+  });
+
+  it('declares the torrent UTI with the .torrent extension on iOS', () => {
+    const importedTypes = expoConfig?.ios?.infoPlist?.UTImportedTypeDeclarations;
+    expect(Array.isArray(importedTypes)).toBe(true);
+
+    const torrentType = importedTypes.find(
+      (entry: { UTTypeIdentifier?: string }) => entry.UTTypeIdentifier === 'org.bittorrent.torrent'
+    );
+
+    expect(torrentType).toBeDefined();
+    expect(torrentType.UTTypeTagSpecification['public.filename-extension']).toContain('torrent');
+    expect(torrentType.UTTypeTagSpecification['public.mime-type']).toContain('application/x-bittorrent');
+  });
+
+  it('registers torrent mime-type intent filter on Android', () => {
+    const intentFilters = expoConfig?.android?.intentFilters;
+    expect(Array.isArray(intentFilters)).toBe(true);
+
+    const hasTorrentIntent = intentFilters.some((filter: { data?: Array<{ mimeType?: string }> }) =>
+      Array.isArray(filter.data) && filter.data.some((d) => d.mimeType === 'application/x-bittorrent')
+    );
+
+    expect(hasTorrentIntent).toBe(true);
+  });
+});

--- a/tests/utils/torrent-file.test.ts
+++ b/tests/utils/torrent-file.test.ts
@@ -1,0 +1,74 @@
+import { extractTorrentFile, isTorrentFileUrl } from '../../utils/torrent-file';
+
+describe('isTorrentFileUrl', () => {
+  it('accepts file:// URLs ending in .torrent', () => {
+    expect(isTorrentFileUrl('file:///private/var/mobile/Inbox/ubuntu-24.04.torrent')).toBe(true);
+  });
+
+  it('accepts file:// URLs with uppercase extension', () => {
+    expect(isTorrentFileUrl('file:///Inbox/UBUNTU.TORRENT')).toBe(true);
+  });
+
+  it('accepts file:// URLs with percent-encoded names', () => {
+    expect(isTorrentFileUrl('file:///Inbox/My%20Movie%20Pack.torrent')).toBe(true);
+  });
+
+  it('rejects file:// URLs with other extensions', () => {
+    expect(isTorrentFileUrl('file:///Inbox/document.pdf')).toBe(false);
+  });
+
+  it('accepts content:// URIs regardless of extension (Android mime-filtered)', () => {
+    expect(
+      isTorrentFileUrl('content://com.android.providers.downloads.documents/document/1234'),
+    ).toBe(true);
+    expect(isTorrentFileUrl('content://downloads/ubuntu.torrent')).toBe(true);
+  });
+
+  it('rejects magnet links, http URLs, and app deep links', () => {
+    expect(isTorrentFileUrl('magnet:?xt=urn:btih:abc123')).toBe(false);
+    expect(isTorrentFileUrl('https://example.com/file.torrent')).toBe(false);
+    expect(isTorrentFileUrl('qRemote://torrents')).toBe(false);
+  });
+
+  it('rejects empty and null values', () => {
+    expect(isTorrentFileUrl('')).toBe(false);
+    expect(isTorrentFileUrl(null)).toBe(false);
+    expect(isTorrentFileUrl(undefined)).toBe(false);
+  });
+});
+
+describe('extractTorrentFile', () => {
+  it('extracts uri and decoded file name from a file:// URL', () => {
+    const result = extractTorrentFile('file:///private/var/mobile/Inbox/My%20Movie%20Pack.torrent');
+    expect(result).toEqual({
+      uri: 'file:///private/var/mobile/Inbox/My%20Movie%20Pack.torrent',
+      name: 'My Movie Pack.torrent',
+    });
+  });
+
+  it('strips query strings and fragments from the name', () => {
+    const result = extractTorrentFile('file:///Inbox/ubuntu.torrent?foo=bar#frag');
+    expect(result?.name).toBe('ubuntu.torrent');
+  });
+
+  it('appends .torrent to content:// names without the extension', () => {
+    const result = extractTorrentFile(
+      'content://com.android.providers.downloads.documents/document/1234',
+    );
+    expect(result?.name).toBe('1234.torrent');
+    expect(result?.uri).toBe('content://com.android.providers.downloads.documents/document/1234');
+  });
+
+  it('trims surrounding whitespace from the URL', () => {
+    const result = extractTorrentFile('  file:///Inbox/ubuntu.torrent  ');
+    expect(result?.uri).toBe('file:///Inbox/ubuntu.torrent');
+  });
+
+  it('returns null for non-torrent URLs', () => {
+    expect(extractTorrentFile('file:///Inbox/document.pdf')).toBeNull();
+    expect(extractTorrentFile('magnet:?xt=urn:btih:abc123')).toBeNull();
+    expect(extractTorrentFile('https://example.com/file.torrent')).toBeNull();
+    expect(extractTorrentFile(null)).toBeNull();
+    expect(extractTorrentFile('')).toBeNull();
+  });
+});

--- a/utils/torrent-file.ts
+++ b/utils/torrent-file.ts
@@ -1,0 +1,55 @@
+const TORRENT_EXTENSION = '.torrent';
+const FALLBACK_FILE_NAME = 'download.torrent';
+
+export interface IncomingTorrentFile {
+  uri: string;
+  name: string;
+}
+
+const safeDecode = (value: string): string => {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+};
+
+const getFileName = (url: string): string => {
+  const withoutQuery = url.split(/[?#]/)[0];
+  const lastSegment = withoutQuery.split('/').filter(Boolean).pop() || '';
+  return safeDecode(lastSegment).trim();
+};
+
+/**
+ * Check whether an incoming URL points to a .torrent file opened from another app.
+ * iOS delivers `file://` URLs (document types); Android delivers `content://` URIs.
+ * content:// URIs only reach the app through the application/x-bittorrent intent
+ * filter, so the extension check is best-effort there.
+ */
+export const isTorrentFileUrl = (value?: string | null): boolean => {
+  if (!value) return false;
+  const raw = value.trim();
+  const lower = raw.toLowerCase();
+  if (lower.startsWith('file://')) {
+    return getFileName(raw).toLowerCase().endsWith(TORRENT_EXTENSION);
+  }
+  return lower.startsWith('content://');
+};
+
+/**
+ * Extract a torrent file reference (upload URI + display name) from an incoming URL.
+ * Returns null when the URL is not a torrent file.
+ */
+export const extractTorrentFile = (incomingUrl?: string | null): IncomingTorrentFile | null => {
+  if (!incomingUrl) return null;
+
+  const raw = incomingUrl.trim();
+  if (!isTorrentFileUrl(raw)) return null;
+
+  let name = getFileName(raw);
+  if (!name.toLowerCase().endsWith(TORRENT_EXTENSION)) {
+    name = name ? `${name}${TORRENT_EXTENSION}` : FALLBACK_FILE_NAME;
+  }
+
+  return { uri: raw, name };
+};


### PR DESCRIPTION
## Summary

Implements #88 — qRemote now registers as a document-type handler for `.torrent` files, so tapping a torrent file in another app (Files, Safari downloads, a file manager, etc.) offers **Open in qRemote** and drops the user straight into the add-torrent flow with the file pre-selected.

## Changes

- **iOS** (`app.config.js`): declares `CFBundleDocumentTypes` and `UTImportedTypeDeclarations` for the `org.bittorrent.torrent` / `com.bittorrent.torrent` UTIs (`.torrent` extension, `application/x-bittorrent` MIME type), so the app appears in the "Open In" share sheet for torrent files.
- **Android** (`app.config.js`): adds a `VIEW` intent filter for the `application/x-bittorrent` MIME type.
- **`utils/torrent-file.ts`** (new): recognizes incoming `file://` / `content://` torrent-file URLs and derives a display/upload filename (percent-decoding, query/fragment stripping, `.torrent` fallback naming for Android content URIs).
- **`app/_layout.tsx`**: the incoming-URL handler now routes torrent-file URLs alongside magnet links, with the same short-window dedupe.
- **`app/(tabs)/index.tsx`** / **`app/torrents/add.tsx`**: accept `torrentFileUri`/`torrentFileName` params and pre-fill the add-torrent flow — compact modal or full screen depending on the user's preference, exactly mirroring the existing magnet-link behavior. Upload reuses `torrentsApi.addTorrentFile` (multipart FormData), which already handles `file://`/`content://` URIs.
- **Changelog**: new 3.5.1 entry (package.json untouched per release process).

## Tests

- New suite `tests/utils/torrent-file.test.ts` covering URL recognition and filename extraction (13 cases).
- Extended `tests/utils/app-config.test.ts` to assert the iOS document types/UTI declaration and the Android MIME intent filter.

`npx tsc --noEmit` clean · `npm test` 180/180 passing (10 suites) · `npm run lint` 0 errors · new files Prettier-clean.

## Notes

- Document-type registration requires a native build (dev client / TestFlight / store build) — it won't be visible in Expo Go, which is expected for anything touching Info.plist/AndroidManifest.
- iOS-first per project conventions; the Android intent filter covers the common file-manager case (MIME-typed content URIs) without the brittle `pathPattern` matching.

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)