### PR TITLE
Fix ITMS-90737: add LSSupportsOpeningDocumentsInPlace for .torrent document types

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -29,6 +29,9 @@ module.exports = {
             CFBundleURLSchemes: ['magnet'],
           },
         ],
+        // Required when CFBundleDocumentTypes is set (ITMS-90737). We import
+        // .torrent files via Linking rather than UIDocumentBrowserViewController.
+        LSSupportsOpeningDocumentsInPlace: true,
         // Register as an "Open In" handler for .torrent files (issue #88)
         CFBundleDocumentTypes: [
           {

--- a/tests/utils/app-config.test.ts
+++ b/tests/utils/app-config.test.ts
@@ -40,6 +40,10 @@ describe('app.config torrent file registration', () => {
     expect(hasTorrentType).toBe(true);
   });
 
+  it('declares LSSupportsOpeningDocumentsInPlace for ITMS-90737 compliance', () => {
+    expect(expoConfig?.ios?.infoPlist?.LSSupportsOpeningDocumentsInPlace).toBe(true);
+  });
+
   it('declares the torrent UTI with the .torrent extension on iOS', () => {
     const importedTypes = expoConfig?.ios?.infoPlist?.UTImportedTypeDeclarations;
     expect(Array.isArray(importedTypes)).toBe(true);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Resolves the App Store Connect warning **ITMS-90737** for build 58 (v3.6.0).

qRemote declares `CFBundleDocumentTypes` so it can act as an "Open In" handler for `.torrent` files (issue #88). Apple requires an additional document-configuration key when that is present:

- `UISupportsDocumentBrowser` — only if the app uses `UIDocumentBrowserViewController`
- `LSSupportsOpeningDocumentsInPlace` — for apps that open/import documents via other means (recommended)

qRemote receives torrent files through Expo `Linking` (`file://` URLs), not a document browser, so we set:

```js
LSSupportsOpeningDocumentsInPlace: true
```

in `app.config.js` → `ios.infoPlist`.

## Testing

- `npx tsc --noEmit`
- `npm test -- tests/utils/app-config.test.ts`
- `npm run lint`

## Next steps

Merge and cut a new iOS build (build 59+) for App Store Connect. No user-facing behavior change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2ef9-6f61-7c4f-a5f5-382a8edea5c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2ef9-6f61-7c4f-a5f5-382a8edea5c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

