### PR TITLE
fix: resolve npm audit uuid vulnerability via scoped override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qRemote",
-  "version": "3.6.0",
+  "version": "3.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qRemote",
-      "version": "3.6.0",
+      "version": "3.7.1",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "^2.2.0",
@@ -12308,13 +12308,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-      "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -59,5 +59,10 @@
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.57.0"
   },
+  "overrides": {
+    "xcode": {
+      "uuid": "^11.1.1"
+    }
+  },
   "private": true
 }


### PR DESCRIPTION
## Summary
- `npm audit` flagged 11 moderate vulnerabilities, all rooted in a single transitive dep: `uuid@7.0.3` pulled in by `xcode@3.0.1` (`expo-sharing → @expo/config-plugins → xcode`), per [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq)
- The patched version (uuid ≥11.1.1) is unreachable through normal resolution because `xcode` pins `^7.0.3`; `npm audit fix --force` would have "fixed" it by downgrading `expo-sharing` instead
- Adds an npm `overrides` entry scoped to `xcode` forcing `uuid@^11.1.1` — scoped so it cannot affect any other package's resolution

## Safety
- `xcode` only calls `uuid.v4()`, whose API is unchanged in v11, so the major-version jump is safe
- Practical exposure was near zero regardless: the vulnerable code path (v3/v5/v6 with a `buf` arg) is never invoked by `xcode`, which itself only runs at build/prebuild time — but a clean audit is worth having
- The override can be removed once Expo ships a `@expo/config-plugins` with a fixed `xcode`

## Verification
- `npm audit` → 0 vulnerabilities
- `npm ls uuid` → resolves to 11.1.1
- `npx tsc --noEmit` → clean
- `npm test` → 223/223 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbsAXZoet7iTW4VvWKknTU