### PR TITLE
Add React Native component/hook test coverage; fix host trailing-slash bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ yarn-error.*
 # typescript
 *.tsbuildinfo
 
+# test coverage
+coverage/
+
 # generated native folders
 /ios
 /android

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -12,6 +12,13 @@ export interface ChangelogRelease {
 
 export const CHANGELOG: ChangelogRelease[] = [
   {
+    version: '3.7.14',
+    date: '2026-07-18',
+    changes: [
+      'Fixed a bug where a server host pasted with a trailing slash (e.g. from a full URL) was saved with the slash intact instead of being stripped',
+    ],
+  },
+  {
     version: '3.7.13',
     date: '2026-07-18',
     changes: [

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,8 +1,34 @@
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  roots: ['<rootDir>/tests'],
-  moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/$1',
-  },
+  collectCoverageFrom: [
+    'app/**/*.{ts,tsx}',
+    'components/**/*.{ts,tsx}',
+    'context/**/*.{ts,tsx}',
+    'hooks/**/*.{ts,tsx}',
+    'services/**/*.{ts,tsx}',
+    'utils/**/*.{ts,tsx}',
+    'constants/**/*.{ts,tsx}',
+    '!**/*.d.ts',
+  ],
+  projects: [
+    {
+      displayName: 'node',
+      preset: 'ts-jest',
+      testEnvironment: 'node',
+      roots: ['<rootDir>/tests'],
+      testPathIgnorePatterns: ['<rootDir>/tests/rn/'],
+      moduleNameMapper: {
+        '^@/(.*)$': '<rootDir>/$1',
+      },
+    },
+    {
+      displayName: 'rn',
+      preset: 'jest-expo',
+      roots: ['<rootDir>/tests/rn'],
+      setupFilesAfterEnv: ['<rootDir>/tests/rn/setup.ts'],
+      testPathIgnorePatterns: ['<rootDir>/tests/rn/setup.ts'],
+      moduleNameMapper: {
+        '^@/(.*)$': '<rootDir>/$1',
+      },
+    },
+  ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.18.0",
+        "@testing-library/react-native": "^14.0.1",
         "@types/jest": "29.5.14",
         "@types/react": "~19.2.4",
         "babel-plugin-module-resolver": "^5.0.2",
@@ -50,6 +51,7 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react-hooks": "^7.0.1",
         "jest": "~29.7.0",
+        "jest-expo": "~57.0.2",
         "prettier": "^3.8.1",
         "ts-jest": "^29.4.6",
         "typescript": "~6.0.3",
@@ -438,7 +440,7 @@
       "version": "7.8.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
       "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -451,7 +453,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
       "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -464,7 +466,7 @@
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
       "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.12.13"
@@ -477,7 +479,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
       "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -550,7 +552,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
       "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
@@ -566,7 +568,7 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
       "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -579,7 +581,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
       "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -607,7 +609,7 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
       "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -632,7 +634,7 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
       "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
@@ -645,7 +647,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
       "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -658,7 +660,7 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
       "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
@@ -683,7 +685,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
       "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -699,7 +701,7 @@
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
       "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.14.5"
@@ -1340,7 +1342,7 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@egjs/hammerjs": {
@@ -2470,7 +2472,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
       "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "camelcase": "^5.3.1",
@@ -2487,7 +2489,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "sprintf-js": "~1.0.2"
@@ -2497,7 +2499,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -2511,7 +2513,7 @@
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
       "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -2525,7 +2527,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -2538,7 +2540,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -2554,7 +2556,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -2567,7 +2569,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
       "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2577,7 +2579,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
       "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -2595,7 +2597,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
       "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -2639,11 +2641,34 @@
         }
       }
     },
+    "node_modules/@jest/create-cache-key-function": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
+      "integrity": "sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
       "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/fake-timers": "^29.7.0",
@@ -2659,7 +2684,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
       "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "expect": "^29.7.0",
@@ -2673,7 +2698,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
       "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "jest-get-type": "^29.6.3"
@@ -2686,7 +2711,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
       "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -2700,11 +2725,21 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/globals": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
       "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -2720,7 +2755,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
       "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
@@ -2765,7 +2800,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -2798,7 +2833,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
       "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.18",
@@ -2813,7 +2848,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
       "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -2829,7 +2864,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
       "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/test-result": "^29.7.0",
@@ -2845,7 +2880,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
       "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -3507,6 +3542,27 @@
         "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
       }
     },
+    "node_modules/@react-native/jest-preset": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/jest-preset/-/jest-preset-0.86.0.tgz",
+      "integrity": "sha512-KA+xpIP3DvJy7PQJ9c6ZdEKkOPChl+Rk/rV2MhQACEAzfhWU84407KZQv4ccyO3B4caD0gPrFjE96a4P993nsQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@jest/create-cache-key-function": "^29.7.0",
+        "@react-native/js-polyfills": "0.86.0",
+        "babel-jest": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "regenerator-runtime": "^0.13.2"
+      },
+      "engines": {
+        "node": ">= 20.19.4"
+      },
+      "peerDependencies": {
+        "react": "^19.2.3"
+      }
+    },
     "node_modules/@react-native/js-polyfills": {
       "version": "0.86.0",
       "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.86.0.tgz",
@@ -3584,7 +3640,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "type-detect": "4.0.8"
@@ -3594,7 +3650,7 @@
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
       "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
@@ -3706,6 +3762,114 @@
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "license": "MIT"
     },
+    "node_modules/@testing-library/react-native": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-14.0.1.tgz",
+      "integrity": "sha512-2r2e2y8SkUNRWKRXlUGqDYunB+AkbdXUPn49Bs5rpv9oxRb0K3USBVugbPbAKJjfj4w5Ba91NJ8LcQCZyopUZA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-matcher-utils": "^30.4.1",
+        "picocolors": "^1.1.1",
+        "pretty-format": "^30.4.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24"
+      },
+      "peerDependencies": {
+        "jest": ">=29.0.0",
+        "react": ">=19.0.0",
+        "react-native": ">=0.78",
+        "test-renderer": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@sinclair/typebox": {
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react-native/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/jest-diff": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.4.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/jest-matcher-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@testing-library/user-event": {
       "version": "14.6.1",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
@@ -3719,6 +3883,16 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -3730,7 +3904,7 @@
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.20.7",
@@ -3744,7 +3918,7 @@
       "version": "7.27.0",
       "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
       "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.0.0"
@@ -3754,7 +3928,7 @@
       "version": "7.4.4",
       "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.1.0",
@@ -3765,7 +3939,7 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
       "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
@@ -3782,7 +3956,7 @@
       "version": "4.1.9",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
       "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -3829,6 +4003,18 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/jsdom": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
+      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3854,6 +4040,17 @@
         "csstype": "^3.2.2"
       }
     },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-HZOXsKT0tGI9LlUw2LuedXsVeB88wFa536vVL0M6vE8zN63nI+sSr1ByxmPToP5K5bukaVscyeCJcF9guVNJ1g==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/react-test-renderer": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
@@ -3867,6 +4064,13 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
     },
@@ -4195,6 +4399,14 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "deprecated": "Use your platform's native atob() and btoa() methods instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -4257,6 +4469,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-globals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.1.0",
+        "acorn-walk": "^8.0.2"
+      }
+    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -4265,6 +4488,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -4357,7 +4593,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -4428,7 +4664,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
       "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/transform": "^29.7.0",
@@ -4450,7 +4686,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
       "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -4467,7 +4703,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
       "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -4484,7 +4720,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
       "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.3.3",
@@ -4601,7 +4837,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
       "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -4695,7 +4931,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
       "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "babel-plugin-jest-hoist": "^29.6.3",
@@ -4712,7 +4948,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -4787,7 +5023,7 @@
       "version": "1.1.16",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
       "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -4893,7 +5129,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4903,7 +5139,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4949,7 +5185,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -5005,7 +5241,7 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cli-cursor": {
@@ -5065,7 +5301,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "iojs": ">= 1.0.0",
@@ -5076,7 +5312,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
       "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/color": {
@@ -5199,7 +5435,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/connect": {
@@ -5255,7 +5491,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
       "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -5352,11 +5588,90 @@
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "license": "MIT"
     },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -5375,6 +5690,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
@@ -5388,7 +5710,7 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
       "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -5477,7 +5799,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5493,7 +5815,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
       "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -5537,6 +5859,30 @@
         }
       ],
       "license": "BSD-2-Clause"
+    },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/domexception/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/domhandler": {
       "version": "5.0.3",
@@ -5597,7 +5943,7 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
       "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5637,7 +5983,7 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -5722,6 +6068,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
       }
     },
     "node_modules/eslint": {
@@ -5889,7 +6257,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -5967,7 +6335,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
       "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
@@ -5991,7 +6359,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -6000,7 +6368,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
       "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/expect-utils": "^29.7.0",
@@ -6883,7 +7251,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -7126,14 +7494,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7208,7 +7575,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -7231,7 +7598,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -7463,11 +7830,24 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/html-parse-stringify": {
@@ -7508,6 +7888,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -7525,7 +7920,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
@@ -7566,6 +7961,19 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -7623,7 +8031,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
       "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "pkg-dir": "^4.2.0",
@@ -7643,7 +8051,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -7663,7 +8071,7 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -7698,7 +8106,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/is-core-module": {
@@ -7754,7 +8162,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -7791,11 +8199,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7826,7 +8241,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
       "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8"
@@ -7836,7 +8251,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
       "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/core": "^7.23.9",
@@ -7853,7 +8268,7 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -7866,7 +8281,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
       "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
@@ -7881,7 +8296,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
       "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "debug": "^4.1.1",
@@ -7896,7 +8311,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
       "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -7910,7 +8325,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
@@ -7937,7 +8352,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
       "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "execa": "^5.0.0",
@@ -7952,7 +8367,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
       "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -7984,7 +8399,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
       "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
@@ -8018,7 +8433,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
       "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -8065,7 +8480,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -8086,7 +8501,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
       "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -8102,7 +8517,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
       "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "detect-newline": "^3.0.0"
@@ -8115,7 +8530,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
       "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -8128,11 +8543,39 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-environment-jsdom": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
+      "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/jsdom": "^20.0.0",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jsdom": "^20.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jest-environment-node": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
       "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -8144,6 +8587,44 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-expo": {
+      "version": "57.0.2",
+      "resolved": "https://registry.npmjs.org/jest-expo/-/jest-expo-57.0.2.tgz",
+      "integrity": "sha512-xoKiYyu8c0fdBsFMkeFnxoTZ/0g4rLldA9isVb7VJSGBGesmhkVor7YkftkHqQ5rWiZ99IY+/uIrzTgb1nC/UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/create-cache-key-function": "^29.2.1",
+        "@jest/globals": "^29.2.1",
+        "babel-jest": "^29.2.1",
+        "jest-environment-jsdom": "^29.2.1",
+        "jest-snapshot": "^29.2.1",
+        "jest-watch-select-projects": "^2.0.0",
+        "jest-watch-typeahead": "2.2.1",
+        "json5": "^2.2.3",
+        "lodash": "^4.17.19",
+        "react-test-renderer": "19.2.3",
+        "server-only": "^0.0.1",
+        "stacktrace-js": "^2.0.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "peerDependencies": {
+        "@react-native/jest-preset": "^0.86.0",
+        "expo": "*",
+        "react-native": "*",
+        "react-server-dom-webpack": "~19.0.4 || ~19.1.5 || ~19.2.4"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "react-server-dom-webpack": {
+          "optional": true
+        }
       }
     },
     "node_modules/jest-get-type": {
@@ -8159,7 +8640,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
       "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -8185,7 +8666,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
       "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "jest-get-type": "^29.6.3",
@@ -8199,7 +8680,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
       "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -8215,7 +8696,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
       "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
@@ -8236,7 +8717,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
       "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -8251,7 +8732,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
       "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8269,7 +8750,7 @@
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
       "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -8279,7 +8760,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
       "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",
@@ -8300,7 +8781,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
       "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "jest-regex-util": "^29.6.3",
@@ -8314,7 +8795,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
       "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/console": "^29.7.0",
@@ -8347,7 +8828,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
       "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
@@ -8382,7 +8863,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -8403,7 +8884,7 @@
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
       "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -8435,7 +8916,7 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8490,11 +8971,141 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/jest-watch-select-projects": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jest-watch-select-projects/-/jest-watch-select-projects-2.0.0.tgz",
+      "integrity": "sha512-j00nW4dXc2NiCW6znXgFLF9g8PJ0zP25cpQ1xRro/HU2GBfZQFZD0SoXnAlaoKkIY4MlfTMkKGbNXFpvCdjl1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^4.3.0",
+        "chalk": "^3.0.0",
+        "prompts": "^2.2.1"
+      }
+    },
+    "node_modules/jest-watch-select-projects/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watch-typeahead": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jest-watch-typeahead/-/jest-watch-typeahead-2.2.1.tgz",
+      "integrity": "sha512-jYpYmUnTzysmVnwq49TAxlmtOAwp8QIqvZyoofQFn8fiWhEDZj33ZXzg3JA4nGnzWFm1hbWf3ADpteUokvXgFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^6.0.0",
+        "chalk": "^4.0.0",
+        "jest-regex-util": "^29.0.0",
+        "jest-watcher": "^29.0.0",
+        "slash": "^5.0.0",
+        "string-length": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "jest": "^27.0.0 || ^28.0.0 || ^29.0.0"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/ansi-escapes": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
+      "integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/char-regex": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-2.0.2.tgz",
+      "integrity": "sha512-cbGOjAptfM2LVmWhwRFHEKTPkLwNddVmuqYZQt895yXwAsWsXObCG+YN4DGQ/JBtT4GP1a1lPPdio2z413LmTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/string-length": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-5.0.1.tgz",
+      "integrity": "sha512-9Ep08KAMUn0OadnVaBuRdE2l615CQ508kr0XMadjClfYpdCyvrbFp6Taebo8yyxokQ4viUd/xPPUA4FGgUa0ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^2.0.0",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/jest-watcher": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
       "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jest/test-result": "^29.7.0",
@@ -8580,6 +9191,111 @@
       "integrity": "sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==",
       "license": "0BSD"
     },
+    "node_modules/jsdom": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.1",
+        "acorn-globals": "^7.0.0",
+        "cssom": "^0.5.0",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^3.0.2",
+        "decimal.js": "^10.4.2",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.2",
+        "parse5": "^7.1.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0",
+        "ws": "^8.11.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -8603,7 +9319,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -8973,7 +9689,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -8991,6 +9707,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -9136,7 +9859,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
       "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.5.3"
@@ -9152,7 +9875,7 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -9650,7 +10373,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9669,7 +10392,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -9744,7 +10467,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -9811,7 +10534,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9848,7 +10571,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
@@ -9873,6 +10596,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
       "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ob1": {
@@ -9921,7 +10651,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -9931,7 +10661,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -10090,7 +10820,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -10122,7 +10852,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10145,7 +10875,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -10172,6 +10902,32 @@
         "node": ">=10"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -10185,7 +10941,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10195,7 +10951,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10272,7 +11028,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -10282,7 +11038,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
       "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "find-up": "^4.0.0"
@@ -10295,7 +11051,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
       "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^5.0.0",
@@ -10309,7 +11065,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
       "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^4.1.0"
@@ -10322,7 +11078,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
       "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "p-try": "^2.0.0"
@@ -10338,7 +11094,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
       "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^2.2.0"
@@ -10599,6 +11355,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -10613,7 +11382,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
       "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "individual",
@@ -10643,6 +11412,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/queue": {
       "version": "6.0.2",
@@ -10742,6 +11518,22 @@
       "version": "19.2.7",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
       "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "license": "MIT"
+    },
+    "node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.7.tgz",
+      "integrity": "sha512-kZFnouyVv7eP/Phmrlo9FK+zcAdriZJvzxXHF1Sl1P377WSGe2G/JxVolhTrB/jeV47lKImhNUsijjHAAbcl/A==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/react-native": {
@@ -11025,6 +11817,23 @@
         "node": ">=10"
       }
     },
+    "node_modules/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -11101,6 +11910,20 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.3.tgz",
+      "integrity": "sha512-TMR1LnSFiWZMJkCgNf5ATSvAheTT2NvKIwiVwdBPHxjBI7n/JbWd4gaZ16DVd9foAXdvDz+sB5yxZTwMjPRxpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^19.2.3",
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.3"
       }
     },
     "node_modules/redent": {
@@ -11184,6 +12007,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/reselect": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
@@ -11216,7 +12046,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
       "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "resolve-from": "^5.0.0"
@@ -11244,7 +12074,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
       "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -11310,6 +12140,13 @@
       ],
       "license": "MIT"
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/sax": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
@@ -11317,6 +12154,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -11544,7 +12394,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11581,7 +12431,7 @@
       "version": "0.5.13",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
       "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -11601,14 +12451,24 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
+      "devOptional": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-generator": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
@@ -11621,7 +12481,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11632,6 +12492,39 @@
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "license": "MIT"
+    },
+    "node_modules/stacktrace-gps": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz",
+      "integrity": "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/stacktrace-gps/node_modules/source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
+      }
     },
     "node_modules/stacktrace-parser": {
       "version": "0.1.11",
@@ -11685,7 +12578,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
       "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "char-regex": "^1.0.2",
@@ -11725,7 +12618,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
       "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11735,7 +12628,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11757,7 +12650,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11815,6 +12708,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -11869,7 +12769,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
       "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "@istanbuljs/schema": "^0.1.2",
@@ -11885,7 +12785,7 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
       "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -11900,6 +12800,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-renderer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/test-renderer/-/test-renderer-1.2.0.tgz",
+      "integrity": "sha512-JYiEGbgBGtmHAWX8Kf99gGRL1HtjcRVHLrmJNTZL4vFs9XrnWcuL45Iszw/pO4094+JR7havSrN+ds6YTOpSQA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/react-reconciler": "~0.33.0",
+        "react-reconciler": "~0.33.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
       }
     },
     "node_modules/throat": {
@@ -11985,6 +12900,22 @@
       "resolved": "https://registry.npmjs.org/toqr/-/toqr-0.1.1.tgz",
       "integrity": "sha512-FWAPzCIHZHnrE/5/w9MPk0kK25hSQSH2IKhYh9PyjS3SG/+IEMvlwIHbhz+oF7xl54I+ueZlVnMjyzdSwLmAwA==",
       "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tr46": {
       "version": "0.0.3",
@@ -12107,7 +13038,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -12249,6 +13180,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -12296,6 +13237,17 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/use-callback-ref": {
@@ -12385,7 +13337,7 @@
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
       "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.12",
@@ -12442,6 +13394,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -12472,11 +13437,35 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -12547,14 +13536,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
       "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
@@ -12598,6 +13587,16 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/xml2js": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.0.tgz",
@@ -12628,6 +13627,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -12690,7 +13696,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",
+    "@testing-library/react-native": "^14.0.1",
     "@types/jest": "29.5.14",
     "@types/react": "~19.2.4",
     "babel-plugin-module-resolver": "^5.0.2",
@@ -54,6 +55,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^7.0.1",
     "jest": "~29.7.0",
+    "jest-expo": "~57.0.2",
     "prettier": "^3.8.1",
     "ts-jest": "^29.4.6",
     "typescript": "~6.0.3",

--- a/services/storage.ts
+++ b/services/storage.ts
@@ -10,7 +10,7 @@ const STORAGE_KEYS = {
 } as const;
 
 const stripProtocol = (host: string): string =>
-  (host || '').replace(/^(https?:\/\/)/i, '');
+  (host || '').replace(/^(https?:\/\/)/i, '').replace(/\/+$/, '');
 
 export const storageService = {
   /**

--- a/tests/rn/components/ActionMenu.test.tsx
+++ b/tests/rn/components/ActionMenu.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render, fireEvent, screen, act } from '@testing-library/react-native';
+import { ActionMenu, ActionMenuItemDef } from '@/components/ActionMenu';
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+
+jest.mock('@/context/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      surface: '#fff',
+      surfaceOutline: '#ccc',
+      error: '#f00',
+      primary: '#00f',
+      text: '#000',
+    },
+  }),
+}));
+
+describe('ActionMenu', () => {
+  const items: ActionMenuItemDef[] = [
+    { label: 'Pause', icon: 'pause', onPress: jest.fn() },
+    { label: 'Delete', icon: 'trash', onPress: jest.fn(), destructive: true },
+  ];
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not crash and renders nothing when not visible', async () => {
+    await render(<ActionMenu visible={false} onClose={jest.fn()} items={items} />);
+    expect(screen.queryByText('Pause')).toBeNull();
+  });
+
+  it('renders all item labels when visible', async () => {
+    await render(<ActionMenu visible onClose={jest.fn()} items={items} />);
+    expect(screen.getByText('Pause')).toBeTruthy();
+    expect(screen.getByText('Delete')).toBeTruthy();
+  });
+
+  it('renders with an empty items list', async () => {
+    await render(<ActionMenu visible onClose={jest.fn()} items={[]} />);
+    expect(screen.queryByText('Pause')).toBeNull();
+  });
+
+  it('calls onClose when an item is pressed', async () => {
+    const onClose = jest.fn();
+    await render(<ActionMenu visible onClose={onClose} items={items} />);
+    fireEvent.press(screen.getByText('Pause'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls item onPress after delay when item pressed', async () => {
+    jest.useFakeTimers();
+    const onClose = jest.fn();
+    await render(<ActionMenu visible onClose={onClose} items={items} />);
+    fireEvent.press(screen.getByText('Pause'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(items[0].onPress).not.toHaveBeenCalled();
+    act(() => {
+      jest.advanceTimersByTime(150);
+    });
+    expect(items[0].onPress).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
+  it('applies destructive styling path for destructive items without crashing', async () => {
+    await render(<ActionMenu visible onClose={jest.fn()} items={items} />);
+    expect(screen.getByText('Delete')).toBeTruthy();
+  });
+});

--- a/tests/rn/components/AnimatedButton.test.tsx
+++ b/tests/rn/components/AnimatedButton.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, fireEvent, screen, act } from '@testing-library/react-native';
+import { AnimatedButton } from '@/components/AnimatedButton';
+
+describe('AnimatedButton', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders children', async () => {
+    await render(
+      <AnimatedButton>
+        <Text>Press me</Text>
+      </AnimatedButton>
+    );
+    expect(screen.getByText('Press me')).toBeTruthy();
+  });
+
+  it('calls onPress when tapped', async () => {
+    const onPress = jest.fn();
+    await render(
+      <AnimatedButton onPress={onPress}>
+        <Text>Tap</Text>
+      </AnimatedButton>
+    );
+    fireEvent.press(screen.getByText('Tap'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles pressIn/pressOut animation without crashing', async () => {
+    jest.useFakeTimers();
+    await render(
+      <AnimatedButton scaleValue={0.9}>
+        <Text>Anim</Text>
+      </AnimatedButton>
+    );
+    const el = screen.getByText('Anim');
+    await act(async () => {
+      fireEvent(el, 'pressIn');
+      fireEvent(el, 'pressOut');
+      jest.runAllTimers();
+    });
+    expect(el).toBeTruthy();
+  });
+
+  it('does not animate when disabled', async () => {
+    const onPress = jest.fn();
+    await render(
+      <AnimatedButton disabled onPress={onPress}>
+        <Text>Disabled</Text>
+      </AnimatedButton>
+    );
+    const el = screen.getByText('Disabled');
+    fireEvent(el, 'pressIn');
+    fireEvent(el, 'pressOut');
+    fireEvent.press(el);
+    expect(onPress).not.toHaveBeenCalled();
+  });
+});

--- a/tests/rn/components/AnimatedProgressBar.test.tsx
+++ b/tests/rn/components/AnimatedProgressBar.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { AnimatedProgressBar } from '@/components/AnimatedProgressBar';
+
+jest.mock('@/context/ThemeContext', () => ({
+  useTheme: () => ({ colors: require('./theme-mock').mockColors }),
+}));
+
+describe('AnimatedProgressBar', () => {
+  it('renders with default props', async () => {
+    const { toJSON } = await render(<AnimatedProgressBar progress={50} />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('renders with custom color and height', async () => {
+    const { toJSON } = await render(<AnimatedProgressBar progress={30} color="#f00" height={10} />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('renders without animation (animated=false)', async () => {
+    const { toJSON } = await render(<AnimatedProgressBar progress={70} animated={false} />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('renders glow effect when showGlow and progress is mid-range', async () => {
+    const { toJSON } = await render(<AnimatedProgressBar progress={50} showGlow />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('does not render glow at 0 progress even if showGlow is set', async () => {
+    const { toJSON } = await render(<AnimatedProgressBar progress={0} showGlow />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('does not render glow at 100 progress even if showGlow is set', async () => {
+    const { toJSON } = await render(<AnimatedProgressBar progress={100} showGlow />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('re-renders on progress change (animated path)', async () => {
+    const { rerender, toJSON } = await render(<AnimatedProgressBar progress={0} />);
+    rerender(<AnimatedProgressBar progress={80} />);
+    expect(toJSON()).toBeTruthy();
+  });
+});

--- a/tests/rn/components/CircularProgress.test.tsx
+++ b/tests/rn/components/CircularProgress.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { CircularProgress } from '@/components/CircularProgress';
+
+jest.mock('@/context/ThemeContext', () => ({
+  useTheme: () => ({ colors: require('./theme-mock').mockColors }),
+}));
+
+describe('CircularProgress', () => {
+  it('renders with limit=0 (no cap, percentage 0)', async () => {
+    await render(<CircularProgress current={500} limit={0} color="#00f" />);
+    expect(screen.getByText('0%')).toBeTruthy();
+  });
+
+  it('renders normal percentage under 80%', async () => {
+    await render(<CircularProgress current={50} limit={100} color="#00f" />);
+    expect(screen.getByText('50%')).toBeTruthy();
+  });
+
+  it('renders warning color range 80-95%', async () => {
+    await render(<CircularProgress current={85} limit={100} color="#00f" />);
+    expect(screen.getByText('85%')).toBeTruthy();
+  });
+
+  it('renders error color range >=95%', async () => {
+    await render(<CircularProgress current={99} limit={100} color="#00f" />);
+    expect(screen.getByText('99%')).toBeTruthy();
+  });
+
+  it('clamps percentage to 100 when current exceeds limit', async () => {
+    await render(<CircularProgress current={999} limit={100} color="#00f" />);
+    expect(screen.getByText('100%')).toBeTruthy();
+  });
+
+  it('hides label when showLabel=false', async () => {
+    await render(<CircularProgress current={10} limit={100} color="#00f" showLabel={false} />);
+    expect(screen.queryByText('10%')).toBeNull();
+  });
+
+  it('supports custom size/strokeWidth', async () => {
+    const { toJSON } = await render(
+      <CircularProgress current={10} limit={100} color="#00f" size={100} strokeWidth={10} />
+    );
+    expect(toJSON()).toBeTruthy();
+  });
+});

--- a/tests/rn/components/Confetti.test.tsx
+++ b/tests/rn/components/Confetti.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, act } from '@testing-library/react-native';
+import { Confetti } from '@/components/Confetti';
+
+describe('Confetti', () => {
+  it('renders nothing when inactive', async () => {
+    const { toJSON } = await render(<Confetti active={false} />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders confetti pieces when active', async () => {
+    const { toJSON } = await render(<Confetti active />);
+    const json = toJSON();
+    expect(json).toBeTruthy();
+  });
+
+  it('accepts a custom duration', async () => {
+    const { toJSON } = await render(<Confetti active duration={500} />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('re-renders from inactive to active', async () => {
+    const { rerender, toJSON } = await render(<Confetti active={false} />);
+    expect(toJSON()).toBeNull();
+    await act(async () => {
+      rerender(<Confetti active />);
+    });
+    expect(toJSON()).toBeTruthy();
+  });
+});

--- a/tests/rn/components/DebugRow.test.tsx
+++ b/tests/rn/components/DebugRow.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react-native';
+import { DebugRow } from '@/components/DebugRow';
+
+jest.mock('@/context/ThemeContext', () => ({
+  useTheme: () => ({ colors: require('./theme-mock').mockColors }),
+}));
+
+describe('DebugRow', () => {
+  it('renders label and value', async () => {
+    await render(<DebugRow label="Host" value="192.168.1.1" />);
+    expect(screen.getByText('Host')).toBeTruthy();
+    expect(screen.getByText('192.168.1.1')).toBeTruthy();
+  });
+
+  it('renders with selectable and numberOfLines props', async () => {
+    await render(<DebugRow label="Token" value="abc123" selectable numberOfLines={1} />);
+    expect(screen.getByText('abc123')).toBeTruthy();
+  });
+
+  it('renders empty value without crashing', async () => {
+    const { toJSON } = await render(<DebugRow label="Empty" value="" />);
+    expect(toJSON()).toBeTruthy();
+  });
+});

--- a/tests/rn/components/EmptyState.test.tsx
+++ b/tests/rn/components/EmptyState.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react-native';
+import { EmptyState } from '@/components/EmptyState';
+
+jest.mock('@/context/ThemeContext', () => ({
+  useTheme: () => ({ colors: require('./theme-mock').mockColors }),
+}));
+
+describe('EmptyState', () => {
+  it('renders with no props (all optional)', async () => {
+    const { toJSON } = await render(<EmptyState />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('renders title and subtitle', async () => {
+    await render(<EmptyState title="Nothing here" subtitle="Try again later" icon="alert" />);
+    expect(screen.getByText('Nothing here')).toBeTruthy();
+    expect(screen.getByText('Try again later')).toBeTruthy();
+  });
+
+  it('renders action button and fires onAction', async () => {
+    const onAction = jest.fn();
+    await render(
+      <EmptyState title="Empty" actionLabel="Retry" actionIcon="refresh" onAction={onAction} />
+    );
+    fireEvent.press(screen.getByText('Retry'));
+    expect(onAction).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render action button without onAction', async () => {
+    await render(<EmptyState title="Empty" actionLabel="Retry" />);
+    expect(screen.queryByText('Retry')).toBeNull();
+  });
+
+  it('renders compact layout', async () => {
+    await render(<EmptyState title="Compact" subtitle="sub" compact />);
+    expect(screen.getByText('Compact')).toBeTruthy();
+  });
+
+  it('applies custom iconColor and iconSize', async () => {
+    await render(<EmptyState icon="warning" iconColor="#f00" iconSize={20} title="Warn" />);
+    expect(screen.getByText('Warn')).toBeTruthy();
+  });
+});

--- a/tests/rn/components/FilterChip.test.tsx
+++ b/tests/rn/components/FilterChip.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, fireEvent, screen } from '@testing-library/react-native';
+import { FilterChip } from '@/components/FilterChip';
+import { mockColors } from './theme-mock';
+
+jest.mock('@/context/ThemeContext', () => ({
+  useTheme: () => ({ colors: require('./theme-mock').mockColors }),
+}));
+
+describe('FilterChip', () => {
+  it('renders label, inactive by default styling', async () => {
+    await render(<FilterChip label="All" active={false} onPress={jest.fn()} />);
+    expect(screen.getByText('All')).toBeTruthy();
+  });
+
+  it('renders active state', async () => {
+    await render(<FilterChip label="Active" active onPress={jest.fn()} />);
+    expect(screen.getByText('Active')).toBeTruthy();
+  });
+
+  it('calls onPress when tapped', async () => {
+    const onPress = jest.fn();
+    await render(<FilterChip label="Tap" active={false} onPress={onPress} />);
+    fireEvent.press(screen.getByText('Tap'));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders icon when provided', async () => {
+    await render(<FilterChip label="Icon" active onPress={jest.fn()} icon="add" />);
+    expect(screen.getByText('Icon')).toBeTruthy();
+  });
+
+  it('renders children', async () => {
+    await render(
+      <FilterChip label="WithChild" active={false} onPress={jest.fn()}>
+        <Text>child-content</Text>
+      </FilterChip>
+    );
+    expect(screen.getByText('child-content')).toBeTruthy();
+  });
+
+  it('uses custom activeColor and accessibility props', async () => {
+    await render(
+      <FilterChip
+        label="Custom"
+        active
+        onPress={jest.fn()}
+        activeColor="#123456"
+        accessibilityLabel="custom-chip"
+        accessibilityState={{ selected: true }}
+        numberOfLines={1}
+      />
+    );
+    expect(screen.getByLabelText('custom-chip')).toBeTruthy();
+  });
+});

--- a/tests/rn/components/FocusAwareStatusBar.test.tsx
+++ b/tests/rn/components/FocusAwareStatusBar.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { FocusAwareStatusBar } from '@/components/FocusAwareStatusBar';
+
+const mockUseIsFocused = jest.fn();
+jest.mock('expo-router', () => ({
+  useIsFocused: () => mockUseIsFocused(),
+}));
+
+jest.mock('expo-status-bar', () => {
+  const { Text } = require('react-native');
+  return {
+    StatusBar: ({ style }: { style: string }) => <Text testID="status-bar">{style}</Text>,
+  };
+});
+
+describe('FocusAwareStatusBar', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('renders StatusBar when focused (light-content)', async () => {
+    mockUseIsFocused.mockReturnValue(true);
+    const { getByTestId } = await render(<FocusAwareStatusBar barStyle="light-content" />);
+    expect(getByTestId('status-bar').props.children).toBe('light');
+  });
+
+  it('renders StatusBar when focused (dark-content)', async () => {
+    mockUseIsFocused.mockReturnValue(true);
+    const { getByTestId } = await render(<FocusAwareStatusBar barStyle="dark-content" />);
+    expect(getByTestId('status-bar').props.children).toBe('dark');
+  });
+
+  it('renders StatusBar for default barStyle', async () => {
+    mockUseIsFocused.mockReturnValue(true);
+    const { getByTestId } = await render(<FocusAwareStatusBar barStyle="default" />);
+    expect(getByTestId('status-bar').props.children).toBe('dark');
+  });
+
+  it('renders nothing when not focused', async () => {
+    mockUseIsFocused.mockReturnValue(false);
+    const { toJSON } = await render(<FocusAwareStatusBar barStyle="light-content" />);
+    expect(toJSON()).toBeNull();
+  });
+});

--- a/tests/rn/components/InputModal.test.tsx
+++ b/tests/rn/components/InputModal.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react-native';
+import { InputModal } from '@/components/InputModal';
+
+jest.mock('@/context/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      surface: '#fff',
+      text: '#000',
+      textSecondary: '#666',
+      background: '#eee',
+      surfaceOutline: '#ccc',
+      primary: '#00f',
+    },
+  }),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+describe('InputModal', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('renders title and message', async () => {
+    await render(
+      <InputModal
+        visible
+        title="Rename"
+        message="Enter a new name"
+        placeholder="type here"
+        onCancel={jest.fn()}
+        onConfirm={jest.fn()}
+      />
+    );
+    expect(screen.getByText('Rename')).toBeTruthy();
+    expect(screen.getByText('Enter a new name')).toBeTruthy();
+  });
+
+  it('does not render message when omitted', async () => {
+    await render(
+      <InputModal visible title="Rename" placeholder="p" onCancel={jest.fn()} onConfirm={jest.fn()} />
+    );
+    expect(screen.queryByText('Enter a new name')).toBeNull();
+  });
+
+  it('initializes input with defaultValue', async () => {
+    await render(
+      <InputModal
+        visible
+        title="Rename"
+        defaultValue="old-name"
+        placeholder="p"
+        onCancel={jest.fn()}
+        onConfirm={jest.fn()}
+      />
+    );
+    expect(screen.getByDisplayValue('old-name')).toBeTruthy();
+  });
+
+  it('updates defaultValue when it changes while visible', async () => {
+    const { rerender } = await render(
+      <InputModal visible title="Rename" defaultValue="a" placeholder="p" onCancel={jest.fn()} onConfirm={jest.fn()} />
+    );
+    expect(screen.getByDisplayValue('a')).toBeTruthy();
+    await rerender(
+      <InputModal visible title="Rename" defaultValue="b" placeholder="p" onCancel={jest.fn()} onConfirm={jest.fn()} />
+    );
+    expect(screen.getByDisplayValue('b')).toBeTruthy();
+  });
+
+  it('lets the user type into the input', async () => {
+    await render(
+      <InputModal visible title="Rename" placeholder="type here" onCancel={jest.fn()} onConfirm={jest.fn()} />
+    );
+    await fireEvent.changeText(screen.getByPlaceholderText('type here'), 'hello');
+    expect(screen.getByPlaceholderText('type here').props.value).toBe('hello');
+  });
+
+  it('calls onConfirm with trimmed value on confirm press', async () => {
+    const onConfirm = jest.fn();
+    await render(
+      <InputModal visible title="Rename" placeholder="type here" onCancel={jest.fn()} onConfirm={onConfirm} />
+    );
+    await fireEvent.changeText(screen.getByPlaceholderText('type here'), '  hello  ');
+    await fireEvent.press(screen.getByText('common.confirm'));
+    expect(onConfirm).toHaveBeenCalledWith('hello');
+  });
+
+  it('does not confirm empty input unless allowEmpty', async () => {
+    const onConfirm = jest.fn();
+    await render(
+      <InputModal visible title="Rename" placeholder="p" onCancel={jest.fn()} onConfirm={onConfirm} />
+    );
+    await fireEvent.press(screen.getByText('common.confirm'));
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it('confirms empty input when allowEmpty is true', async () => {
+    const onConfirm = jest.fn();
+    await render(
+      <InputModal visible title="Rename" placeholder="p" onCancel={jest.fn()} onConfirm={onConfirm} allowEmpty />
+    );
+    await fireEvent.press(screen.getByText('common.confirm'));
+    expect(onConfirm).toHaveBeenCalledWith('');
+  });
+
+  it('calls onCancel on cancel press', async () => {
+    const onCancel = jest.fn();
+    await render(
+      <InputModal visible title="Rename" defaultValue="x" placeholder="p" onCancel={onCancel} onConfirm={jest.fn()} />
+    );
+    await fireEvent.press(screen.getByText('common.cancel'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes multiline prop to TextInput', async () => {
+    await render(
+      <InputModal visible title="Rename" placeholder="p" onCancel={jest.fn()} onConfirm={jest.fn()} multiline />
+    );
+    const textInput = screen.getByPlaceholderText('p');
+    expect(textInput.props.multiline).toBe(true);
+  });
+
+  it('passes keyboardType prop to TextInput', async () => {
+    await render(
+      <InputModal
+        visible
+        title="Rename"
+        placeholder="p"
+        onCancel={jest.fn()}
+        onConfirm={jest.fn()}
+        keyboardType="numeric"
+      />
+    );
+    const textInput = screen.getByPlaceholderText('p');
+    expect(textInput.props.keyboardType).toBe('numeric');
+  });
+});

--- a/tests/rn/components/SettingRow.test.tsx
+++ b/tests/rn/components/SettingRow.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, screen } from '@testing-library/react-native';
+import { SettingRow } from '@/components/SettingRow';
+
+jest.mock('@/context/ThemeContext', () => ({
+  useTheme: () => ({ colors: require('./theme-mock').mockColors }),
+}));
+
+describe('SettingRow', () => {
+  it('renders label only', async () => {
+    await render(<SettingRow label="My Setting" />);
+    expect(screen.getByText('My Setting')).toBeTruthy();
+  });
+
+  it('renders hint when provided', async () => {
+    await render(<SettingRow label="My Setting" hint="Some hint" />);
+    expect(screen.getByText('Some hint')).toBeTruthy();
+  });
+
+  it('renders icon when provided', async () => {
+    const { toJSON } = await render(<SettingRow label="Icon row" icon="settings" iconColor="#f00" />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('renders children in right slot', async () => {
+    await render(
+      <SettingRow label="Row">
+        <Text>right-slot</Text>
+      </SettingRow>
+    );
+    expect(screen.getByText('right-slot')).toBeTruthy();
+  });
+});

--- a/tests/rn/components/SkeletonLoader.test.tsx
+++ b/tests/rn/components/SkeletonLoader.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { SkeletonLoader, SkeletonTorrentCard } from '@/components/SkeletonLoader';
+
+jest.mock('@/context/ThemeContext', () => ({
+  useTheme: () => ({ colors: require('./theme-mock').mockColors }),
+}));
+
+describe('SkeletonLoader', () => {
+  it('renders with default props', async () => {
+    const { toJSON } = await render(<SkeletonLoader />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('renders with custom width/height/borderRadius/style', async () => {
+    const { toJSON } = await render(
+      <SkeletonLoader width={100} height={40} borderRadius={10} style={{ marginTop: 4 }} />
+    );
+    expect(toJSON()).toBeTruthy();
+  });
+});
+
+describe('SkeletonTorrentCard', () => {
+  it('renders without crashing', async () => {
+    const { toJSON } = await render(<SkeletonTorrentCard />);
+    expect(toJSON()).toBeTruthy();
+  });
+});

--- a/tests/rn/components/SpeedGraph.test.tsx
+++ b/tests/rn/components/SpeedGraph.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { SpeedGraph } from '@/components/SpeedGraph';
+
+jest.mock('@/context/ThemeContext', () => ({
+  useTheme: () => ({ colors: require('./theme-mock').mockColors }),
+}));
+
+describe('SpeedGraph', () => {
+  it('renders empty-state dashed line when data is empty', async () => {
+    const { toJSON } = await render(<SpeedGraph data={[]} color="#00f" />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('renders single data point as a vertical line', async () => {
+    const { toJSON } = await render(<SpeedGraph data={[42]} color="#00f" />);
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('renders multi-point polyline with custom dimensions and maxValue', async () => {
+    const { toJSON } = await render(
+      <SpeedGraph data={[1, 5, 3, 8, 2]} color="#0f0" width={200} height={80} maxValue={10} />
+    );
+    expect(toJSON()).toBeTruthy();
+  });
+
+  it('handles all-zero data without dividing by zero', async () => {
+    const { toJSON } = await render(<SpeedGraph data={[0, 0, 0]} color="#f00" />);
+    expect(toJSON()).toBeTruthy();
+  });
+});

--- a/tests/rn/components/Toast.test.tsx
+++ b/tests/rn/components/Toast.test.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, fireEvent, screen, act } from '@testing-library/react-native';
+import { Toast } from '@/components/Toast';
+
+jest.mock('@/context/ThemeContext', () => ({
+  useTheme: () => ({ colors: require('./theme-mock').mockColors }),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+jest.mock('react-native-safe-area-context', () =>
+  require('react-native-safe-area-context/jest/mock.tsx').default
+);
+
+describe('Toast', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders the message', async () => {
+    await render(<Toast message="Hello world" />);
+    expect(screen.getByText('Hello world')).toBeTruthy();
+  });
+
+  it.each(['success', 'error', 'warning', 'info'] as const)(
+    'renders %s type with its icon/color',
+    async (type) => {
+      const { toJSON } = await render(<Toast message="msg" type={type} />);
+      expect(toJSON()).toBeTruthy();
+    }
+  );
+
+  it('calls onHide when the toast body is pressed', async () => {
+    jest.useFakeTimers();
+    const onHide = jest.fn();
+    await render(<Toast message="Press me" onHide={onHide} duration={9999} />);
+    fireEvent.press(screen.getByText('Press me'));
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(onHide).toHaveBeenCalled();
+  });
+
+  it('calls onHide when the close icon is pressed', async () => {
+    jest.useFakeTimers();
+    const onHide = jest.fn();
+    await render(<Toast message="Closeable" onHide={onHide} duration={9999} />);
+    fireEvent.press(screen.getByLabelText('common.close'));
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(onHide).toHaveBeenCalled();
+  });
+
+  it('auto-hides after duration elapses', async () => {
+    jest.useFakeTimers();
+    const onHide = jest.fn();
+    await render(<Toast message="Auto" onHide={onHide} duration={1000} />);
+    act(() => {
+      jest.advanceTimersByTime(1000 + 300);
+    });
+    expect(onHide).toHaveBeenCalled();
+  });
+});

--- a/tests/rn/components/theme-mock.ts
+++ b/tests/rn/components/theme-mock.ts
@@ -1,0 +1,25 @@
+// Shared mock colors object for components/*.test.tsx files.
+// Not a test file itself (no .test suffix) so jest won't try to run it.
+export const mockColors = {
+  background: '#000000',
+  surface: '#111111',
+  surfaceOutline: '#222222',
+  text: '#ffffff',
+  textSecondary: '#aaaaaa',
+  primary: '#3366ff',
+  primaryOpac: 'rgba(51,102,255,0.1)',
+  error: '#ff0000',
+  success: '#00ff00',
+  warning: '#ffaa00',
+  stateDownloading: '#0af',
+  stateSeeding: '#0fa',
+  stateUploadAndDownload: '#aa0',
+  stateUploadOnly: '#a0a',
+  stateError: '#f00',
+  stateStalled: '#888',
+  statePaused: '#666',
+  stateChecking: '#f80',
+  stateMetadata: '#08f',
+  stateQueued: '#048',
+  stateOther: '#999',
+};

--- a/tests/rn/context/ApiVersionContext.test.tsx
+++ b/tests/rn/context/ApiVersionContext.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, waitFor } from '@testing-library/react-native';
+import { ApiVersionProvider, useApiFeatures } from '@/context/ApiVersionContext';
+import { apiClient } from '@/services/api/client';
+
+jest.mock('@/services/api/client', () => ({
+  apiClient: {
+    getApiVersion: jest.fn(),
+  },
+}));
+
+let mockIsConnected = false;
+jest.mock('@/context/ServerContext', () => ({
+  useServer: () => ({ isConnected: mockIsConnected }),
+}));
+
+function Consumer({ onRender }: { onRender: (ctx: ReturnType<typeof useApiFeatures>) => void }) {
+  const ctx = useApiFeatures();
+  onRender(ctx);
+  return <Text>{ctx.apiVersion ?? 'none'}</Text>;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIsConnected = false;
+});
+
+describe('ApiVersionContext', () => {
+  it('throws when useApiFeatures used outside provider', async () => {
+    const Bad = () => {
+      useApiFeatures();
+      return null;
+    };
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(render(<Bad />)).rejects.toThrow(
+      'useApiFeatures must be used within ApiVersionProvider'
+    );
+    spy.mockRestore();
+  });
+
+  it('apiVersion is null and V5 feature defaults apply when not connected', async () => {
+    mockIsConnected = false;
+    (apiClient.getApiVersion as jest.Mock).mockReturnValue('2.9.0');
+    let latest: ReturnType<typeof useApiFeatures> | undefined;
+    await render(
+      <ApiVersionProvider>
+        <Consumer onRender={(ctx) => (latest = ctx)} />
+      </ApiVersionProvider>
+    );
+    await waitFor(() => expect(latest).toBeDefined());
+    expect(latest!.apiVersion).toBeNull();
+    expect(latest!.features.useStartStopEndpoints).toBe(true);
+  });
+
+  it('derives apiVersion and features from apiClient when connected (pre-2.11)', async () => {
+    mockIsConnected = true;
+    (apiClient.getApiVersion as jest.Mock).mockReturnValue('2.8.3');
+    let latest: ReturnType<typeof useApiFeatures> | undefined;
+    await render(
+      <ApiVersionProvider>
+        <Consumer onRender={(ctx) => (latest = ctx)} />
+      </ApiVersionProvider>
+    );
+    await waitFor(() => expect(latest).toBeDefined());
+    expect(latest!.apiVersion).toBe('2.8.3');
+    expect(latest!.features.useStartStopEndpoints).toBe(false);
+    expect(latest!.features.hasRatioLimitFields).toBe(true);
+  });
+
+  it('derives V5 features when connected with a >=2.11 version', async () => {
+    mockIsConnected = true;
+    (apiClient.getApiVersion as jest.Mock).mockReturnValue('2.11.2');
+    let latest: ReturnType<typeof useApiFeatures> | undefined;
+    await render(
+      <ApiVersionProvider>
+        <Consumer onRender={(ctx) => (latest = ctx)} />
+      </ApiVersionProvider>
+    );
+    await waitFor(() => expect(latest).toBeDefined());
+    expect(latest!.apiVersion).toBe('2.11.2');
+    expect(latest!.features.useStartStopEndpoints).toBe(true);
+    expect(latest!.features.supportsSetCookies).toBe(true);
+  });
+});

--- a/tests/rn/context/ServerContext.test.tsx
+++ b/tests/rn/context/ServerContext.test.tsx
@@ -1,0 +1,359 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, screen, waitFor, act } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ServerProvider, useServer } from '@/context/ServerContext';
+import { ServerManager } from '@/services/server-manager';
+import { apiClient } from '@/services/api/client';
+import { storageService } from '@/services/storage';
+
+jest.mock('@/services/server-manager', () => ({
+  ServerManager: {
+    getCurrentServer: jest.fn(),
+    getServers: jest.fn(),
+    connectToServer: jest.fn(),
+    disconnect: jest.fn(),
+    reconnect: jest.fn(),
+  },
+}));
+
+jest.mock('@/services/api/client', () => ({
+  apiClient: {
+    getServer: jest.fn(),
+    setServer: jest.fn(),
+  },
+}));
+
+jest.mock('@/services/storage', () => ({
+  storageService: {
+    getPreferences: jest.fn(),
+  },
+}));
+
+jest.mock('@/services/connectivity-log', () => ({
+  clogInfo: jest.fn(),
+  clogWarn: jest.fn(),
+  clogDebug: jest.fn(),
+  clogError: jest.fn(),
+}));
+
+const server1: any = { id: 's1', host: 'host1', port: 8080 };
+const server2: any = { id: 's2', host: 'host2', port: 8080 };
+
+function Consumer({ onRender }: { onRender: (ctx: ReturnType<typeof useServer>) => void }) {
+  const ctx = useServer();
+  onRender(ctx);
+  return <Text>{ctx.isConnected ? 'connected' : 'disconnected'}</Text>;
+}
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+}
+
+async function renderProvider() {
+  let latest: ReturnType<typeof useServer> | undefined;
+  const queryClient = makeQueryClient();
+  await render(
+    <QueryClientProvider client={queryClient}>
+      <ServerProvider>
+        <Consumer onRender={(ctx) => (latest = ctx)} />
+      </ServerProvider>
+    </QueryClientProvider>
+  );
+  return () => latest!;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (storageService.getPreferences as jest.Mock).mockResolvedValue({});
+  (ServerManager.getCurrentServer as jest.Mock).mockResolvedValue(null);
+  (ServerManager.getServers as jest.Mock).mockResolvedValue([]);
+  (apiClient.getServer as jest.Mock).mockReturnValue(null);
+});
+
+describe('ServerContext', () => {
+  it('throws when useServer used outside provider', async () => {
+    const BadConsumer = () => {
+      useServer();
+      return null;
+    };
+    // Suppress React error logging noise
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(render(<BadConsumer />)).rejects.toThrow(
+      'useServer must be used within a ServerProvider'
+    );
+    spy.mockRestore();
+  });
+
+  it('starts disconnected when no server saved', async () => {
+    const getLatest = await renderProvider();
+    await waitFor(() => expect(getLatest().isLoading).toBe(false));
+    expect(getLatest().isConnected).toBe(false);
+    expect(getLatest().currentServer).toBeNull();
+    expect(screen.getByText('disconnected')).toBeTruthy();
+  });
+
+  it('clears apiClient at startup when no saved server but a stale server is set', async () => {
+    (apiClient.getServer as jest.Mock).mockReturnValue(server1);
+    const getLatest = await renderProvider();
+    await waitFor(() => expect(getLatest().isLoading).toBe(false));
+    expect(apiClient.setServer).toHaveBeenCalledWith(null);
+  });
+
+  it('auto-connects to last server when autoConnectLastServer preference is not false', async () => {
+    (ServerManager.getCurrentServer as jest.Mock).mockResolvedValue(server1);
+    (ServerManager.connectToServer as jest.Mock).mockResolvedValue(true);
+    (apiClient.getServer as jest.Mock).mockReturnValue(server1);
+
+    const getLatest = await renderProvider();
+    await waitFor(() => expect(getLatest().isLoading).toBe(false));
+    expect(getLatest().isConnected).toBe(true);
+    expect(getLatest().currentServer).toEqual(server1);
+  });
+
+  it('does not auto-connect when autoConnectLastServer is false, but connects if exactly one server exists', async () => {
+    (storageService.getPreferences as jest.Mock).mockResolvedValue({ autoConnectLastServer: false });
+    (ServerManager.getServers as jest.Mock).mockResolvedValue([server1]);
+    (ServerManager.connectToServer as jest.Mock).mockResolvedValue(true);
+    (apiClient.getServer as jest.Mock).mockReturnValue(server1);
+
+    const getLatest = await renderProvider();
+    await waitFor(() => expect(getLatest().isLoading).toBe(false));
+    expect(ServerManager.getCurrentServer).not.toHaveBeenCalled();
+    expect(getLatest().isConnected).toBe(true);
+  });
+
+  it('clears currentServer when auto-connect fails', async () => {
+    (ServerManager.getCurrentServer as jest.Mock).mockResolvedValue(server1);
+    (ServerManager.connectToServer as jest.Mock).mockResolvedValue(false);
+
+    const getLatest = await renderProvider();
+    await waitFor(() => expect(getLatest().isLoading).toBe(false));
+    expect(getLatest().isConnected).toBe(false);
+    expect(getLatest().currentServer).toBeNull();
+  });
+
+  it('handles auto-connect throwing', async () => {
+    (ServerManager.getCurrentServer as jest.Mock).mockResolvedValue(server1);
+    (ServerManager.connectToServer as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    const getLatest = await renderProvider();
+    await waitFor(() => expect(getLatest().isLoading).toBe(false));
+    expect(getLatest().isConnected).toBe(false);
+    expect(getLatest().currentServer).toBeNull();
+  });
+
+  it('handles preferences load throwing entirely', async () => {
+    (storageService.getPreferences as jest.Mock).mockRejectedValue(new Error('storage broke'));
+    (apiClient.getServer as jest.Mock).mockReturnValue(server1);
+
+    const getLatest = await renderProvider();
+    await waitFor(() => expect(getLatest().isLoading).toBe(false));
+    expect(getLatest().isConnected).toBe(false);
+    expect(apiClient.setServer).toHaveBeenCalledWith(null);
+  });
+
+  it('connectToServer sets connected state on success', async () => {
+    (ServerManager.connectToServer as jest.Mock).mockResolvedValue(true);
+    (apiClient.getServer as jest.Mock).mockReturnValue(server2);
+
+    const getLatest = await renderProvider();
+    await waitFor(() => expect(getLatest().isLoading).toBe(false));
+
+    await act(async () => {
+      await getLatest().connectToServer(server2);
+    });
+
+    expect(getLatest().isConnected).toBe(true);
+    expect(getLatest().currentServer).toEqual(server2);
+  });
+
+  it('connectToServer sets disconnected on failure', async () => {
+    (ServerManager.connectToServer as jest.Mock).mockResolvedValue(false);
+
+    const getLatest = await renderProvider();
+    await waitFor(() => expect(getLatest().isLoading).toBe(false));
+
+    await act(async () => {
+      await getLatest().connectToServer(server2);
+    });
+
+    expect(getLatest().isConnected).toBe(false);
+    expect(getLatest().activeEndpoint).toBeNull();
+  });
+
+  it('connectToServer handles mutation error', async () => {
+    (ServerManager.connectToServer as jest.Mock).mockRejectedValue(new Error('network'));
+
+    const getLatest = await renderProvider();
+    await waitFor(() => expect(getLatest().isLoading).toBe(false));
+
+    await expect(
+      act(async () => {
+        await getLatest().connectToServer(server2);
+      })
+    ).rejects.toThrow('network');
+
+    expect(getLatest().isConnected).toBe(false);
+  });
+
+  it('disconnect resets state', async () => {
+    (ServerManager.getCurrentServer as jest.Mock).mockResolvedValue(server1);
+    (ServerManager.connectToServer as jest.Mock).mockResolvedValue(true);
+    (apiClient.getServer as jest.Mock).mockReturnValue(server1);
+    (ServerManager.disconnect as jest.Mock).mockResolvedValue(undefined);
+
+    const getLatest = await renderProvider();
+    await waitFor(() => expect(getLatest().isLoading).toBe(false));
+    expect(getLatest().isConnected).toBe(true);
+
+    await act(async () => {
+      await getLatest().disconnect();
+    });
+
+    expect(getLatest().isConnected).toBe(false);
+    expect(getLatest().currentServer).toBeNull();
+  });
+
+  it('disconnect swallows ServerManager.disconnect errors', async () => {
+    (ServerManager.getCurrentServer as jest.Mock).mockResolvedValue(server1);
+    (ServerManager.connectToServer as jest.Mock).mockResolvedValue(true);
+    (apiClient.getServer as jest.Mock).mockReturnValue(server1);
+    (ServerManager.disconnect as jest.Mock).mockRejectedValue(new Error('fail'));
+
+    const getLatest = await renderProvider();
+    await waitFor(() => expect(getLatest().isLoading).toBe(false));
+
+    await act(async () => {
+      await getLatest().disconnect();
+    });
+
+    expect(getLatest().isConnected).toBe(false);
+  });
+
+  it('reconnect() updates connection status on success/failure', async () => {
+    (ServerManager.getCurrentServer as jest.Mock).mockResolvedValue(server1);
+    (ServerManager.connectToServer as jest.Mock).mockResolvedValue(true);
+    (apiClient.getServer as jest.Mock).mockReturnValue(server1);
+    (ServerManager.reconnect as jest.Mock).mockResolvedValue(true);
+
+    const getLatest = await renderProvider();
+    await waitFor(() => expect(getLatest().isLoading).toBe(false));
+
+    let result: boolean | undefined;
+    await act(async () => {
+      result = await getLatest().reconnect();
+    });
+    expect(result).toBe(true);
+    expect(getLatest().isConnected).toBe(true);
+
+    (ServerManager.reconnect as jest.Mock).mockResolvedValue(false);
+    await act(async () => {
+      result = await getLatest().reconnect();
+    });
+    expect(result).toBe(false);
+    expect(getLatest().isConnected).toBe(false);
+  });
+
+  it('reconnect() catches thrown errors', async () => {
+    (ServerManager.getCurrentServer as jest.Mock).mockResolvedValue(server1);
+    (ServerManager.connectToServer as jest.Mock).mockResolvedValue(true);
+    (apiClient.getServer as jest.Mock).mockReturnValue(server1);
+    (ServerManager.reconnect as jest.Mock).mockRejectedValue(new Error('boom'));
+
+    const getLatest = await renderProvider();
+    await waitFor(() => expect(getLatest().isLoading).toBe(false));
+
+    let result: boolean | undefined;
+    await act(async () => {
+      result = await getLatest().reconnect();
+    });
+    expect(result).toBe(false);
+    expect(getLatest().isConnected).toBe(false);
+  });
+
+  it('checkAndReconnect returns false immediately with no current server', async () => {
+    const getLatest = await renderProvider();
+    await waitFor(() => expect(getLatest().isLoading).toBe(false));
+
+    let result: boolean | undefined;
+    await act(async () => {
+      result = await getLatest().checkAndReconnect();
+    });
+    expect(result).toBe(false);
+  });
+
+  it('checkAndReconnect succeeds via ServerManager.reconnect', async () => {
+    (ServerManager.getCurrentServer as jest.Mock).mockResolvedValue(server1);
+    (ServerManager.connectToServer as jest.Mock).mockResolvedValue(true);
+    (apiClient.getServer as jest.Mock).mockReturnValue(server1);
+    (ServerManager.reconnect as jest.Mock).mockResolvedValue(true);
+
+    const getLatest = await renderProvider();
+    await waitFor(() => expect(getLatest().isLoading).toBe(false));
+
+    let result: boolean | undefined;
+    await act(async () => {
+      result = await getLatest().checkAndReconnect();
+    });
+    expect(result).toBe(true);
+  });
+
+  it('checkAndReconnect falls back to connectToServer when reconnect throws', async () => {
+    (ServerManager.getCurrentServer as jest.Mock).mockResolvedValue(server1);
+    (ServerManager.connectToServer as jest.Mock).mockResolvedValue(true);
+    (apiClient.getServer as jest.Mock).mockReturnValue(server1);
+    (ServerManager.reconnect as jest.Mock).mockRejectedValue(new Error('session dead'));
+
+    const getLatest = await renderProvider();
+    await waitFor(() => expect(getLatest().isLoading).toBe(false));
+
+    (ServerManager.connectToServer as jest.Mock).mockResolvedValue(true);
+    let result: boolean | undefined;
+    await act(async () => {
+      result = await getLatest().checkAndReconnect();
+    });
+    expect(result).toBe(true);
+  });
+
+  it('checkAndReconnect returns false when both reconnect and connectToServer fail', async () => {
+    (ServerManager.getCurrentServer as jest.Mock).mockResolvedValue(server1);
+    (ServerManager.connectToServer as jest.Mock).mockResolvedValue(true);
+    (apiClient.getServer as jest.Mock).mockReturnValue(server1);
+
+    const getLatest = await renderProvider();
+    await waitFor(() => expect(getLatest().isLoading).toBe(false));
+
+    (ServerManager.reconnect as jest.Mock).mockRejectedValue(new Error('dead'));
+    (ServerManager.connectToServer as jest.Mock).mockRejectedValue(new Error('dead too'));
+
+    let result: boolean | undefined;
+    await act(async () => {
+      result = await getLatest().checkAndReconnect();
+    });
+    expect(result).toBe(false);
+  });
+
+  it('checkAndReconnect de-dupes concurrent calls into one in-flight promise', async () => {
+    (ServerManager.getCurrentServer as jest.Mock).mockResolvedValue(server1);
+    (ServerManager.connectToServer as jest.Mock).mockResolvedValue(true);
+    (apiClient.getServer as jest.Mock).mockReturnValue(server1);
+
+    const getLatest = await renderProvider();
+    await waitFor(() => expect(getLatest().isLoading).toBe(false));
+
+    (ServerManager.reconnect as jest.Mock).mockResolvedValue(true);
+
+    let r1: Promise<boolean>, r2: Promise<boolean>;
+    await act(async () => {
+      r1 = getLatest().checkAndReconnect();
+      r2 = getLatest().checkAndReconnect();
+      await Promise.all([r1, r2]);
+    });
+
+    // reconnect should have only been triggered once despite two callers
+    expect((ServerManager.reconnect as jest.Mock).mock.calls.length).toBe(1);
+  });
+});

--- a/tests/rn/context/ToastContext.test.tsx
+++ b/tests/rn/context/ToastContext.test.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { Text, TouchableOpacity, Platform } from 'react-native';
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react-native';
+import { ToastProvider, useToast, ModalToast } from '@/context/ToastContext';
+import { ThemeProvider } from '@/context/ThemeContext';
+import { storageService } from '@/services/storage';
+
+jest.mock('@/services/storage', () => ({
+  storageService: {
+    getPreferences: jest.fn(),
+  },
+}));
+
+function Consumer() {
+  const { showToast, toast, hideToast } = useToast();
+  return (
+    <>
+      <TouchableOpacity testID="show" onPress={() => showToast('hello', 'success')} />
+      <TouchableOpacity testID="hide" onPress={hideToast} />
+      <Text testID="toast-text">{toast ? toast.message : 'none'}</Text>
+    </>
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (storageService.getPreferences as jest.Mock).mockResolvedValue({});
+});
+
+describe('ToastContext', () => {
+  it('throws when useToast used outside provider', async () => {
+    const Bad = () => {
+      useToast();
+      return null;
+    };
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(render(<Bad />)).rejects.toThrow('useToast must be used within a ToastProvider');
+    spy.mockRestore();
+  });
+
+  it('starts with no toast', async () => {
+    await render(
+      <ThemeProvider>
+      <ToastProvider>
+        <Consumer />
+      </ToastProvider>
+      </ThemeProvider>
+    );
+    expect(screen.getByTestId('toast-text').props.children).toBe('none');
+  });
+
+  it('showToast sets toast state and it renders; hideToast clears it', async () => {
+    await render(
+      <ThemeProvider>
+      <ToastProvider>
+        <Consumer />
+      </ToastProvider>
+      </ThemeProvider>
+    );
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('show'));
+    });
+    await waitFor(() => expect(screen.getByTestId('toast-text').props.children).toBe('hello'));
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('hide'));
+    });
+    await waitFor(() => expect(screen.getByTestId('toast-text').props.children).toBe('none'));
+  });
+
+  it('loads toastDuration preference on mount', async () => {
+    (storageService.getPreferences as jest.Mock).mockResolvedValue({ toastDuration: 5000 });
+    await render(
+      <ThemeProvider>
+      <ToastProvider>
+        <Consumer />
+      </ToastProvider>
+      </ThemeProvider>
+    );
+    await waitFor(() => expect(storageService.getPreferences).toHaveBeenCalled());
+  });
+
+  it('ignores errors loading toastDuration preference', async () => {
+    (storageService.getPreferences as jest.Mock).mockRejectedValue(new Error('fail'));
+    await render(
+      <ThemeProvider>
+      <ToastProvider>
+        <Consumer />
+      </ToastProvider>
+      </ThemeProvider>
+    );
+    await waitFor(() => expect(storageService.getPreferences).toHaveBeenCalled());
+  });
+
+  it('ignores non-numeric toastDuration preference', async () => {
+    (storageService.getPreferences as jest.Mock).mockResolvedValue({ toastDuration: 'nope' });
+    await render(
+      <ThemeProvider>
+      <ToastProvider>
+        <Consumer />
+      </ToastProvider>
+      </ThemeProvider>
+    );
+    await waitFor(() => expect(storageService.getPreferences).toHaveBeenCalled());
+  });
+
+  it('ModalToast renders nothing on Android', async () => {
+    const originalOS = Platform.OS;
+    Platform.OS = 'android';
+    await render(
+      <ThemeProvider>
+      <ToastProvider>
+        <Consumer />
+        <ModalToast />
+      </ToastProvider>
+      </ThemeProvider>
+    );
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('show'));
+    });
+    // ModalToast shouldn't add a second toast text node; global toast still shows.
+    await waitFor(() => expect(screen.getByTestId('toast-text').props.children).toBe('hello'));
+    Platform.OS = originalOS;
+  });
+
+  it('ModalToast suppresses the global toast on iOS while mounted', async () => {
+    const originalOS = Platform.OS;
+    Platform.OS = 'ios';
+
+    function Wrapper() {
+      const [showModal, setShowModal] = React.useState(true);
+      return (
+        <>
+          <Consumer />
+          {showModal && <ModalToast />}
+          <TouchableOpacity testID="unmount-modal" onPress={() => setShowModal(false)} />
+        </>
+      );
+    }
+
+    await render(
+      <ThemeProvider>
+      <ToastProvider>
+        <Wrapper />
+      </ToastProvider>
+      </ThemeProvider>
+    );
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('show'));
+    });
+    await waitFor(() => expect(screen.getByTestId('toast-text').props.children).toBe('hello'));
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('unmount-modal'));
+    });
+
+    Platform.OS = originalOS;
+  });
+});

--- a/tests/rn/hooks/useReactiveReconnect.test.ts
+++ b/tests/rn/hooks/useReactiveReconnect.test.ts
@@ -1,0 +1,114 @@
+import { renderHook } from '@testing-library/react-native';
+import { useReactiveReconnect, isReconnectableError } from '@/hooks/useReactiveReconnect';
+import { useServer } from '@/context/ServerContext';
+
+jest.mock('@/context/ServerContext', () => ({
+  useServer: jest.fn(),
+}));
+
+describe('isReconnectableError', () => {
+  it('matches known reconnectable fragments', () => {
+    expect(isReconnectableError('Authentication failed: bad creds')).toBe(true);
+    expect(isReconnectableError('No server configured')).toBe(true);
+    expect(isReconnectableError('Connection timeout after 5s')).toBe(true);
+    expect(isReconnectableError('Network Error')).toBe(true);
+  });
+
+  it('does not match unrelated messages', () => {
+    expect(isReconnectableError('Some other error')).toBe(false);
+  });
+});
+
+describe('useReactiveReconnect', () => {
+  let checkAndReconnect: jest.Mock;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    checkAndReconnect = jest.fn().mockResolvedValue(true);
+    jest.mocked(useServer).mockReturnValue({
+      isConnected: true,
+      checkAndReconnect,
+    } as any);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('does nothing when there is no error', async () => {
+    await renderHook(({ error }: { error: unknown }) => useReactiveReconnect(error), {
+      initialProps: { error: null as unknown },
+    });
+    expect(checkAndReconnect).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when not connected', async () => {
+    jest.mocked(useServer).mockReturnValue({
+      isConnected: false,
+      checkAndReconnect,
+    } as any);
+    await renderHook(() => useReactiveReconnect(new Error('Network Error')));
+    expect(checkAndReconnect).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when the error is not reconnectable', async () => {
+    await renderHook(() => useReactiveReconnect(new Error('Some random failure')));
+    expect(checkAndReconnect).not.toHaveBeenCalled();
+  });
+
+  it('calls checkAndReconnect for a reconnectable error', async () => {
+    await renderHook(() => useReactiveReconnect(new Error('Network Error')));
+    expect(checkAndReconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects the cooldown between attempts', async () => {
+    const { rerender } = await renderHook(
+      ({ error }: { error: unknown }) => useReactiveReconnect(error),
+      { initialProps: { error: new Error('Network Error') as unknown } },
+    );
+    expect(checkAndReconnect).toHaveBeenCalledTimes(1);
+
+    // Rerender with a new error instance quickly — should be within cooldown.
+    await rerender({ error: new Error('Connection timeout') });
+    expect(checkAndReconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a new attempt after the cooldown has elapsed', async () => {
+    const nowSpy = jest.spyOn(Date, 'now');
+    nowSpy.mockReturnValue(1_000_000);
+    const { rerender } = await renderHook(
+      ({ error }: { error: unknown }) => useReactiveReconnect(error),
+      { initialProps: { error: new Error('Network Error') as unknown } },
+    );
+    expect(checkAndReconnect).toHaveBeenCalledTimes(1);
+
+    nowSpy.mockReturnValue(1_000_000 + 16_000);
+    await rerender({ error: new Error('Connection timeout') });
+    expect(checkAndReconnect).toHaveBeenCalledTimes(2);
+    nowSpy.mockRestore();
+  });
+
+  it('does not start a new reconnect while one is in flight', async () => {
+    let resolveReconnect: (v: boolean) => void = () => {};
+    checkAndReconnect.mockReturnValue(
+      new Promise((resolve) => {
+        resolveReconnect = resolve;
+      }),
+    );
+    const { rerender } = await renderHook(
+      ({ error }: { error: unknown }) => useReactiveReconnect(error),
+      { initialProps: { error: new Error('Network Error') as unknown } },
+    );
+    expect(checkAndReconnect).toHaveBeenCalledTimes(1);
+
+    // Force cooldown to have "elapsed" by manipulating error identity + time.
+    const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(Date.now() + 20_000);
+    await rerender({ error: new Error('Network Error 2') });
+    // Still only 1 call because reconnectingRef is true (in-flight).
+    expect(checkAndReconnect).toHaveBeenCalledTimes(1);
+
+    resolveReconnect(true);
+    nowSpy.mockRestore();
+  });
+});

--- a/tests/rn/hooks/useSearchJob.test.tsx
+++ b/tests/rn/hooks/useSearchJob.test.tsx
@@ -1,0 +1,312 @@
+import React from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AppState } from 'react-native';
+import { useSearchJob } from '@/hooks/useSearchJob';
+import { searchApi } from '@/services/api/search';
+import { useServer } from '@/context/ServerContext';
+import { useReactiveReconnect } from '@/hooks/useReactiveReconnect';
+
+jest.mock('@/services/api/search', () => ({
+  searchApi: {
+    start: jest.fn(),
+    stop: jest.fn(),
+    deleteSearch: jest.fn(),
+    getStatus: jest.fn(),
+    getResults: jest.fn(),
+  },
+}));
+jest.mock('@/context/ServerContext', () => ({ useServer: jest.fn() }));
+jest.mock('@/hooks/useReactiveReconnect', () => ({ useReactiveReconnect: jest.fn() }));
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useSearchJob', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useServer).mockReturnValue({ isConnected: true } as any);
+    jest.mocked(searchApi.getStatus).mockResolvedValue([]);
+    jest.mocked(searchApi.getResults).mockResolvedValue({
+      status: 'Running',
+      total: 0,
+      results: [],
+    } as any);
+    jest.mocked(searchApi.stop).mockResolvedValue(undefined as any);
+    jest.mocked(searchApi.deleteSearch).mockResolvedValue(undefined as any);
+  });
+
+  it('starts idle with no job', async () => {
+    const { result } = await renderHook(() => useSearchJob(), { wrapper: makeWrapper() });
+    expect(result.current.jobId).toBeNull();
+    expect(result.current.status).toBeNull();
+    expect(result.current.results).toEqual([]);
+    expect(result.current.total).toBe(0);
+  });
+
+  it('shows error when starting while not connected', async () => {
+    jest.mocked(useServer).mockReturnValue({ isConnected: false } as any);
+    const { result } = await renderHook(() => useSearchJob(), { wrapper: makeWrapper() });
+    await act(async () => {
+      await result.current.start('term', 'all', 'all');
+    });
+    expect(result.current.error).toBe('Not connected to a server.');
+    expect(searchApi.start).not.toHaveBeenCalled();
+  });
+
+  it('starts a search job and polls for status/results', async () => {
+    jest.mocked(searchApi.start).mockResolvedValue({ id: 42 } as any);
+    const { result } = await renderHook(() => useSearchJob(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      await result.current.start('ubuntu', 'all', 'all');
+    });
+
+    expect(result.current.jobId).toBe(42);
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('Running');
+    });
+    expect(searchApi.getResults).toHaveBeenCalledWith(42, 1000, 0);
+  });
+
+  it('retries start once on a 409 conflict then succeeds', async () => {
+    jest
+      .mocked(searchApi.start)
+      .mockRejectedValueOnce(new Error('409 conflict'))
+      .mockResolvedValueOnce({ id: 7 } as any);
+    const { result } = await renderHook(() => useSearchJob(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      await result.current.start('term', 'all', 'all');
+    });
+
+    expect(searchApi.start).toHaveBeenCalledTimes(2);
+    expect(result.current.jobId).toBe(7);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets mutationError when the 409 retry also fails', async () => {
+    jest
+      .mocked(searchApi.start)
+      .mockRejectedValueOnce(new Error('409 conflict'))
+      .mockRejectedValueOnce(new Error('still broken'));
+    const { result } = await renderHook(() => useSearchJob(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      await result.current.start('term', 'all', 'all');
+    });
+
+    expect(result.current.error).toBe('still broken');
+    expect(result.current.jobId).toBeNull();
+  });
+
+  it('sets mutationError for a non-409 start failure', async () => {
+    jest.mocked(searchApi.start).mockRejectedValue(new Error('server exploded'));
+    const { result } = await renderHook(() => useSearchJob(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      await result.current.start('term', 'all', 'all');
+    });
+
+    expect(result.current.error).toBe('server exploded');
+    expect(result.current.jobId).toBeNull();
+  });
+
+  it('stops and deletes a previous job before starting a new one', async () => {
+    jest
+      .mocked(searchApi.start)
+      .mockResolvedValueOnce({ id: 1 } as any)
+      .mockResolvedValueOnce({ id: 2 } as any);
+    const { result } = await renderHook(() => useSearchJob(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      await result.current.start('first', 'all', 'all');
+    });
+    expect(result.current.jobId).toBe(1);
+
+    await act(async () => {
+      await result.current.start('second', 'all', 'all');
+    });
+
+    expect(searchApi.stop).toHaveBeenCalledWith(1);
+    expect(searchApi.deleteSearch).toHaveBeenCalledWith(1);
+    expect(result.current.jobId).toBe(2);
+  });
+
+  it('stop() invokes searchApi.stop for the active job', async () => {
+    jest.mocked(searchApi.start).mockResolvedValue({ id: 5 } as any);
+    const { result } = await renderHook(() => useSearchJob(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      await result.current.start('term', 'all', 'all');
+    });
+    await act(async () => {
+      await result.current.stop();
+    });
+
+    expect(searchApi.stop).toHaveBeenCalledWith(5);
+  });
+
+  it('stop() is a no-op when there is no active job', async () => {
+    const { result } = await renderHook(() => useSearchJob(), { wrapper: makeWrapper() });
+    await act(async () => {
+      await result.current.stop();
+    });
+    expect(searchApi.stop).not.toHaveBeenCalled();
+  });
+
+  it('tolerates a failing stop call (job already stopped/removed server-side)', async () => {
+    jest.mocked(searchApi.start).mockResolvedValue({ id: 9 } as any);
+    jest.mocked(searchApi.stop).mockRejectedValue(new Error('stop boom'));
+    const { result } = await renderHook(() => useSearchJob(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      await result.current.start('term', 'all', 'all');
+    });
+    await act(async () => {
+      await result.current.stop();
+    });
+
+    expect(searchApi.stop).toHaveBeenCalledWith(9);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('reset() clears job state and deletes the server-side job when connected', async () => {
+    jest.mocked(searchApi.start).mockResolvedValue({ id: 11 } as any);
+    const { result } = await renderHook(() => useSearchJob(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      await result.current.start('term', 'all', 'all');
+    });
+    await act(async () => {
+      await result.current.reset();
+    });
+
+    expect(searchApi.deleteSearch).toHaveBeenCalledWith(11);
+    expect(result.current.jobId).toBeNull();
+  });
+
+  it('reset() does not call deleteSearch when there is no active job', async () => {
+    const { result } = await renderHook(() => useSearchJob(), { wrapper: makeWrapper() });
+    await act(async () => {
+      await result.current.reset();
+    });
+    expect(searchApi.deleteSearch).not.toHaveBeenCalled();
+  });
+
+  it('force-clears local state when disconnected mid-search', async () => {
+    jest.mocked(searchApi.start).mockResolvedValue({ id: 3 } as any);
+    const { result, rerender } = await renderHook(
+      ({ connected }: { connected: boolean }) => {
+        jest.mocked(useServer).mockReturnValue({ isConnected: connected } as any);
+        return useSearchJob();
+      },
+      { wrapper: makeWrapper(), initialProps: { connected: true } },
+    );
+
+    await act(async () => {
+      await result.current.start('term', 'all', 'all');
+    });
+    expect(result.current.jobId).toBe(3);
+
+    await act(async () => {
+      await rerender({ connected: false });
+    });
+
+    expect(result.current.jobId).toBeNull();
+  });
+
+  it('deletes the server-side job on unmount', async () => {
+    jest.mocked(searchApi.start).mockResolvedValue({ id: 21 } as any);
+    const { result, unmount } = await renderHook(() => useSearchJob(), {
+      wrapper: makeWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.start('term', 'all', 'all');
+    });
+
+    unmount();
+
+    await waitFor(() => {
+      expect(searchApi.deleteSearch).toHaveBeenCalledWith(21);
+    });
+  });
+
+  it('refreshes on AppState becoming active while a job is running', async () => {
+    let appStateHandler: ((state: string) => void) | undefined;
+    const addListenerSpy = jest
+      .spyOn(AppState, 'addEventListener')
+      .mockImplementation((_event, handler) => {
+        appStateHandler = handler as (state: string) => void;
+        return { remove: jest.fn() } as any;
+      });
+
+    jest.mocked(searchApi.start).mockResolvedValue({ id: 55 } as any);
+    const { result } = await renderHook(() => useSearchJob(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      await result.current.start('term', 'all', 'all');
+    });
+
+    jest.mocked(searchApi.getResults).mockClear();
+
+    await act(async () => {
+      appStateHandler?.('active');
+    });
+
+    await waitFor(() => {
+      expect(searchApi.getResults).toHaveBeenCalled();
+    });
+
+    // Intentionally not restored: AppState is a singleton, and restoring it here
+    // triggers a jest/RN quirk where subsequent addEventListener calls return
+    // undefined instead of a real subscription (breaking later tests' unmount).
+    void addListenerSpy;
+  });
+
+  it('surfaces query errors via getErrorMessage and calls useReactiveReconnect', async () => {
+    jest.mocked(searchApi.start).mockResolvedValue({ id: 99 } as any);
+    jest.mocked(searchApi.getResults).mockRejectedValue(new Error('poll failed'));
+    const { result } = await renderHook(() => useSearchJob(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      await result.current.start('term', 'all', 'all');
+    });
+
+    await waitFor(
+      () => {
+        expect(result.current.error).toBe('poll failed');
+      },
+      { timeout: 3000 }
+    );
+    expect(useReactiveReconnect).toHaveBeenCalled();
+  });
+
+  it('stops polling once status is Stopped', async () => {
+    jest.mocked(searchApi.start).mockResolvedValue({ id: 8 } as any);
+    jest.mocked(searchApi.getResults).mockResolvedValue({
+      status: 'Stopped',
+      total: 5,
+      results: [{ fileName: 'x' } as any],
+    } as any);
+    const { result } = await renderHook(() => useSearchJob(), { wrapper: makeWrapper() });
+
+    await act(async () => {
+      await result.current.start('term', 'all', 'all');
+    });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('Stopped');
+    });
+    expect(result.current.total).toBe(5);
+    expect(result.current.results).toHaveLength(1);
+  });
+});

--- a/tests/rn/hooks/useSpeedHistory.test.ts
+++ b/tests/rn/hooks/useSpeedHistory.test.ts
@@ -1,0 +1,43 @@
+import { renderHook } from '@testing-library/react-native';
+import { useSpeedHistory } from '@/hooks/useSpeedHistory';
+import { useTransfer } from '@/context/TransferContext';
+
+jest.mock('@/context/TransferContext', () => ({
+  useTransfer: jest.fn(),
+}));
+
+describe('useSpeedHistory', () => {
+  it('returns zeroed history and zero current speeds when transferInfo is null', async () => {
+    jest.mocked(useTransfer).mockReturnValue({ transferInfo: null } as any);
+    const { result } = await renderHook(() => useSpeedHistory());
+    expect(result.current.downloadHistory).toHaveLength(30);
+    expect(result.current.downloadHistory.every((v) => v === 0)).toBe(true);
+    expect(result.current.uploadHistory).toHaveLength(30);
+    expect(result.current.currentDownload).toBe(0);
+    expect(result.current.currentUpload).toBe(0);
+  });
+
+  it('appends a converted reading and drops the oldest when transferInfo updates', async () => {
+    const mockUseTransfer = jest.mocked(useTransfer);
+    mockUseTransfer.mockReturnValue({
+      transferInfo: { dl_info_speed: 1024 * 1024 * 2, up_info_speed: 1024 * 1024 },
+    } as any);
+
+    const { result, rerender } = await renderHook(() => useSpeedHistory());
+
+    expect(result.current.downloadHistory[29]).toBeCloseTo(2);
+    expect(result.current.uploadHistory[29]).toBeCloseTo(1);
+    expect(result.current.currentDownload).toBe(1024 * 1024 * 2);
+    expect(result.current.currentUpload).toBe(1024 * 1024);
+
+    mockUseTransfer.mockReturnValue({
+      transferInfo: { dl_info_speed: 1024 * 1024 * 4, up_info_speed: 1024 * 1024 * 3 },
+    } as any);
+    await rerender({});
+
+    expect(result.current.downloadHistory).toHaveLength(30);
+    expect(result.current.downloadHistory[28]).toBeCloseTo(2);
+    expect(result.current.downloadHistory[29]).toBeCloseTo(4);
+    expect(result.current.uploadHistory[29]).toBeCloseTo(3);
+  });
+});

--- a/tests/rn/hooks/useSpeedTracker.test.ts
+++ b/tests/rn/hooks/useSpeedTracker.test.ts
@@ -1,0 +1,68 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useSpeedTracker } from '@/hooks/useSpeedTracker';
+
+describe('useSpeedTracker', () => {
+  it('resets stats on mount when enabled', async () => {
+    const { result } = await renderHook(() => useSpeedTracker(true));
+    expect(result.current.speedData).toEqual([]);
+    expect(result.current.stats.averageDownload).toBe(0);
+    expect(result.current.stats.peakDownload).toBe(0);
+    expect(result.current.getLatestSpeeds()).toEqual({ download: 0, upload: 0 });
+  });
+
+  it('does not reset when disabled on mount', async () => {
+    const { result } = await renderHook(() => useSpeedTracker(false));
+    // still starts empty since state is initialized empty regardless
+    expect(result.current.speedData).toEqual([]);
+  });
+
+  it('adds speed data points and updates stats/peaks', async () => {
+    const { result } = await renderHook(() => useSpeedTracker(true));
+
+    await act(async () => {
+      result.current.addSpeedData(100, 50);
+    });
+    expect(result.current.speedData).toHaveLength(1);
+    expect(result.current.stats.peakDownload).toBe(100);
+    expect(result.current.stats.peakUpload).toBe(50);
+    expect(result.current.stats.averageDownload).toBe(100);
+    expect(result.current.getLatestSpeeds()).toEqual({ download: 100, upload: 50 });
+
+    await act(async () => {
+      result.current.addSpeedData(200, 20);
+    });
+    expect(result.current.speedData).toHaveLength(2);
+    expect(result.current.stats.peakDownload).toBe(200);
+    expect(result.current.stats.peakUpload).toBe(50);
+    expect(result.current.getLatestSpeeds()).toEqual({ download: 200, upload: 20 });
+  });
+
+  it('caps stored data points at MAX_DATA_POINTS (60)', async () => {
+    const { result } = await renderHook(() => useSpeedTracker(true));
+
+    await act(async () => {
+      for (let i = 0; i < 65; i++) {
+        result.current.addSpeedData(i, i);
+      }
+    });
+    expect(result.current.speedData).toHaveLength(60);
+    expect(result.current.speedData[59].downloadSpeed).toBe(64);
+  });
+
+  it('resetStats clears data, stats, and last speeds', async () => {
+    const { result } = await renderHook(() => useSpeedTracker(true));
+
+    await act(async () => {
+      result.current.addSpeedData(100, 50);
+    });
+    expect(result.current.speedData).toHaveLength(1);
+
+    await act(async () => {
+      result.current.resetStats();
+    });
+    expect(result.current.speedData).toEqual([]);
+    expect(result.current.stats.averageDownload).toBe(0);
+    expect(result.current.stats.peakDownload).toBe(0);
+    expect(result.current.getLatestSpeeds()).toEqual({ download: 0, upload: 0 });
+  });
+});

--- a/tests/rn/hooks/useTorrentActions.test.ts
+++ b/tests/rn/hooks/useTorrentActions.test.ts
@@ -1,0 +1,420 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { Alert } from 'react-native';
+import * as Clipboard from 'expo-clipboard';
+import { useTorrentActions } from '@/hooks/useTorrentActions';
+import { useServer } from '@/context/ServerContext';
+import { useTorrents } from '@/context/TorrentContext';
+import { useTransfer } from '@/context/TransferContext';
+import { useToast } from '@/context/ToastContext';
+import { apiClient } from '@/services/api/client';
+import { torrentsApi } from '@/services/api/torrents';
+import { TorrentInfo } from '@/types/api';
+
+jest.mock('@/context/ServerContext', () => ({ useServer: jest.fn() }));
+jest.mock('@/context/TorrentContext', () => ({ useTorrents: jest.fn() }));
+jest.mock('@/context/TransferContext', () => ({ useTransfer: jest.fn() }));
+jest.mock('@/context/ToastContext', () => ({ useToast: jest.fn() }));
+jest.mock('@/services/api/client', () => ({
+  apiClient: { getServer: jest.fn() },
+}));
+jest.mock('@/services/api/torrents', () => ({
+  torrentsApi: {
+    resumeTorrents: jest.fn(),
+    pauseTorrents: jest.fn(),
+    setForceStart: jest.fn(),
+    recheckTorrents: jest.fn(),
+    reannounceTorrents: jest.fn(),
+    deleteTorrents: jest.fn(),
+    setMaximalPriority: jest.fn(),
+    setTorrentDownloadLimit: jest.fn(),
+  },
+}));
+jest.mock('expo-clipboard', () => ({
+  setStringAsync: jest.fn(),
+}));
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string, opts?: any) => (opts ? `${key}:${JSON.stringify(opts)}` : key) }),
+}));
+
+const baseTorrent: TorrentInfo = {
+  hash: 'abc123',
+  name: 'Test Torrent',
+  state: 'downloading',
+  dl_limit: 0,
+  magnet_uri: 'magnet:?xt=urn:btih:abc123',
+} as TorrentInfo;
+
+describe('useTorrentActions', () => {
+  let showToast: jest.Mock;
+  let sync: jest.Mock;
+  let reconnect: jest.Mock;
+  let toggleAlternativeSpeedLimits: jest.Mock;
+  let refreshTransfer: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    showToast = jest.fn();
+    sync = jest.fn().mockResolvedValue(undefined);
+    reconnect = jest.fn().mockResolvedValue(true);
+    toggleAlternativeSpeedLimits = jest.fn().mockResolvedValue(undefined);
+    refreshTransfer = jest.fn().mockResolvedValue(undefined);
+
+    jest.mocked(useServer).mockReturnValue({
+      isConnected: true,
+      currentServer: { id: '1' },
+      reconnect,
+    } as any);
+    jest.mocked(useTorrents).mockReturnValue({ sync } as any);
+    jest.mocked(useTransfer).mockReturnValue({
+      transferInfo: { use_alt_speed_limits: false },
+      toggleAlternativeSpeedLimits,
+      refresh: refreshTransfer,
+    } as any);
+    jest.mocked(useToast).mockReturnValue({ showToast } as any);
+    jest.mocked(apiClient.getServer).mockReturnValue({ id: '1' } as any);
+  });
+
+  it('returns empty action menu items when torrent is null', async () => {
+    const { result } = await renderHook(() => useTorrentActions(null));
+    expect(result.current.actionMenuItems).toEqual([]);
+    expect(result.current.dlLimitDefaultValue).toBe('0');
+  });
+
+  it('computes dlLimitDefaultValue from dl_limit', async () => {
+    const { result } = await renderHook(() =>
+      useTorrentActions({ ...baseTorrent, dl_limit: 2048 } as TorrentInfo),
+    );
+    expect(result.current.dlLimitDefaultValue).toBe('2');
+  });
+
+  it('builds 9 action menu items for a non-paused torrent', async () => {
+    const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+    expect(result.current.actionMenuItems).toHaveLength(9);
+    expect(result.current.actionMenuItems[0].label).toBe('actions.pause');
+  });
+
+  it('shows resume label when torrent is paused', async () => {
+    const { result } = await renderHook(() =>
+      useTorrentActions({ ...baseTorrent, state: 'pausedDL' } as TorrentInfo),
+    );
+    expect(result.current.actionMenuItems[0].label).toBe('actions.resume');
+  });
+
+  describe('handlePauseResume', () => {
+    it('pauses a running torrent', async () => {
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        await result.current.handlePauseResume();
+      });
+      expect(torrentsApi.pauseTorrents).toHaveBeenCalledWith(['abc123']);
+      expect(sync).toHaveBeenCalled();
+    });
+
+    it('resumes a paused torrent', async () => {
+      const { result } = await renderHook(() =>
+        useTorrentActions({ ...baseTorrent, state: 'stoppedDL' } as TorrentInfo),
+      );
+      await act(async () => {
+        await result.current.handlePauseResume();
+      });
+      expect(torrentsApi.resumeTorrents).toHaveBeenCalledWith(['abc123']);
+    });
+
+    it('shows a toast when not connected', async () => {
+      jest.mocked(useServer).mockReturnValue({
+        isConnected: false,
+        currentServer: null,
+        reconnect,
+      } as any);
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        await result.current.handlePauseResume();
+      });
+      expect(showToast).toHaveBeenCalledWith('toast.notConnected', 'error');
+      expect(torrentsApi.pauseTorrents).not.toHaveBeenCalled();
+    });
+
+    it('reconnects when apiClient has no server bound', async () => {
+      jest.mocked(apiClient.getServer).mockReturnValue(null as any);
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        await result.current.handlePauseResume();
+      });
+      expect(reconnect).toHaveBeenCalled();
+      expect(torrentsApi.pauseTorrents).toHaveBeenCalled();
+    });
+
+    it('shows toast when reconnect fails', async () => {
+      jest.mocked(apiClient.getServer).mockReturnValue(null as any);
+      reconnect.mockResolvedValue(false);
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        await result.current.handlePauseResume();
+      });
+      expect(showToast).toHaveBeenCalledWith('toast.lostConnection', 'error');
+      expect(torrentsApi.pauseTorrents).not.toHaveBeenCalled();
+    });
+
+    it('shows an error toast on failure', async () => {
+      jest.mocked(torrentsApi.pauseTorrents).mockRejectedValue(new Error('boom'));
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        await result.current.handlePauseResume();
+      });
+      expect(showToast).toHaveBeenCalledWith('boom', 'error');
+    });
+
+    it('does nothing when torrent is null', async () => {
+      const { result } = await renderHook(() => useTorrentActions(null));
+      await act(async () => {
+        await result.current.handlePauseResume();
+      });
+      expect(torrentsApi.pauseTorrents).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handleForceStart', () => {
+    it('sets force start and syncs', async () => {
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        await result.current.handleForceStart();
+      });
+      expect(torrentsApi.setForceStart).toHaveBeenCalledWith(['abc123'], true);
+      expect(sync).toHaveBeenCalled();
+    });
+
+    it('shows generic error toast on failure', async () => {
+      jest.mocked(torrentsApi.setForceStart).mockRejectedValue(new Error('nope'));
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        await result.current.handleForceStart();
+      });
+      expect(showToast).toHaveBeenCalledWith('nope', 'error');
+    });
+  });
+
+  describe('handleVerifyData', () => {
+    it('rechecks torrent and shows success toast', async () => {
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        await result.current.handleVerifyData();
+      });
+      expect(torrentsApi.recheckTorrents).toHaveBeenCalledWith(['abc123']);
+      expect(showToast).toHaveBeenCalledWith('toast.verificationStarted', 'success');
+    });
+
+    it('shows error toast on failure', async () => {
+      jest.mocked(torrentsApi.recheckTorrents).mockRejectedValue(new Error('recheck fail'));
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        await result.current.handleVerifyData();
+      });
+      expect(showToast).toHaveBeenCalledWith('recheck fail', 'error');
+    });
+  });
+
+  describe('handleReannounce', () => {
+    it('reannounces and shows success toast', async () => {
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        await result.current.handleReannounce();
+      });
+      expect(torrentsApi.reannounceTorrents).toHaveBeenCalledWith(['abc123']);
+      expect(showToast).toHaveBeenCalledWith('toast.reannounceSent', 'success');
+    });
+
+    it('shows error toast on failure', async () => {
+      jest.mocked(torrentsApi.reannounceTorrents).mockRejectedValue(new Error('fail'));
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        await result.current.handleReannounce();
+      });
+      expect(showToast).toHaveBeenCalledWith('fail', 'error');
+    });
+  });
+
+  describe('handleCopyMagnet', () => {
+    it('copies magnet link when available', async () => {
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        await result.current.handleCopyMagnet();
+      });
+      expect(Clipboard.setStringAsync).toHaveBeenCalledWith(baseTorrent.magnet_uri);
+      expect(showToast).toHaveBeenCalledWith('toast.magnetCopied', 'success');
+    });
+
+    it('shows error toast when magnet is missing', async () => {
+      const { result } = await renderHook(() =>
+        useTorrentActions({ ...baseTorrent, magnet_uri: '' } as TorrentInfo),
+      );
+      await act(async () => {
+        await result.current.handleCopyMagnet();
+      });
+      expect(showToast).toHaveBeenCalledWith('toast.noMagnetAvailable', 'error');
+    });
+
+    it('shows error toast on clipboard failure', async () => {
+      jest.mocked(Clipboard.setStringAsync).mockRejectedValue(new Error('clip fail'));
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        await result.current.handleCopyMagnet();
+      });
+      expect(showToast).toHaveBeenCalledWith('clip fail', 'error');
+    });
+  });
+
+  describe('handleDelete', () => {
+    it('opens an Alert with delete options and handles torrent-only delete', async () => {
+      const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation((_t, _m, buttons) => {
+        const torrentOnly = buttons?.find((b) => b.text === 'alerts.torrentOnly');
+        torrentOnly?.onPress?.();
+      });
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        result.current.handleDelete();
+      });
+      expect(torrentsApi.deleteTorrents).toHaveBeenCalledWith(['abc123'], false);
+      expect(showToast).toHaveBeenCalledWith('toast.torrentDeleted', 'success');
+      alertSpy.mockRestore();
+    });
+
+    it('handles delete with files', async () => {
+      const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation((_t, _m, buttons) => {
+        const withFiles = buttons?.find((b) => b.text === 'alerts.withFiles');
+        withFiles?.onPress?.();
+      });
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        result.current.handleDelete();
+      });
+      expect(torrentsApi.deleteTorrents).toHaveBeenCalledWith(['abc123'], true);
+      alertSpy.mockRestore();
+    });
+
+    it('shows error toast when delete fails', async () => {
+      jest.mocked(torrentsApi.deleteTorrents).mockRejectedValue(new Error('del fail'));
+      const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation((_t, _m, buttons) => {
+        const torrentOnly = buttons?.find((b) => b.text === 'alerts.torrentOnly');
+        torrentOnly?.onPress?.();
+      });
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        result.current.handleDelete();
+      });
+      expect(showToast).toHaveBeenCalledWith('del fail', 'error');
+      alertSpy.mockRestore();
+    });
+
+    it('does nothing when torrent is null', async () => {
+      const alertSpy = jest.spyOn(Alert, 'alert');
+      const { result } = await renderHook(() => useTorrentActions(null));
+      result.current.handleDelete();
+      expect(alertSpy).not.toHaveBeenCalled();
+      alertSpy.mockRestore();
+    });
+  });
+
+  describe('handleMaxPriority', () => {
+    it('sets max priority and shows success toast', async () => {
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        await result.current.handleMaxPriority();
+      });
+      expect(torrentsApi.setMaximalPriority).toHaveBeenCalledWith(['abc123']);
+      expect(showToast).toHaveBeenCalledWith('toast.prioritySetMax', 'success');
+    });
+
+    it('shows error toast on failure', async () => {
+      jest.mocked(torrentsApi.setMaximalPriority).mockRejectedValue(new Error('prio fail'));
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        await result.current.handleMaxPriority();
+      });
+      expect(showToast).toHaveBeenCalledWith('prio fail', 'error');
+    });
+  });
+
+  describe('handleSetDownloadLimit', () => {
+    it('sets a positive limit in bytes and shows toast', async () => {
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        result.current.handleSetDownloadLimit('100');
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(torrentsApi.setTorrentDownloadLimit).toHaveBeenCalledWith(['abc123'], 100 * 1024);
+    });
+
+    it('treats unparsable/zero value as unlimited', async () => {
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        result.current.handleSetDownloadLimit('abc');
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(torrentsApi.setTorrentDownloadLimit).toHaveBeenCalledWith(['abc123'], 0);
+    });
+
+    it('does nothing when torrent is null', async () => {
+      const { result } = await renderHook(() => useTorrentActions(null));
+      await act(async () => {
+        result.current.handleSetDownloadLimit('100');
+      });
+      expect(torrentsApi.setTorrentDownloadLimit).not.toHaveBeenCalled();
+    });
+
+    it('shows error toast on failure', async () => {
+      jest.mocked(torrentsApi.setTorrentDownloadLimit).mockRejectedValue(new Error('limit fail'));
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        result.current.handleSetDownloadLimit('50');
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(showToast).toHaveBeenCalledWith('limit fail', 'error');
+    });
+  });
+
+  describe('handleToggleGlobalSpeedLimit', () => {
+    it('toggles and refreshes transfer info', async () => {
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        await result.current.handleToggleGlobalSpeedLimit();
+      });
+      expect(toggleAlternativeSpeedLimits).toHaveBeenCalled();
+      expect(refreshTransfer).toHaveBeenCalled();
+      expect(showToast).toHaveBeenCalled();
+    });
+
+    it('shows error toast on failure', async () => {
+      toggleAlternativeSpeedLimits.mockRejectedValue(new Error('toggle fail'));
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        await result.current.handleToggleGlobalSpeedLimit();
+      });
+      expect(showToast).toHaveBeenCalledWith('toggle fail', 'error');
+    });
+
+    it('shows toast when not connected', async () => {
+      jest.mocked(useServer).mockReturnValue({
+        isConnected: false,
+        currentServer: null,
+        reconnect,
+      } as any);
+      const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+      await act(async () => {
+        await result.current.handleToggleGlobalSpeedLimit();
+      });
+      expect(toggleAlternativeSpeedLimits).not.toHaveBeenCalled();
+    });
+  });
+
+  it('exposes dlLimitModalVisible state and setter', async () => {
+    const { result } = await renderHook(() => useTorrentActions(baseTorrent));
+    expect(result.current.dlLimitModalVisible).toBe(false);
+    await act(async () => {
+      result.current.setDlLimitModalVisible(true);
+    });
+    expect(result.current.dlLimitModalVisible).toBe(true);
+  });
+});

--- a/tests/rn/setup.ts
+++ b/tests/rn/setup.ts
@@ -1,0 +1,24 @@
+jest.mock('react-native-safe-area-context', () =>
+  require('react-native-safe-area-context/jest/mock').default,
+);
+
+jest.mock('expo-router', () => {
+  const actual = jest.requireActual('expo-router');
+  return {
+    ...actual,
+    useRouter: jest.fn(() => ({
+      push: jest.fn(),
+      replace: jest.fn(),
+      back: jest.fn(),
+      dismiss: jest.fn(),
+      dismissAll: jest.fn(),
+      canGoBack: jest.fn(() => true),
+      setParams: jest.fn(),
+    })),
+    useLocalSearchParams: jest.fn(() => ({})),
+    useSegments: jest.fn(() => []),
+    useFocusEffect: jest.fn(),
+    useNavigation: jest.fn(() => ({ setOptions: jest.fn(), addListener: jest.fn(() => jest.fn()) })),
+    Link: actual.Link,
+  };
+});

--- a/tests/services/api-test-helpers.ts
+++ b/tests/services/api-test-helpers.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared mock for the apiClient singleton, used across services/api/*.test.ts.
+ */
+export const mockApiClient = {
+  get: jest.fn(),
+  post: jest.fn(),
+  postUrlEncoded: jest.fn(),
+  postFormData: jest.fn(),
+  getApiFeatures: jest.fn(() => ({})),
+  getServer: jest.fn(),
+  setServer: jest.fn(),
+};

--- a/tests/services/application.test.ts
+++ b/tests/services/application.test.ts
@@ -1,0 +1,112 @@
+jest.mock('@/services/api/client', () => ({
+  apiClient: {
+    get: jest.fn(),
+    postUrlEncoded: jest.fn(),
+  },
+}));
+
+import { AxiosError } from 'axios';
+import { applicationApi } from '@/services/api/application';
+import { apiClient } from '@/services/api/client';
+
+const mockGet = apiClient.get as jest.Mock;
+const mockPost = apiClient.postUrlEncoded as jest.Mock;
+
+describe('applicationApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('getVersion combines version and apiVersion calls', async () => {
+    mockGet.mockResolvedValueOnce('v4.5.0').mockResolvedValueOnce('2.9.0');
+    const result = await applicationApi.getVersion();
+    expect(result).toEqual({ version: 'v4.5.0', apiVersion: '2.9.0' });
+    expect(mockGet).toHaveBeenNthCalledWith(1, '/api/v2/app/version', undefined, undefined);
+    expect(mockGet).toHaveBeenNthCalledWith(2, '/api/v2/app/webapiVersion', undefined, undefined);
+  });
+
+  it('getBuildInfo returns build info', async () => {
+    mockGet.mockResolvedValueOnce({ qt: '5.15' });
+    const result = await applicationApi.getBuildInfo();
+    expect(result).toEqual({ qt: '5.15' });
+    expect(mockGet).toHaveBeenCalledWith('/api/v2/app/buildInfo');
+  });
+
+  it('shutdown posts to shutdown endpoint', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await applicationApi.shutdown();
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/app/shutdown', {});
+  });
+
+  it('getPreferences returns preferences', async () => {
+    mockGet.mockResolvedValueOnce({ locale: 'en' });
+    const result = await applicationApi.getPreferences();
+    expect(result).toEqual({ locale: 'en' });
+  });
+
+  it('setPreferences posts JSON-encoded preferences', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await applicationApi.setPreferences({ locale: 'en' } as never);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/app/setPreferences', {
+      json: JSON.stringify({ locale: 'en' }),
+    });
+  });
+
+  it('getDefaultSavePath returns path string', async () => {
+    mockGet.mockResolvedValueOnce('/downloads');
+    const result = await applicationApi.getDefaultSavePath();
+    expect(result).toBe('/downloads');
+  });
+
+  describe('getCookies', () => {
+    it('returns cookies object on success', async () => {
+      mockGet.mockResolvedValueOnce({ 'example.com': 'a=b' });
+      const result = await applicationApi.getCookies();
+      expect(result).toEqual({ 'example.com': 'a=b' });
+    });
+
+    it('returns empty object on 404 (qBittorrent 4.x)', async () => {
+      const err = new AxiosError('Not Found');
+      err.response = { status: 404 } as never;
+      mockGet.mockRejectedValueOnce(err);
+      const result = await applicationApi.getCookies();
+      expect(result).toEqual({});
+    });
+
+    it('rethrows non-404 errors', async () => {
+      const err = new AxiosError('Server Error');
+      err.response = { status: 500 } as never;
+      mockGet.mockRejectedValueOnce(err);
+      await expect(applicationApi.getCookies()).rejects.toThrow(err);
+    });
+
+    it('rethrows non-axios errors', async () => {
+      mockGet.mockRejectedValueOnce(new Error('boom'));
+      await expect(applicationApi.getCookies()).rejects.toThrow('boom');
+    });
+  });
+
+  describe('setCookies', () => {
+    it('posts JSON-encoded cookies', async () => {
+      mockPost.mockResolvedValueOnce(undefined);
+      await applicationApi.setCookies({ 'example.com': 'a=b' });
+      expect(mockPost).toHaveBeenCalledWith('/api/v2/app/setCookies', {
+        json: JSON.stringify({ 'example.com': 'a=b' }),
+      });
+    });
+
+    it('silently swallows 404 (qBittorrent 4.x)', async () => {
+      const err = new AxiosError('Not Found');
+      err.response = { status: 404 } as never;
+      mockPost.mockRejectedValueOnce(err);
+      await expect(applicationApi.setCookies({})).resolves.toBeUndefined();
+    });
+
+    it('rethrows non-404 errors', async () => {
+      const err = new AxiosError('Server Error');
+      err.response = { status: 500 } as never;
+      mockPost.mockRejectedValueOnce(err);
+      await expect(applicationApi.setCookies({})).rejects.toThrow(err);
+    });
+  });
+});

--- a/tests/services/auth.test.ts
+++ b/tests/services/auth.test.ts
@@ -152,4 +152,45 @@ describe('authApi.login', () => {
     const postOrder = postUrlEncoded.mock.invocationCallOrder[0];
     expect(clearOrder).toBeLessThan(postOrder);
   });
+
+  it('re-throws ERR_CANCELED AxiosError instead of returning Fails', async () => {
+    const axiosErr = new AxiosError('canceled');
+    axiosErr.code = 'ERR_CANCELED';
+    postUrlEncoded.mockRejectedValue(axiosErr);
+    getCookies.mockReturnValue('');
+
+    await expect(authApi.login('admin', 'pw')).rejects.toBe(axiosErr);
+  });
+
+  it('returns Fails for a non-Error thrown value', async () => {
+    postUrlEncoded.mockRejectedValue('plain string failure');
+    getCookies.mockReturnValue('');
+
+    const result = await authApi.login('admin', 'pw');
+
+    expect(result).toEqual({ status: 'Fails' });
+  });
+});
+
+describe('authApi.logout', () => {
+  beforeEach(() => {
+    postUrlEncoded.mockReset();
+    clearCookies.mockReset();
+  });
+
+  it('posts to the logout endpoint and clears cookies', async () => {
+    postUrlEncoded.mockResolvedValue(undefined);
+
+    await authApi.logout();
+
+    expect(postUrlEncoded).toHaveBeenCalledWith('/api/v2/auth/logout', {});
+    expect(clearCookies).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates errors from postUrlEncoded and does not clear cookies', async () => {
+    postUrlEncoded.mockRejectedValue(new Error('network down'));
+
+    await expect(authApi.logout()).rejects.toThrow('network down');
+    expect(clearCookies).not.toHaveBeenCalled();
+  });
 });

--- a/tests/services/categories.test.ts
+++ b/tests/services/categories.test.ts
@@ -1,0 +1,63 @@
+jest.mock('@/services/api/client', () => ({
+  apiClient: {
+    get: jest.fn(),
+    postUrlEncoded: jest.fn(),
+  },
+}));
+
+import { categoriesApi } from '@/services/api/categories';
+import { apiClient } from '@/services/api/client';
+
+const mockGet = apiClient.get as jest.Mock;
+const mockPost = apiClient.postUrlEncoded as jest.Mock;
+
+describe('categoriesApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('getAllCategories returns the categories map', async () => {
+    mockGet.mockResolvedValueOnce({ Movies: { name: 'Movies', savePath: '/m' } });
+    const result = await categoriesApi.getAllCategories();
+    expect(result).toEqual({ Movies: { name: 'Movies', savePath: '/m' } });
+    expect(mockGet).toHaveBeenCalledWith('/api/v2/torrents/categories');
+  });
+
+  it('getAllCategories returns {} when response is falsy', async () => {
+    mockGet.mockResolvedValueOnce(null);
+    const result = await categoriesApi.getAllCategories();
+    expect(result).toEqual({});
+  });
+
+  it('addCategory without savePath', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await categoriesApi.addCategory('Movies');
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/createCategory', { category: 'Movies' });
+  });
+
+  it('addCategory with savePath', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await categoriesApi.addCategory('Movies', '/m');
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/createCategory', {
+      category: 'Movies',
+      savePath: '/m',
+    });
+  });
+
+  it('editCategory', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await categoriesApi.editCategory('Movies', '/new');
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/editCategory', {
+      category: 'Movies',
+      savePath: '/new',
+    });
+  });
+
+  it('removeCategories joins with newline', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await categoriesApi.removeCategories(['Movies', 'TV']);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/removeCategories', {
+      categories: 'Movies\nTV',
+    });
+  });
+});

--- a/tests/services/client.test.ts
+++ b/tests/services/client.test.ts
@@ -1,0 +1,487 @@
+/**
+ * Comprehensive tests for the apiClient singleton in services/api/client.ts:
+ * request/response interceptors, cookie capture, error normalization,
+ * retry logic, and the public request methods.
+ */
+
+jest.mock('@/services/connectivity-log', () => ({
+  clogDebug: jest.fn(),
+  clogInfo: jest.fn(),
+  clogWarn: jest.fn(),
+  clogError: jest.fn(),
+}));
+
+jest.mock('@/utils/apiVersion', () => ({
+  getApiFeatures: jest.fn(() => ({ mockFeature: true })),
+}));
+
+type RequestInterceptorFn = (config: Record<string, unknown>) => Record<string, unknown>;
+type RequestInterceptorErrFn = (error: unknown) => unknown;
+type ResponseInterceptorSuccessFn = (response: unknown) => unknown;
+type ResponseInterceptorErrorFn = (error: unknown) => unknown;
+
+let capturedRequestInterceptor: RequestInterceptorFn | null = null;
+let capturedRequestInterceptorErr: RequestInterceptorErrFn | null = null;
+let capturedResponseInterceptorSuccess: ResponseInterceptorSuccessFn | null = null;
+let capturedResponseInterceptorError: ResponseInterceptorErrorFn | null = null;
+
+const mockAxiosInstance = {
+  interceptors: {
+    request: {
+      use: jest.fn((fn: RequestInterceptorFn, errFn: RequestInterceptorErrFn) => {
+        capturedRequestInterceptor = fn;
+        capturedRequestInterceptorErr = errFn;
+      }),
+    },
+    response: {
+      use: jest.fn((success: ResponseInterceptorSuccessFn, error: ResponseInterceptorErrorFn) => {
+        capturedResponseInterceptorSuccess = success;
+        capturedResponseInterceptorError = error;
+      }),
+    },
+  },
+  defaults: { timeout: 10000 },
+  post: jest.fn(),
+  get: jest.fn(),
+};
+
+class MockAxiosError extends Error {
+  code?: string;
+  config?: Record<string, unknown>;
+  response?: { status?: number; data?: unknown; headers?: Record<string, unknown> };
+  isAxiosError = true;
+  constructor(message?: string) {
+    super(message);
+  }
+}
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: {
+    create: jest.fn(() => mockAxiosInstance),
+  },
+  AxiosHeaders: class {
+    private headers: Record<string, string> = {};
+    constructor(initial?: Record<string, string>) {
+      if (initial) Object.assign(this.headers, initial);
+    }
+    set(key: string, value: string) {
+      this.headers[key] = value;
+    }
+    get(key: string) {
+      return this.headers[key];
+    }
+  },
+  AxiosError: MockAxiosError,
+}));
+
+import { apiClient } from '@/services/api/client';
+import type { ServerConfig } from '@/types/api';
+
+function makeServer(overrides: Partial<ServerConfig> = {}): ServerConfig {
+  return {
+    id: 'test-server',
+    name: 'Test',
+    host: 'example.com',
+    port: 8080,
+    username: 'admin',
+    password: 'adminadmin',
+    useHttps: false,
+    bypassAuth: false,
+    ...overrides,
+  };
+}
+
+function runRequestInterceptor(config: Record<string, unknown> = { headers: {}, method: 'get', url: '/test' }) {
+  if (!capturedRequestInterceptor) throw new Error('Request interceptor not captured');
+  return capturedRequestInterceptor(config);
+}
+
+describe('apiClient', () => {
+  afterEach(() => {
+    apiClient.setServer(null);
+    jest.clearAllMocks();
+  });
+
+  describe('request interceptor', () => {
+    it('rejects when no server is configured', async () => {
+      apiClient.setServer(null);
+      const result = runRequestInterceptor();
+      await expect(result).rejects.toThrow('No server configured');
+    });
+
+    it('builds baseURL for http with no basePath', () => {
+      apiClient.setServer(makeServer({ useHttps: false, basePath: undefined }));
+      const config = runRequestInterceptor() as { baseURL: string };
+      expect(config.baseURL).toBe('http://example.com:8080');
+    });
+
+    it('builds baseURL for https', () => {
+      apiClient.setServer(makeServer({ useHttps: true }));
+      const config = runRequestInterceptor() as { baseURL: string };
+      expect(config.baseURL).toBe('https://example.com:8080');
+    });
+
+    it('strips protocol and trailing slashes/colons from host', () => {
+      apiClient.setServer(makeServer({ host: 'http://example.com/:' }));
+      const config = runRequestInterceptor() as { baseURL: string };
+      expect(config.baseURL).toBe('http://example.com:8080');
+    });
+
+    it('omits port when not provided or invalid', () => {
+      apiClient.setServer(makeServer({ port: undefined }));
+      const config = runRequestInterceptor() as { baseURL: string };
+      expect(config.baseURL).toBe('http://example.com');
+    });
+
+    it('omits port when NaN', () => {
+      apiClient.setServer(makeServer({ port: 'not-a-number' as unknown as number }));
+      const config = runRequestInterceptor() as { baseURL: string };
+      expect(config.baseURL).toBe('http://example.com');
+    });
+
+    it('normalizes basePath without leading slash', () => {
+      apiClient.setServer(makeServer({ basePath: 'qbt' }));
+      const config = runRequestInterceptor() as { baseURL: string };
+      expect(config.baseURL).toBe('http://example.com:8080/qbt');
+    });
+
+    it('treats basePath of "/" as empty', () => {
+      apiClient.setServer(makeServer({ basePath: '/' }));
+      const config = runRequestInterceptor() as { baseURL: string };
+      expect(config.baseURL).toBe('http://example.com:8080');
+    });
+
+    it('strips trailing slash from non-root basePath', () => {
+      apiClient.setServer(makeServer({ basePath: '/qbt/' }));
+      const config = runRequestInterceptor() as { baseURL: string };
+      expect(config.baseURL).toBe('http://example.com:8080/qbt');
+    });
+
+    it('sets Referer and Origin headers', () => {
+      apiClient.setServer(makeServer());
+      const config = runRequestInterceptor() as { headers: Record<string, string>; baseURL: string };
+      expect(config.headers.Referer).toBe(`${config.baseURL}/`);
+      expect(config.headers.Origin).toBe('http://example.com:8080');
+    });
+
+    it('sets Cookie header when cookies are present', () => {
+      apiClient.setServer(makeServer());
+      if (capturedResponseInterceptorSuccess) {
+        capturedResponseInterceptorSuccess({
+          headers: { 'set-cookie': 'SID=abc123; Path=/' },
+          data: 'Ok.',
+          status: 200,
+        });
+      }
+      const config = runRequestInterceptor() as { headers: Record<string, string> };
+      expect(config.headers.Cookie).toContain('SID=abc123');
+    });
+
+    it('request interceptor error handler rejects with the original error', async () => {
+      if (!capturedRequestInterceptorErr) throw new Error('not captured');
+      const err = new Error('boom');
+      await expect(capturedRequestInterceptorErr(err)).rejects.toBe(err);
+    });
+  });
+
+  describe('response interceptor — success (cookie capture)', () => {
+    beforeEach(() => {
+      apiClient.setServer(makeServer());
+    });
+
+    it('captures a single set-cookie header', () => {
+      const response = { headers: { 'set-cookie': 'SID=xyz; Path=/' }, data: 'Ok.', status: 200 };
+      const result = capturedResponseInterceptorSuccess!(response);
+      expect(result).toBe(response);
+      expect(apiClient.getCookies()).toBe('SID=xyz');
+    });
+
+    it('captures and joins an array of set-cookie headers', () => {
+      capturedResponseInterceptorSuccess!({
+        headers: { 'set-cookie': ['SID=a; Path=/', 'OTHER=b; HttpOnly'] },
+        data: '',
+        status: 200,
+      });
+      expect(apiClient.getCookies()).toBe('SID=a; OTHER=b');
+    });
+
+    it('uses Set-Cookie (capitalized) fallback', () => {
+      capturedResponseInterceptorSuccess!({ headers: { 'Set-Cookie': 'SID=cap; Path=/' }, data: '', status: 200 });
+      expect(apiClient.getCookies()).toBe('SID=cap');
+    });
+
+    it('uses headers.get() fallback when present', () => {
+      capturedResponseInterceptorSuccess!({
+        headers: { get: (key: string) => (key === 'set-cookie' ? 'SID=viaget' : null) },
+        data: '',
+        status: 200,
+      });
+      expect(apiClient.getCookies()).toBe('SID=viaget');
+    });
+
+    it('leaves cookies untouched when no set-cookie header exists', () => {
+      apiClient.clearCookies();
+      capturedResponseInterceptorSuccess!({ headers: { 'x-other': 'val' }, data: '', status: 200 });
+      expect(apiClient.getCookies()).toBe('');
+    });
+
+    it('handles missing headers object gracefully', () => {
+      apiClient.clearCookies();
+      capturedResponseInterceptorSuccess!({ data: '', status: 200 });
+      expect(apiClient.getCookies()).toBe('');
+    });
+  });
+
+  describe('response interceptor — error normalization', () => {
+    function makeErr(overrides: Partial<InstanceType<typeof MockAxiosError>> = {}) {
+      const err = new MockAxiosError('request failed');
+      Object.assign(err, { config: { baseURL: 'http://example.com', url: '/api/v2/x' } }, overrides);
+      return err;
+    }
+
+    it('normalizes 403 to auth error and clears cookies', () => {
+      apiClient.setServer(makeServer());
+      capturedResponseInterceptorSuccess!({ headers: { 'set-cookie': 'SID=abc' }, data: '', status: 200 });
+      expect(apiClient.getCookies()).not.toBe('');
+      const err = makeErr({ response: { status: 403 } });
+      expect(() => capturedResponseInterceptorError!(err)).toThrow('Authentication failed. Please check your credentials.');
+      expect(apiClient.getCookies()).toBe('');
+    });
+
+    it('normalizes 429 with retry-after header', () => {
+      const err = makeErr({ response: { status: 429, headers: { 'retry-after': '30' } } });
+      expect(() => capturedResponseInterceptorError!(err)).toThrow('Rate limited by server. Please retry after 30 seconds.');
+    });
+
+    it('normalizes 429 without retry-after header', () => {
+      const err = makeErr({ response: { status: 429, headers: {} } });
+      expect(() => capturedResponseInterceptorError!(err)).toThrow('Rate limited by server.');
+    });
+
+    it('normalizes 409 to queueing error', () => {
+      const err = makeErr({ response: { status: 409 } });
+      expect(() => capturedResponseInterceptorError!(err)).toThrow(
+        'Torrent queueing must be enabled in qBittorrent to change priorities.'
+      );
+    });
+
+    it('normalizes 404 to endpoint-not-found error', () => {
+      const err = makeErr({ response: { status: 404 } });
+      expect(() => capturedResponseInterceptorError!(err)).toThrow(/Endpoint not found/);
+    });
+
+    it('normalizes ECONNABORTED to connection timeout error', () => {
+      const err = makeErr({ code: 'ECONNABORTED' });
+      expect(() => capturedResponseInterceptorError!(err)).toThrow('Connection timeout. Please check your server connection.');
+    });
+
+    it('normalizes ERR_NETWORK to connection timeout error', () => {
+      const err = makeErr({ code: 'ERR_NETWORK' });
+      expect(() => capturedResponseInterceptorError!(err)).toThrow('Connection timeout. Please check your server connection.');
+    });
+
+    it('falls through to response data message for unknown status', () => {
+      const err = makeErr({ response: { status: 500, data: 'Internal Server Error' } });
+      expect(() => capturedResponseInterceptorError!(err)).toThrow('Internal Server Error');
+    });
+
+    it('falls back to error.message when no response data', () => {
+      const err = makeErr({ message: 'socket hang up' });
+      expect(() => capturedResponseInterceptorError!(err)).toThrow('socket hang up');
+    });
+
+    it('falls back to unknown error message when nothing else present', () => {
+      const err = makeErr({ message: '' });
+      expect(() => capturedResponseInterceptorError!(err)).toThrow('An unknown error occurred');
+    });
+  });
+
+  describe('setServer / getServer', () => {
+    it('sets and gets the current server', () => {
+      const server = makeServer();
+      apiClient.setServer(server);
+      expect(apiClient.getServer()).toBe(server);
+    });
+
+    it('clears cookies and apiVersion when switching to a different server id', () => {
+      apiClient.setServer(makeServer({ id: 'server-1' }));
+      apiClient.setApiVersion('2.8.3');
+      capturedResponseInterceptorSuccess!({ headers: { 'set-cookie': 'SID=abc' }, data: '', status: 200 });
+      expect(apiClient.getCookies()).not.toBe('');
+
+      apiClient.setServer(makeServer({ id: 'server-2' }));
+      expect(apiClient.getCookies()).toBe('');
+      expect(apiClient.getApiVersion()).toBeNull();
+    });
+
+    it('preserves cookies when re-setting the same server id', () => {
+      apiClient.setServer(makeServer({ id: 'server-1' }));
+      capturedResponseInterceptorSuccess!({ headers: { 'set-cookie': 'SID=abc' }, data: '', status: 200 });
+      expect(apiClient.getCookies()).not.toBe('');
+
+      apiClient.setServer(makeServer({ id: 'server-1', name: 'renamed' }));
+      expect(apiClient.getCookies()).not.toBe('');
+    });
+
+    it('clears cookies when setting server to null', () => {
+      apiClient.setServer(makeServer());
+      capturedResponseInterceptorSuccess!({ headers: { 'set-cookie': 'SID=abc' }, data: '', status: 200 });
+      apiClient.setServer(null);
+      expect(apiClient.getCookies()).toBe('');
+      expect(apiClient.getServer()).toBeNull();
+    });
+  });
+
+  describe('apiVersion / features', () => {
+    it('caches features until version changes', () => {
+      const { getApiFeatures } = jest.requireMock('@/utils/apiVersion') as { getApiFeatures: jest.Mock };
+      apiClient.setApiVersion('2.9.0');
+      apiClient.getApiFeatures();
+      apiClient.getApiFeatures();
+      expect(getApiFeatures).toHaveBeenCalledTimes(1);
+
+      apiClient.setApiVersion('2.9.1');
+      apiClient.getApiFeatures();
+      expect(getApiFeatures).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('updateSettings', () => {
+    it('updates connectionTimeout on the axios client defaults', () => {
+      apiClient.updateSettings({ connectionTimeout: 5000 });
+      expect(mockAxiosInstance.defaults.timeout).toBe(5000);
+    });
+
+    it('leaves timeout unchanged when connectionTimeout is undefined', () => {
+      mockAxiosInstance.defaults.timeout = 7000;
+      apiClient.updateSettings({});
+      expect(mockAxiosInstance.defaults.timeout).toBe(7000);
+    });
+
+    it('clamps retryAttempts to a minimum of 0', async () => {
+      apiClient.updateSettings({ retryAttempts: -5 });
+      apiClient.setServer(makeServer());
+      mockAxiosInstance.get.mockRejectedValueOnce(new MockAxiosError('ECONNABORTED-ish'));
+      await expect(apiClient.get('/test')).rejects.toThrow();
+      expect(mockAxiosInstance.get).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('postFormData', () => {
+    it('throws when no server is configured', async () => {
+      apiClient.setServer(null);
+      await expect(apiClient.postFormData('/upload', new FormData())).rejects.toThrow('No server configured');
+    });
+
+    it('posts with multipart headers and cookie when present', async () => {
+      apiClient.setServer(makeServer());
+      capturedResponseInterceptorSuccess!({ headers: { 'set-cookie': 'SID=abc' }, data: '', status: 200 });
+      mockAxiosInstance.post.mockResolvedValueOnce({ data: 'ok' });
+
+      const result = await apiClient.postFormData('/upload', new FormData());
+
+      expect(result).toBe('ok');
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/upload', expect.any(FormData), expect.anything());
+    });
+  });
+
+  describe('postUrlEncoded', () => {
+    it('throws when no server is configured', async () => {
+      apiClient.setServer(null);
+      await expect(apiClient.postUrlEncoded('/auth/login', { a: 1 })).rejects.toThrow(
+        'No server configured. Please connect to a server first.'
+      );
+    });
+
+    it('encodes data and skips undefined/null values', async () => {
+      apiClient.setServer(makeServer());
+      mockAxiosInstance.post.mockResolvedValueOnce({ data: 'Ok.' });
+
+      const result = await apiClient.postUrlEncoded('/auth/login', {
+        username: 'admin',
+        password: 'p@ss word',
+        skip1: undefined as unknown as string,
+        skip2: null as unknown as string,
+      });
+
+      expect(result).toBe('Ok.');
+      const [, body] = mockAxiosInstance.post.mock.calls[0];
+      expect(body).toBe('username=admin&password=p%40ss%20word');
+    });
+  });
+
+  describe('get', () => {
+    it('throws when no server is configured', async () => {
+      apiClient.setServer(null);
+      await expect(apiClient.get('/torrents/info')).rejects.toThrow('No server configured');
+    });
+
+    it('returns data on success', async () => {
+      apiClient.setServer(makeServer());
+      mockAxiosInstance.get.mockResolvedValueOnce({ data: [{ hash: 'a' }] });
+      const result = await apiClient.get('/torrents/info');
+      expect(result).toEqual([{ hash: 'a' }]);
+    });
+
+    it('retries a retriable error and eventually succeeds', async () => {
+      apiClient.setServer(makeServer());
+      apiClient.updateSettings({ retryAttempts: 2 });
+      const timeoutErr = new MockAxiosError('timeout of 10000ms exceeded');
+      timeoutErr.code = 'ECONNABORTED';
+      mockAxiosInstance.get
+        .mockRejectedValueOnce(timeoutErr)
+        .mockResolvedValueOnce({ data: 'ok' });
+
+      const result = await apiClient.get('/torrents/info');
+
+      expect(result).toBe('ok');
+      expect(mockAxiosInstance.get).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not retry a non-retriable error', async () => {
+      apiClient.setServer(makeServer());
+      apiClient.updateSettings({ retryAttempts: 3 });
+      mockAxiosInstance.get.mockRejectedValueOnce(new Error('Authentication failed. Please check your credentials.'));
+
+      await expect(apiClient.get('/torrents/info')).rejects.toThrow('Authentication failed');
+      expect(mockAxiosInstance.get).toHaveBeenCalledTimes(1);
+    });
+
+    it('exhausts retries and throws the last error', async () => {
+      apiClient.setServer(makeServer());
+      apiClient.updateSettings({ retryAttempts: 1 });
+      const timeoutErr = new MockAxiosError('ETIMEDOUT');
+      timeoutErr.code = 'ETIMEDOUT';
+      mockAxiosInstance.get.mockRejectedValue(timeoutErr);
+
+      await expect(apiClient.get('/torrents/info')).rejects.toBe(timeoutErr);
+      expect(mockAxiosInstance.get).toHaveBeenCalledTimes(2);
+    });
+
+    it('treats a plain Error with "timeout" in message as retriable', async () => {
+      apiClient.setServer(makeServer());
+      apiClient.updateSettings({ retryAttempts: 1 });
+      mockAxiosInstance.get
+        .mockRejectedValueOnce(new Error('Request timeout occurred'))
+        .mockResolvedValueOnce({ data: 'ok' });
+
+      const result = await apiClient.get('/torrents/info');
+      expect(result).toBe('ok');
+    });
+  });
+
+  describe('post', () => {
+    it('throws when no server is configured', async () => {
+      apiClient.setServer(null);
+      await expect(apiClient.post('/torrents/pause')).rejects.toThrow('No server configured');
+    });
+
+    it('returns data on success', async () => {
+      apiClient.setServer(makeServer());
+      mockAxiosInstance.post.mockResolvedValueOnce({ data: 'ok' });
+      const result = await apiClient.post('/torrents/pause', { hashes: 'all' });
+      expect(result).toBe('ok');
+    });
+  });
+});

--- a/tests/services/color-theme-manager.test.ts
+++ b/tests/services/color-theme-manager.test.ts
@@ -6,6 +6,162 @@ jest.mock('@/services/storage', () => ({
 }));
 
 import { colorThemeManager, ColorTheme } from '@/services/color-theme-manager';
+import { storageService } from '@/services/storage';
+
+const getPreferences = storageService.getPreferences as jest.Mock;
+const savePreferences = storageService.savePreferences as jest.Mock;
+
+describe('getCustomColors', () => {
+  beforeEach(() => {
+    getPreferences.mockReset();
+    savePreferences.mockReset();
+  });
+
+  it('returns dark colors when isDark is true', async () => {
+    getPreferences.mockResolvedValue({
+      customColors: { dark: { primary: '#111111' }, light: { primary: '#eeeeee' } },
+    });
+    const result = await colorThemeManager.getCustomColors(true);
+    expect(result).toEqual({ primary: '#111111' });
+  });
+
+  it('returns light colors when isDark is false', async () => {
+    getPreferences.mockResolvedValue({
+      customColors: { dark: { primary: '#111111' }, light: { primary: '#eeeeee' } },
+    });
+    const result = await colorThemeManager.getCustomColors(false);
+    expect(result).toEqual({ primary: '#eeeeee' });
+  });
+
+  it('returns null when no custom colors are stored', async () => {
+    getPreferences.mockResolvedValue({});
+    const result = await colorThemeManager.getCustomColors(true);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when getPreferences throws', async () => {
+    getPreferences.mockRejectedValue(new Error('storage failure'));
+    const result = await colorThemeManager.getCustomColors(true);
+    expect(result).toBeNull();
+  });
+});
+
+describe('saveCustomColors', () => {
+  beforeEach(() => {
+    getPreferences.mockReset();
+    savePreferences.mockReset();
+  });
+
+  it('saves colors under the correct theme key, preserving other theme', async () => {
+    getPreferences.mockResolvedValue({
+      customColors: { light: { primary: '#eeeeee' } },
+      otherPref: 'x',
+    });
+    savePreferences.mockResolvedValue(undefined);
+
+    await colorThemeManager.saveCustomColors(true, { primary: '#123456' });
+
+    expect(savePreferences).toHaveBeenCalledWith({
+      otherPref: 'x',
+      customColors: {
+        light: { primary: '#eeeeee' },
+        dark: { primary: '#123456' },
+      },
+    });
+  });
+
+  it('creates customColors object when none exists', async () => {
+    getPreferences.mockResolvedValue({});
+    savePreferences.mockResolvedValue(undefined);
+
+    await colorThemeManager.saveCustomColors(false, { primary: '#abcdef' });
+
+    expect(savePreferences).toHaveBeenCalledWith({
+      customColors: { light: { primary: '#abcdef' } },
+    });
+  });
+
+  it('rethrows when savePreferences fails', async () => {
+    getPreferences.mockResolvedValue({});
+    savePreferences.mockRejectedValue(new Error('save failed'));
+
+    await expect(colorThemeManager.saveCustomColors(true, {})).rejects.toThrow('save failed');
+  });
+});
+
+describe('resetCustomColors', () => {
+  beforeEach(() => {
+    getPreferences.mockReset();
+    savePreferences.mockReset();
+  });
+
+  it('deletes only the specified theme key', async () => {
+    getPreferences.mockResolvedValue({
+      customColors: { dark: { primary: '#111' }, light: { primary: '#eee' } },
+    });
+    savePreferences.mockResolvedValue(undefined);
+
+    await colorThemeManager.resetCustomColors(true);
+
+    expect(savePreferences).toHaveBeenCalledWith({
+      customColors: { light: { primary: '#eee' } },
+    });
+  });
+
+  it('rethrows when savePreferences fails', async () => {
+    getPreferences.mockResolvedValue({ customColors: {} });
+    savePreferences.mockRejectedValue(new Error('save failed'));
+
+    await expect(colorThemeManager.resetCustomColors(false)).rejects.toThrow('save failed');
+  });
+});
+
+describe('resetTorrentStateColors', () => {
+  beforeEach(() => {
+    getPreferences.mockReset();
+    savePreferences.mockReset();
+  });
+
+  it('does nothing when no custom colors exist for the theme', async () => {
+    getPreferences.mockResolvedValue({});
+    await colorThemeManager.resetTorrentStateColors(true);
+    expect(savePreferences).not.toHaveBeenCalled();
+  });
+
+  it('removes only torrent state color keys, keeps advanced colors', async () => {
+    getPreferences.mockResolvedValue({
+      customColors: {
+        dark: {
+          primary: '#123456',
+          stateDownloading: '#00ff00',
+          stateSeeding: '#0000ff',
+        },
+      },
+    });
+    savePreferences.mockResolvedValue(undefined);
+
+    await colorThemeManager.resetTorrentStateColors(true);
+
+    expect(savePreferences).toHaveBeenCalledWith({
+      customColors: {
+        dark: { primary: '#123456' },
+      },
+    });
+  });
+
+  it('rethrows when an error occurs during save', async () => {
+    getPreferences.mockResolvedValueOnce({
+      customColors: { dark: { stateDownloading: '#fff' } },
+    });
+    // second getPreferences call happens inside saveCustomColors via getCustomColors->resetTorrentStateColors flow
+    getPreferences.mockResolvedValueOnce({
+      customColors: { dark: { stateDownloading: '#fff' } },
+    });
+    savePreferences.mockRejectedValue(new Error('boom'));
+
+    await expect(colorThemeManager.resetTorrentStateColors(true)).rejects.toThrow('boom');
+  });
+});
 
 describe('mergeColors', () => {
   const defaults: ColorTheme = {

--- a/tests/services/connectivity-log.test.ts
+++ b/tests/services/connectivity-log.test.ts
@@ -1,0 +1,87 @@
+import {
+  clog,
+  clogDebug,
+  clogInfo,
+  clogWarn,
+  clogError,
+  getConnectivityLog,
+  clearConnectivityLog,
+  formatConnectivityLog,
+  setDebugMode,
+} from '@/services/connectivity-log';
+
+describe('connectivity-log', () => {
+  beforeEach(() => {
+    clearConnectivityLog();
+    setDebugMode(false);
+  });
+
+  it('formatConnectivityLog returns a placeholder message when empty', () => {
+    expect(formatConnectivityLog()).toBe('(no connectivity log entries captured this session)');
+  });
+
+  it('clogInfo/Warn/Error add entries regardless of debug mode', () => {
+    clogInfo('TAG', 'info msg');
+    clogWarn('TAG', 'warn msg');
+    clogError('TAG', 'error msg');
+    const entries = getConnectivityLog();
+    expect(entries).toHaveLength(3);
+    expect(entries.map((e) => e.level)).toEqual(['INFO', 'WARN', 'ERROR']);
+  });
+
+  it('clogDebug is dropped when debug mode disabled', () => {
+    clogDebug('TAG', 'debug msg');
+    expect(getConnectivityLog()).toHaveLength(0);
+  });
+
+  it('clogDebug is captured when debug mode enabled', () => {
+    setDebugMode(true);
+    clogDebug('TAG', 'debug msg');
+    expect(getConnectivityLog()).toHaveLength(1);
+  });
+
+  it('assigns incrementing ids', () => {
+    clogInfo('TAG', 'first');
+    clogInfo('TAG', 'second');
+    const entries = getConnectivityLog();
+    expect(entries[1].id).toBe(entries[0].id + 1);
+  });
+
+  it('getConnectivityLog returns a copy, not a live reference', () => {
+    clogInfo('TAG', 'msg');
+    const entries = getConnectivityLog();
+    entries.push({ id: 999, timestamp: 0, level: 'INFO', tag: 'X', message: 'injected' });
+    expect(getConnectivityLog()).toHaveLength(1);
+  });
+
+  it('clearConnectivityLog resets entries and id counter', () => {
+    clogInfo('TAG', 'msg');
+    clearConnectivityLog();
+    expect(getConnectivityLog()).toHaveLength(0);
+    clogInfo('TAG', 'again');
+    expect(getConnectivityLog()[0].id).toBe(1);
+  });
+
+  it('trims oldest entries beyond MAX_ENTRIES (500)', () => {
+    for (let i = 0; i < 505; i++) {
+      clog('INFO', 'TAG', `msg ${i}`);
+    }
+    const entries = getConnectivityLog();
+    expect(entries).toHaveLength(500);
+    expect(entries[0].message).toBe('msg 5');
+    expect(entries[499].message).toBe('msg 504');
+  });
+
+  it('formatConnectivityLog formats entries with timestamp/level/tag/message', () => {
+    clogInfo('AUTH', 'logged in');
+    const formatted = formatConnectivityLog();
+    expect(formatted).toMatch(/\[INFO\] \[AUTH\] logged in/);
+  });
+
+  it('formatConnectivityLog joins multiple entries with newlines', () => {
+    clogInfo('A', 'one');
+    clogWarn('B', 'two');
+    const formatted = formatConnectivityLog();
+    expect(formatted.split('\n')).toHaveLength(2);
+  });
+});

--- a/tests/services/log-storage.test.ts
+++ b/tests/services/log-storage.test.ts
@@ -1,0 +1,151 @@
+const mockAsyncStorage: Record<string, string> = {};
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn((key: string, value: string) => {
+    mockAsyncStorage[key] = value;
+    return Promise.resolve();
+  }),
+  getItem: jest.fn((key: string) => Promise.resolve(mockAsyncStorage[key] ?? null)),
+  removeItem: jest.fn((key: string) => {
+    delete mockAsyncStorage[key];
+    return Promise.resolve();
+  }),
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { logStorage } from '@/services/log-storage';
+
+describe('logStorage', () => {
+  beforeEach(() => {
+    Object.keys(mockAsyncStorage).forEach((k) => delete mockAsyncStorage[k]);
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  const sampleLogs = [{ id: 1, message: 'hello', timestamp: 100, type: 1 }];
+
+  describe('storeLogs / getLogs', () => {
+    it('stores and retrieves logs with storedAt added', async () => {
+      await logStorage.storeLogs(sampleLogs);
+      const logs = await logStorage.getLogs();
+      expect(logs).toHaveLength(1);
+      expect(logs[0].message).toBe('hello');
+      expect(typeof logs[0].storedAt).toBe('number');
+    });
+
+    it('getLogs returns [] when nothing stored', async () => {
+      const logs = await logStorage.getLogs();
+      expect(logs).toEqual([]);
+    });
+
+    it('getLogs returns [] and logs error on AsyncStorage failure', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const logs = await logStorage.getLogs();
+      expect(logs).toEqual([]);
+      consoleSpy.mockRestore();
+    });
+
+    it('storeLogs logs error and does not throw on failure', async () => {
+      (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      await expect(logStorage.storeLogs(sampleLogs)).resolves.toBeUndefined();
+      consoleSpy.mockRestore();
+    });
+
+    it('auto-deletes logs older than 5 minutes', async () => {
+      await logStorage.storeLogs(sampleLogs);
+      // Manually rewrite the timestamp key to be > 5 minutes old
+      const oldTimestamp = Date.now() - 6 * 60 * 1000;
+      mockAsyncStorage['app_logs_timestamp'] = oldTimestamp.toString();
+      const logs = await logStorage.getLogs();
+      expect(logs).toEqual([]);
+      expect(mockAsyncStorage['app_logs']).toBeUndefined();
+    });
+
+    it('keeps logs when within 5 minute window', async () => {
+      await logStorage.storeLogs(sampleLogs);
+      const logs = await logStorage.getLogs();
+      expect(logs).toHaveLength(1);
+    });
+  });
+
+  describe('clearLogs', () => {
+    it('removes both storage keys', async () => {
+      await logStorage.storeLogs(sampleLogs);
+      await logStorage.clearLogs();
+      expect(mockAsyncStorage['app_logs']).toBeUndefined();
+      expect(mockAsyncStorage['app_logs_timestamp']).toBeUndefined();
+    });
+
+    it('rethrows on failure', async () => {
+      (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      await expect(logStorage.clearLogs()).rejects.toThrow('fail');
+      consoleSpy.mockRestore();
+    });
+
+    it('retries removal if logs remain after first attempt', async () => {
+      await logStorage.storeLogs(sampleLogs);
+      // Simulate remainingLogs check returning a value once, forcing retry path
+      const originalGetItem = AsyncStorage.getItem as jest.Mock;
+      originalGetItem.mockImplementationOnce((key: string) => Promise.resolve(mockAsyncStorage[key] ?? null)); // check call
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      await logStorage.clearLogs();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('autoDeleteIfNeeded', () => {
+    it('does nothing when no timestamp stored', async () => {
+      await logStorage.autoDeleteIfNeeded();
+      expect(mockAsyncStorage['app_logs']).toBeUndefined();
+    });
+
+    it('clears logs when timestamp is stale', async () => {
+      await logStorage.storeLogs(sampleLogs);
+      mockAsyncStorage['app_logs_timestamp'] = (Date.now() - 6 * 60 * 1000).toString();
+      await logStorage.autoDeleteIfNeeded();
+      expect(mockAsyncStorage['app_logs']).toBeUndefined();
+    });
+
+    it('keeps logs when timestamp is fresh', async () => {
+      await logStorage.storeLogs(sampleLogs);
+      await logStorage.autoDeleteIfNeeded();
+      expect(mockAsyncStorage['app_logs']).toBeDefined();
+    });
+
+    it('logs error and does not throw on failure', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      await expect(logStorage.autoDeleteIfNeeded()).resolves.toBeUndefined();
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('setupAutoDeleteTimer', () => {
+    it('clears logs after the timeout fires, and cleanup cancels it', async () => {
+      jest.useFakeTimers();
+      await logStorage.storeLogs(sampleLogs);
+      const cleanup = logStorage.setupAutoDeleteTimer();
+      jest.advanceTimersByTime(5 * 60 * 1000);
+      // allow the async clearLogs() inside the timer callback to resolve
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockAsyncStorage['app_logs']).toBeUndefined();
+      cleanup();
+      jest.useRealTimers();
+    });
+
+    it('cleanup function cancels the timer before it fires', async () => {
+      jest.useFakeTimers();
+      await logStorage.storeLogs(sampleLogs);
+      const cleanup = logStorage.setupAutoDeleteTimer();
+      cleanup();
+      jest.advanceTimersByTime(5 * 60 * 1000);
+      await Promise.resolve();
+      expect(mockAsyncStorage['app_logs']).toBeDefined();
+      jest.useRealTimers();
+    });
+  });
+});

--- a/tests/services/logs.test.ts
+++ b/tests/services/logs.test.ts
@@ -1,0 +1,87 @@
+jest.mock('@/services/api/client', () => ({
+  apiClient: {
+    get: jest.fn(),
+  },
+}));
+
+import { logsApi } from '@/services/api/logs';
+import { apiClient } from '@/services/api/client';
+
+const mockGet = apiClient.get as jest.Mock;
+
+describe('logsApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getLog', () => {
+    it('uses default params and returns array response', async () => {
+      mockGet.mockResolvedValueOnce([{ id: 1, message: 'hi', timestamp: 1, type: 1 }]);
+      const result = await logsApi.getLog();
+      expect(result).toEqual([{ id: 1, message: 'hi', timestamp: 1, type: 1 }]);
+      expect(mockGet).toHaveBeenCalledWith('/api/v2/log/main', {
+        normal: 1,
+        info: 1,
+        warning: 1,
+        critical: 1,
+      });
+    });
+
+    it('encodes false flags as 0 and includes last_known_id', async () => {
+      mockGet.mockResolvedValueOnce([]);
+      await logsApi.getLog(false, false, false, false, 5);
+      expect(mockGet).toHaveBeenCalledWith('/api/v2/log/main', {
+        normal: 0,
+        info: 0,
+        warning: 0,
+        critical: 0,
+        last_known_id: 5,
+      });
+    });
+
+    it('extracts .data when response is a wrapped object', async () => {
+      mockGet.mockResolvedValueOnce({ data: [{ id: 2 }] });
+      const result = await logsApi.getLog();
+      expect(result).toEqual([{ id: 2 }]);
+    });
+
+    it('returns [] for unrecognized response shape', async () => {
+      mockGet.mockResolvedValueOnce({ foo: 'bar' });
+      const result = await logsApi.getLog();
+      expect(result).toEqual([]);
+    });
+
+    it('returns [] for null response', async () => {
+      mockGet.mockResolvedValueOnce(null);
+      const result = await logsApi.getLog();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getPeerLog', () => {
+    it('omits last_known_id when undefined', async () => {
+      mockGet.mockResolvedValueOnce([{ ip: '1.2.3.4' }]);
+      const result = await logsApi.getPeerLog();
+      expect(result).toEqual([{ ip: '1.2.3.4' }]);
+      expect(mockGet).toHaveBeenCalledWith('/api/v2/log/peers', {});
+    });
+
+    it('includes last_known_id when provided', async () => {
+      mockGet.mockResolvedValueOnce([]);
+      await logsApi.getPeerLog(10);
+      expect(mockGet).toHaveBeenCalledWith('/api/v2/log/peers', { last_known_id: 10 });
+    });
+
+    it('extracts .data when response is a wrapped object', async () => {
+      mockGet.mockResolvedValueOnce({ data: [{ ip: '1.1.1.1' }] });
+      const result = await logsApi.getPeerLog();
+      expect(result).toEqual([{ ip: '1.1.1.1' }]);
+    });
+
+    it('returns [] for unrecognized response shape', async () => {
+      mockGet.mockResolvedValueOnce(42);
+      const result = await logsApi.getPeerLog();
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/tests/services/query-client.test.ts
+++ b/tests/services/query-client.test.ts
@@ -1,0 +1,15 @@
+import { QueryClient } from '@tanstack/react-query';
+import { queryClient } from '@/services/query-client';
+
+describe('queryClient', () => {
+  it('exports a configured QueryClient instance', () => {
+    expect(queryClient).toBeInstanceOf(QueryClient);
+  });
+
+  it('is configured with the expected default query options', () => {
+    const defaults = queryClient.getDefaultOptions();
+    expect(defaults.queries?.retry).toBe(2);
+    expect(defaults.queries?.staleTime).toBe(2000);
+    expect(defaults.queries?.refetchOnWindowFocus).toBe(false);
+  });
+});

--- a/tests/services/search.test.ts
+++ b/tests/services/search.test.ts
@@ -1,0 +1,139 @@
+jest.mock('@/services/api/client', () => ({
+  apiClient: {
+    get: jest.fn(),
+    postUrlEncoded: jest.fn(),
+  },
+}));
+
+import { searchApi } from '@/services/api/search';
+import { apiClient } from '@/services/api/client';
+
+const mockGet = apiClient.get as jest.Mock;
+const mockPost = apiClient.postUrlEncoded as jest.Mock;
+
+describe('searchApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('start joins array plugins with pipe', async () => {
+    mockPost.mockResolvedValueOnce({ id: 1 });
+    const result = await searchApi.start('ubuntu', ['plugin1', 'plugin2'], 'all');
+    expect(result).toEqual({ id: 1 });
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/search/start', {
+      pattern: 'ubuntu',
+      plugins: 'plugin1|plugin2',
+      category: 'all',
+    });
+  });
+
+  it('start passes through string plugins unchanged', async () => {
+    mockPost.mockResolvedValueOnce({ id: 2 });
+    await searchApi.start('ubuntu', 'enabled', 'all');
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/search/start', {
+      pattern: 'ubuntu',
+      plugins: 'enabled',
+      category: 'all',
+    });
+  });
+
+  it('stop posts id', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await searchApi.stop(1);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/search/stop', { id: 1 });
+  });
+
+  it('getStatus with id', async () => {
+    mockGet.mockResolvedValueOnce([{ id: 1, status: 'Running' }]);
+    const result = await searchApi.getStatus(1);
+    expect(result).toEqual([{ id: 1, status: 'Running' }]);
+    expect(mockGet).toHaveBeenCalledWith('/api/v2/search/status', { id: 1 });
+  });
+
+  it('getStatus without id', async () => {
+    mockGet.mockResolvedValueOnce([]);
+    await searchApi.getStatus();
+    expect(mockGet).toHaveBeenCalledWith('/api/v2/search/status', {});
+  });
+
+  it('getStatus returns [] for non-array response', async () => {
+    mockGet.mockResolvedValueOnce(null);
+    const result = await searchApi.getStatus();
+    expect(result).toEqual([]);
+  });
+
+  it('getResults with limit and offset', async () => {
+    mockGet.mockResolvedValueOnce({ results: [], status: 'Running', total: 0 });
+    await searchApi.getResults(1, 10, 20);
+    expect(mockGet).toHaveBeenCalledWith('/api/v2/search/results', { id: 1, limit: 10, offset: 20 });
+  });
+
+  it('getResults without limit/offset', async () => {
+    mockGet.mockResolvedValueOnce({ results: [], status: 'Running', total: 0 });
+    await searchApi.getResults(1);
+    expect(mockGet).toHaveBeenCalledWith('/api/v2/search/results', { id: 1 });
+  });
+
+  it('deleteSearch posts id', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await searchApi.deleteSearch(1);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/search/delete', { id: 1 });
+  });
+
+  it('getPlugins returns array response', async () => {
+    mockGet.mockResolvedValueOnce([{ name: 'plugin1' }]);
+    const result = await searchApi.getPlugins();
+    expect(result).toEqual([{ name: 'plugin1' }]);
+  });
+
+  it('getPlugins returns [] for non-array response', async () => {
+    mockGet.mockResolvedValueOnce(undefined);
+    const result = await searchApi.getPlugins();
+    expect(result).toEqual([]);
+  });
+
+  it('installPlugin with array sources', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await searchApi.installPlugin(['url1', 'url2']);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/search/installPlugin', { sources: 'url1|url2' });
+  });
+
+  it('installPlugin with string source', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await searchApi.installPlugin('url1');
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/search/installPlugin', { sources: 'url1' });
+  });
+
+  it('uninstallPlugin with array names', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await searchApi.uninstallPlugin(['a', 'b']);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/search/uninstallPlugin', { names: 'a|b' });
+  });
+
+  it('enablePlugin true', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await searchApi.enablePlugin(['a'], true);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/search/enablePlugin', { names: 'a', enable: 'true' });
+  });
+
+  it('enablePlugin false', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await searchApi.enablePlugin('a', false);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/search/enablePlugin', { names: 'a', enable: 'false' });
+  });
+
+  it('updatePlugins', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await searchApi.updatePlugins();
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/search/updatePlugins', {});
+  });
+
+  it('downloadTorrent', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await searchApi.downloadTorrent('magnet:?xt=urn', 'plugin1');
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/search/downloadTorrent', {
+      torrentUrl: 'magnet:?xt=urn',
+      pluginName: 'plugin1',
+    });
+  });
+});

--- a/tests/services/server-manager.test.ts
+++ b/tests/services/server-manager.test.ts
@@ -1,0 +1,373 @@
+jest.mock('@/services/storage', () => ({
+  storageService: {
+    saveServer: jest.fn(),
+    getServers: jest.fn(),
+    getServer: jest.fn(),
+    deleteServer: jest.fn(),
+    setCurrentServerId: jest.fn(),
+    getCurrentServerId: jest.fn(),
+    getCurrentServer: jest.fn(),
+  },
+}));
+
+jest.mock('@/services/api/client', () => ({
+  apiClient: {
+    getServer: jest.fn(),
+    setServer: jest.fn(),
+    setApiVersion: jest.fn(),
+  },
+}));
+
+jest.mock('@/services/api/auth', () => ({
+  authApi: {
+    login: jest.fn(),
+    logout: jest.fn(),
+  },
+}));
+
+jest.mock('@/services/api/application', () => ({
+  applicationApi: {
+    getVersion: jest.fn(),
+  },
+}));
+
+jest.mock('@/services/connectivity-log', () => ({
+  clogInfo: jest.fn(),
+  clogWarn: jest.fn(),
+  clogError: jest.fn(),
+}));
+
+import { AxiosError } from 'axios';
+import { ServerManager, isNetworkError } from '@/services/server-manager';
+import { storageService } from '@/services/storage';
+import { apiClient } from '@/services/api/client';
+import { authApi } from '@/services/api/auth';
+import { applicationApi } from '@/services/api/application';
+import type { ServerConfig } from '@/types/api';
+
+const mockStorage = storageService as jest.Mocked<typeof storageService>;
+const mockApiClient = apiClient as jest.Mocked<typeof apiClient>;
+const mockAuth = authApi as jest.Mocked<typeof authApi>;
+const mockApp = applicationApi as jest.Mocked<typeof applicationApi>;
+
+function makeServer(overrides: Partial<ServerConfig> = {}): ServerConfig {
+  return {
+    id: 's1',
+    name: 'Test',
+    host: 'example.com',
+    port: 8080,
+    username: 'admin',
+    password: 'secret',
+    useHttps: false,
+    bypassAuth: false,
+    ...overrides,
+  };
+}
+
+describe('isNetworkError', () => {
+  it('returns true for ECONNABORTED axios errors', () => {
+    const err = new AxiosError('timeout');
+    err.code = 'ECONNABORTED';
+    expect(isNetworkError(err)).toBe(true);
+  });
+
+  it('returns true for 5xx axios errors', () => {
+    const err = new AxiosError('server error');
+    err.response = { status: 503 } as never;
+    expect(isNetworkError(err)).toBe(true);
+  });
+
+  it('returns false for 4xx axios errors without network-ish message', () => {
+    const err = new AxiosError('bad request');
+    err.response = { status: 400 } as never;
+    expect(isNetworkError(err)).toBe(false);
+  });
+
+  it('returns true for a plain Error with "Network" in message', () => {
+    expect(isNetworkError(new Error('Network request failed'))).toBe(true);
+  });
+
+  it('returns false for a plain Error unrelated to network', () => {
+    expect(isNetworkError(new Error('Authentication failed'))).toBe(false);
+  });
+
+  it('returns false for non-error values', () => {
+    expect(isNetworkError('a string')).toBe(false);
+    expect(isNetworkError(null)).toBe(false);
+  });
+});
+
+describe('ServerManager', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('saveServer / getServers / getServer', () => {
+    it('delegates to storageService', async () => {
+      const server = makeServer();
+      await ServerManager.saveServer(server);
+      expect(mockStorage.saveServer).toHaveBeenCalledWith(server);
+
+      mockStorage.getServers.mockResolvedValueOnce([server]);
+      expect(await ServerManager.getServers()).toEqual([server]);
+
+      mockStorage.getServer.mockResolvedValueOnce(server);
+      expect(await ServerManager.getServer('s1')).toEqual(server);
+    });
+  });
+
+  describe('deleteServer', () => {
+    it('clears the api client when deleting the currently-connected server', async () => {
+      mockApiClient.getServer.mockReturnValue(makeServer());
+      await ServerManager.deleteServer('s1');
+      expect(mockApiClient.setServer).toHaveBeenCalledWith(null);
+      expect(mockStorage.setCurrentServerId).toHaveBeenCalledWith(null);
+      expect(mockStorage.deleteServer).toHaveBeenCalledWith('s1');
+    });
+
+    it('does not touch the api client when deleting a different server', async () => {
+      mockApiClient.getServer.mockReturnValue(makeServer({ id: 'other' }));
+      await ServerManager.deleteServer('s1');
+      expect(mockApiClient.setServer).not.toHaveBeenCalled();
+      expect(mockStorage.deleteServer).toHaveBeenCalledWith('s1');
+    });
+  });
+
+  describe('connectToServer (primary only, no fallback)', () => {
+    it('succeeds via authenticated login', async () => {
+      mockAuth.login.mockResolvedValueOnce({ status: 'Ok' });
+      mockApp.getVersion.mockResolvedValueOnce({ version: '4.5', apiVersion: '2.9' });
+      const result = await ServerManager.connectToServer(makeServer());
+      expect(result).toBe(true);
+      expect(mockStorage.setCurrentServerId).toHaveBeenCalledWith('s1');
+      expect(mockApiClient.setApiVersion).toHaveBeenCalledWith('2.9');
+    });
+
+    it('succeeds via bypassAuth without calling login', async () => {
+      mockApp.getVersion.mockResolvedValueOnce({ version: '4.5', apiVersion: '2.9' });
+      const result = await ServerManager.connectToServer(makeServer({ bypassAuth: true }));
+      expect(result).toBe(true);
+      expect(mockAuth.login).not.toHaveBeenCalled();
+    });
+
+    it('returns false when login Fails', async () => {
+      mockAuth.login.mockResolvedValueOnce({ status: 'Fails' });
+      const result = await ServerManager.connectToServer(makeServer());
+      expect(result).toBe(false);
+      expect(mockApiClient.setServer).toHaveBeenLastCalledWith(null);
+    });
+
+    it('throws a friendly auth error on 403 after login succeeds but version check fails', async () => {
+      mockAuth.login.mockResolvedValueOnce({ status: 'Ok' });
+      const err = new AxiosError('forbidden');
+      err.response = { status: 403 } as never;
+      mockApp.getVersion.mockRejectedValueOnce(err);
+      await expect(ServerManager.connectToServer(makeServer())).rejects.toThrow('Authentication failed');
+    });
+
+    it('rethrows network errors from the post-login version check', async () => {
+      mockAuth.login.mockResolvedValueOnce({ status: 'Ok' });
+      const err = new AxiosError('timeout');
+      err.code = 'ECONNABORTED';
+      mockApp.getVersion.mockRejectedValueOnce(err);
+      await expect(ServerManager.connectToServer(makeServer())).rejects.toThrow();
+    });
+
+    it('throws generic error for unrecognized post-login failure', async () => {
+      mockAuth.login.mockResolvedValueOnce({ status: 'Ok' });
+      mockApp.getVersion.mockRejectedValueOnce(new Error('weird failure'));
+      await expect(ServerManager.connectToServer(makeServer())).rejects.toThrow('Failed to connect to server');
+    });
+
+    it('propagates a network error from bypassAuth version check', async () => {
+      const err = new AxiosError('timeout');
+      err.code = 'ERR_NETWORK';
+      mockApp.getVersion.mockRejectedValueOnce(err);
+      await expect(ServerManager.connectToServer(makeServer({ bypassAuth: true }))).rejects.toThrow();
+    });
+
+    it('throws generic error for non-network bypassAuth failure', async () => {
+      mockApp.getVersion.mockRejectedValueOnce(new Error('boom'));
+      await expect(ServerManager.connectToServer(makeServer({ bypassAuth: true }))).rejects.toThrow(
+        'Failed to connect to server'
+      );
+    });
+  });
+
+  describe('connectToServer (with fallback)', () => {
+    const serverWithFallback = makeServer({
+      useFallback: true,
+      fallbackHost: 'fallback.example.com',
+      fallbackPort: 9090,
+    });
+
+    it('falls back when primary fails with a network error', async () => {
+      const netErr = new AxiosError('timeout');
+      netErr.code = 'ECONNABORTED';
+      mockAuth.login.mockRejectedValueOnce(netErr);
+      mockAuth.login.mockResolvedValueOnce({ status: 'Ok' });
+      mockApp.getVersion.mockResolvedValueOnce({ version: '4.5', apiVersion: '2.9' });
+
+      const result = await ServerManager.connectToServer(serverWithFallback);
+      expect(result).toBe(true);
+      expect(mockAuth.login).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not fall back on a non-network primary error', async () => {
+      mockAuth.login.mockRejectedValueOnce(new Error('Authentication failed. Please check your credentials.'));
+      await expect(ServerManager.connectToServer(serverWithFallback)).rejects.toThrow('Authentication failed');
+      expect(mockAuth.login).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws the fallback error when both endpoints fail', async () => {
+      const netErr = new AxiosError('timeout');
+      netErr.code = 'ECONNABORTED';
+      mockAuth.login.mockRejectedValueOnce(netErr);
+      const netErr2 = new AxiosError('timeout2');
+      netErr2.code = 'ECONNABORTED';
+      mockAuth.login.mockRejectedValueOnce(netErr2);
+
+      await expect(ServerManager.connectToServer(serverWithFallback)).rejects.toThrow();
+      expect(mockAuth.login).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('getCurrentServer / disconnect / reconnect', () => {
+    it('getCurrentServer delegates to storageService', async () => {
+      mockStorage.getCurrentServer.mockResolvedValueOnce(makeServer());
+      const result = await ServerManager.getCurrentServer();
+      expect(result?.id).toBe('s1');
+    });
+
+    it('disconnect logs out, clears the api client and current server id', async () => {
+      mockApiClient.getServer.mockReturnValue(makeServer());
+      mockAuth.logout.mockResolvedValueOnce(undefined);
+      await ServerManager.disconnect();
+      expect(mockAuth.logout).toHaveBeenCalled();
+      expect(mockApiClient.setServer).toHaveBeenCalledWith(null);
+      expect(mockStorage.setCurrentServerId).toHaveBeenCalledWith(null);
+    });
+
+    it('disconnect swallows logout errors', async () => {
+      mockApiClient.getServer.mockReturnValue(null);
+      mockAuth.logout.mockRejectedValueOnce(new Error('logout failed'));
+      await expect(ServerManager.disconnect()).resolves.toBeUndefined();
+      expect(mockApiClient.setServer).toHaveBeenCalledWith(null);
+    });
+
+    it('reconnect returns false when no current server', async () => {
+      mockStorage.getCurrentServer.mockResolvedValueOnce(null);
+      const result = await ServerManager.reconnect();
+      expect(result).toBe(false);
+    });
+
+    it('reconnect connects to the current server', async () => {
+      mockStorage.getCurrentServer.mockResolvedValueOnce(makeServer());
+      mockAuth.login.mockResolvedValueOnce({ status: 'Ok' });
+      mockApp.getVersion.mockResolvedValueOnce({ version: '4.5', apiVersion: '2.9' });
+      const result = await ServerManager.reconnect();
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('testConnection (primary only)', () => {
+    it('returns success on happy path', async () => {
+      mockApiClient.getServer.mockReturnValue(null);
+      mockAuth.login.mockResolvedValueOnce({ status: 'Ok' });
+      mockApp.getVersion.mockResolvedValueOnce({ version: '4.5', apiVersion: '2.9' });
+      const result = await ServerManager.testConnection(makeServer());
+      expect(result.success).toBe(true);
+      expect(mockApiClient.setServer).toHaveBeenLastCalledWith(null);
+    });
+
+    it('skips login when bypassAuth is set', async () => {
+      mockApiClient.getServer.mockReturnValue(null);
+      mockApp.getVersion.mockResolvedValueOnce({ version: '4.5', apiVersion: '2.9' });
+      const result = await ServerManager.testConnection(makeServer({ bypassAuth: true }));
+      expect(result.success).toBe(true);
+      expect(mockAuth.login).not.toHaveBeenCalled();
+    });
+
+    it('returns failure when login status is not Ok', async () => {
+      mockApiClient.getServer.mockReturnValue(null);
+      mockAuth.login.mockResolvedValueOnce({ status: 'Fails' });
+      const result = await ServerManager.testConnection(makeServer());
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/Authentication failed/);
+    });
+
+    it('returns auth failure message on 401/403', async () => {
+      mockApiClient.getServer.mockReturnValue(null);
+      const err = new AxiosError('forbidden');
+      err.response = { status: 401 } as never;
+      mockAuth.login.mockRejectedValueOnce(err);
+      const result = await ServerManager.testConnection(makeServer());
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/Authentication failed/);
+    });
+
+    it('returns network failure message on network error', async () => {
+      mockApiClient.getServer.mockReturnValue(null);
+      const err = new AxiosError('timeout');
+      err.code = 'ECONNABORTED';
+      mockAuth.login.mockRejectedValueOnce(err);
+      const result = await ServerManager.testConnection(makeServer());
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/Connection failed/);
+    });
+
+    it('returns raw message for other errors', async () => {
+      mockApiClient.getServer.mockReturnValue(null);
+      mockAuth.login.mockRejectedValueOnce(new Error('weird'));
+      const result = await ServerManager.testConnection(makeServer());
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('weird');
+    });
+
+    it('rethrows AbortError/CanceledError', async () => {
+      mockApiClient.getServer.mockReturnValue(null);
+      const abortErr = new Error('aborted');
+      abortErr.name = 'AbortError';
+      mockAuth.login.mockRejectedValueOnce(abortErr);
+      await expect(ServerManager.testConnection(makeServer())).rejects.toThrow('aborted');
+    });
+  });
+
+  describe('testConnection (with fallback)', () => {
+    const serverWithFallback = makeServer({
+      useFallback: true,
+      fallbackHost: 'fallback.example.com',
+      fallbackPort: 9090,
+    });
+
+    it('succeeds when primary succeeds', async () => {
+      mockApiClient.getServer.mockReturnValue(null);
+      mockAuth.login.mockResolvedValueOnce({ status: 'Ok' });
+      mockApp.getVersion.mockResolvedValueOnce({ version: '4.5', apiVersion: '2.9' });
+      const result = await ServerManager.testConnection(serverWithFallback);
+      expect(result.success).toBe(true);
+      expect(result.primary?.success).toBe(true);
+      // Only primary attempted since it succeeded first — actually implementation always tests both.
+    });
+
+    it('succeeds when primary fails but fallback succeeds', async () => {
+      mockApiClient.getServer.mockReturnValue(null);
+      mockAuth.login.mockResolvedValueOnce({ status: 'Fails' });
+      mockAuth.login.mockResolvedValueOnce({ status: 'Ok' });
+      mockApp.getVersion.mockResolvedValueOnce({ version: '4.5', apiVersion: '2.9' });
+      const result = await ServerManager.testConnection(serverWithFallback);
+      expect(result.success).toBe(true);
+      expect(result.fallback?.success).toBe(true);
+    });
+
+    it('fails when both endpoints fail, reporting fallback error preferentially', async () => {
+      mockApiClient.getServer.mockReturnValue(null);
+      mockAuth.login.mockResolvedValueOnce({ status: 'Fails' });
+      mockAuth.login.mockResolvedValueOnce({ status: 'Fails' });
+      const result = await ServerManager.testConnection(serverWithFallback);
+      expect(result.success).toBe(false);
+      expect(result.primary?.success).toBe(false);
+      expect(result.fallback?.success).toBe(false);
+    });
+  });
+});

--- a/tests/services/storage.test.ts
+++ b/tests/services/storage.test.ts
@@ -1,0 +1,201 @@
+const mockAsyncStorage: Record<string, string> = {};
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  setItem: jest.fn((key: string, value: string) => {
+    mockAsyncStorage[key] = value;
+    return Promise.resolve();
+  }),
+  getItem: jest.fn((key: string) => Promise.resolve(mockAsyncStorage[key] ?? null)),
+  removeItem: jest.fn((key: string) => {
+    delete mockAsyncStorage[key];
+    return Promise.resolve();
+  }),
+}));
+
+const mockSecureStore: Record<string, string> = {};
+
+jest.mock('expo-secure-store', () => ({
+  setItemAsync: jest.fn((key: string, value: string) => {
+    mockSecureStore[key] = value;
+    return Promise.resolve();
+  }),
+  getItemAsync: jest.fn((key: string) => Promise.resolve(mockSecureStore[key] ?? null)),
+  deleteItemAsync: jest.fn((key: string) => {
+    delete mockSecureStore[key];
+    return Promise.resolve();
+  }),
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { storageService } from '@/services/storage';
+import type { ServerConfig } from '@/types/api';
+
+function makeServer(overrides: Partial<ServerConfig> = {}): ServerConfig {
+  return {
+    id: 's1',
+    name: 'Test',
+    host: 'https://example.com/',
+    port: 8080,
+    username: 'admin',
+    password: 'secret',
+    useHttps: true,
+    bypassAuth: false,
+    ...overrides,
+  };
+}
+
+describe('storageService', () => {
+  beforeEach(() => {
+    Object.keys(mockAsyncStorage).forEach((k) => delete mockAsyncStorage[k]);
+    Object.keys(mockSecureStore).forEach((k) => delete mockSecureStore[k]);
+    jest.clearAllMocks();
+  });
+
+  describe('saveServer / getServers', () => {
+    it('saves a new server and strips protocol from host', async () => {
+      await storageService.saveServer(makeServer());
+      const servers = await storageService.getServers();
+      expect(servers).toHaveLength(1);
+      expect(servers[0].host).toBe('example.com');
+      expect(servers[0].password).toBe('secret');
+    });
+
+    it('does not persist password in AsyncStorage', async () => {
+      await storageService.saveServer(makeServer());
+      const raw = JSON.parse(mockAsyncStorage['servers']);
+      expect(raw[0].password).toBe('');
+      expect(raw[0].basicAuthPassword).toBe('');
+    });
+
+    it('stores password securely via SecureStore', async () => {
+      await storageService.saveServer(makeServer());
+      expect(mockSecureStore['server_password_s1']).toBe('secret');
+    });
+
+    it('updates existing server instead of duplicating', async () => {
+      await storageService.saveServer(makeServer({ name: 'First' }));
+      await storageService.saveServer(makeServer({ name: 'Second' }));
+      const servers = await storageService.getServers();
+      expect(servers).toHaveLength(1);
+      expect(servers[0].name).toBe('Second');
+    });
+
+    it('omits port when 0 or negative', async () => {
+      await storageService.saveServer(makeServer({ port: 0 }));
+      const servers = await storageService.getServers();
+      expect(servers[0].port).toBeUndefined();
+    });
+
+    it('persists basicAuth fields separately, storing password in SecureStore', async () => {
+      await storageService.saveServer(
+        makeServer({ useBasicAuth: true, basicAuthUsername: 'proxyuser', basicAuthPassword: 'proxypass' })
+      );
+      const servers = await storageService.getServers();
+      expect(servers[0].useBasicAuth).toBe(true);
+      expect(servers[0].basicAuthUsername).toBe('proxyuser');
+      expect(servers[0].basicAuthPassword).toBe('proxypass');
+      const raw = JSON.parse(mockAsyncStorage['servers']);
+      expect(raw[0].basicAuthPassword).toBe('');
+    });
+
+    it('getServers returns [] when nothing stored', async () => {
+      const servers = await storageService.getServers();
+      expect(servers).toEqual([]);
+    });
+
+    it('getServers returns [] and swallows errors', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      const servers = await storageService.getServers();
+      expect(servers).toEqual([]);
+    });
+
+    it('saveServer rethrows on failure', async () => {
+      (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('disk full'));
+      await expect(storageService.saveServer(makeServer())).rejects.toThrow('disk full');
+    });
+  });
+
+  describe('getServer', () => {
+    it('returns matching server', async () => {
+      await storageService.saveServer(makeServer());
+      const server = await storageService.getServer('s1');
+      expect(server?.id).toBe('s1');
+    });
+
+    it('returns null when not found', async () => {
+      const server = await storageService.getServer('missing');
+      expect(server).toBeNull();
+    });
+  });
+
+  describe('deleteServer', () => {
+    it('removes server from list and secure store', async () => {
+      await storageService.saveServer(makeServer());
+      await storageService.deleteServer('s1');
+      const servers = await storageService.getServers();
+      expect(servers).toEqual([]);
+      expect(mockSecureStore['server_password_s1']).toBeUndefined();
+    });
+
+    it('clears currentServerId when deleting the current server', async () => {
+      await storageService.saveServer(makeServer());
+      await storageService.setCurrentServerId('s1');
+      await storageService.deleteServer('s1');
+      const currentId = await storageService.getCurrentServerId();
+      expect(currentId).toBeNull();
+    });
+
+    it('leaves currentServerId untouched when deleting a different server', async () => {
+      await storageService.saveServer(makeServer());
+      await storageService.saveServer(makeServer({ id: 's2' }));
+      await storageService.setCurrentServerId('s1');
+      await storageService.deleteServer('s2');
+      const currentId = await storageService.getCurrentServerId();
+      expect(currentId).toBe('s1');
+    });
+  });
+
+  describe('current server id', () => {
+    it('sets and gets current server id', async () => {
+      await storageService.setCurrentServerId('s1');
+      expect(await storageService.getCurrentServerId()).toBe('s1');
+    });
+
+    it('removes the key when set to null', async () => {
+      await storageService.setCurrentServerId('s1');
+      await storageService.setCurrentServerId(null);
+      expect(await storageService.getCurrentServerId()).toBeNull();
+    });
+
+    it('getCurrentServer resolves the full server object', async () => {
+      await storageService.saveServer(makeServer());
+      await storageService.setCurrentServerId('s1');
+      const server = await storageService.getCurrentServer();
+      expect(server?.id).toBe('s1');
+    });
+
+    it('getCurrentServer returns null when no current id is set', async () => {
+      const server = await storageService.getCurrentServer();
+      expect(server).toBeNull();
+    });
+  });
+
+  describe('preferences', () => {
+    it('saves and retrieves preferences', async () => {
+      await storageService.savePreferences({ theme: 'dark' } as never);
+      const prefs = await storageService.getPreferences();
+      expect(prefs).toEqual({ theme: 'dark' });
+    });
+
+    it('returns {} when nothing stored', async () => {
+      const prefs = await storageService.getPreferences();
+      expect(prefs).toEqual({});
+    });
+
+    it('returns {} and swallows errors', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('fail'));
+      const prefs = await storageService.getPreferences();
+      expect(prefs).toEqual({});
+    });
+  });
+});

--- a/tests/services/sync.test.ts
+++ b/tests/services/sync.test.ts
@@ -1,0 +1,64 @@
+jest.mock('@/services/api/client', () => ({
+  apiClient: {
+    get: jest.fn(),
+  },
+}));
+
+import { syncApi } from '@/services/api/sync';
+import { apiClient } from '@/services/api/client';
+
+const mockGet = apiClient.get as jest.Mock;
+
+describe('syncApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getMainData', () => {
+    it('omits rid param when 0 (default)', async () => {
+      mockGet.mockResolvedValueOnce({ rid: 1, torrents: {} });
+      await syncApi.getMainData();
+      expect(mockGet).toHaveBeenCalledWith('/api/v2/sync/maindata', {});
+    });
+
+    it('includes rid param when > 0', async () => {
+      mockGet.mockResolvedValueOnce({ rid: 2, torrents: {} });
+      await syncApi.getMainData(5);
+      expect(mockGet).toHaveBeenCalledWith('/api/v2/sync/maindata', { rid: 5 });
+    });
+
+    it('injects hash key into each torrent', async () => {
+      mockGet.mockResolvedValueOnce({
+        rid: 1,
+        torrents: {
+          abc123: { name: 'Torrent A' },
+          def456: { name: 'Torrent B' },
+        },
+      });
+      const result = await syncApi.getMainData();
+      expect(result.torrents!.abc123.hash).toBe('abc123');
+      expect(result.torrents!.def456.hash).toBe('def456');
+      expect(result.torrents!.abc123.name).toBe('Torrent A');
+    });
+
+    it('defaults torrents to {} when absent', async () => {
+      mockGet.mockResolvedValueOnce({ rid: 1 });
+      const result = await syncApi.getMainData();
+      expect(result.torrents).toEqual({});
+    });
+  });
+
+  describe('getTorrentPeers', () => {
+    it('omits rid when 0 (default)', async () => {
+      mockGet.mockResolvedValueOnce({ peers: {} });
+      await syncApi.getTorrentPeers('abc123');
+      expect(mockGet).toHaveBeenCalledWith('/api/v2/sync/torrentPeers', { hash: 'abc123' });
+    });
+
+    it('includes rid when > 0', async () => {
+      mockGet.mockResolvedValueOnce({ peers: {} });
+      await syncApi.getTorrentPeers('abc123', 3);
+      expect(mockGet).toHaveBeenCalledWith('/api/v2/sync/torrentPeers', { hash: 'abc123', rid: 3 });
+    });
+  });
+});

--- a/tests/services/tags.test.ts
+++ b/tests/services/tags.test.ts
@@ -1,0 +1,43 @@
+jest.mock('@/services/api/client', () => ({
+  apiClient: {
+    get: jest.fn(),
+    postUrlEncoded: jest.fn(),
+  },
+}));
+
+import { tagsApi } from '@/services/api/tags';
+import { apiClient } from '@/services/api/client';
+
+const mockGet = apiClient.get as jest.Mock;
+const mockPost = apiClient.postUrlEncoded as jest.Mock;
+
+describe('tagsApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('getAllTags returns array response', async () => {
+    mockGet.mockResolvedValueOnce(['a', 'b']);
+    const result = await tagsApi.getAllTags();
+    expect(result).toEqual(['a', 'b']);
+    expect(mockGet).toHaveBeenCalledWith('/api/v2/torrents/tags');
+  });
+
+  it('getAllTags returns [] for non-array response', async () => {
+    mockGet.mockResolvedValueOnce(null);
+    const result = await tagsApi.getAllTags();
+    expect(result).toEqual([]);
+  });
+
+  it('createTags joins with comma', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await tagsApi.createTags(['a', 'b']);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/createTags', { tags: 'a,b' });
+  });
+
+  it('deleteTags joins with comma', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await tagsApi.deleteTags(['a', 'b']);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/deleteTags', { tags: 'a,b' });
+  });
+});

--- a/tests/services/torrents.test.ts
+++ b/tests/services/torrents.test.ts
@@ -1,0 +1,445 @@
+jest.mock('@/services/api/client', () => ({
+  apiClient: {
+    get: jest.fn(),
+    post: jest.fn(),
+    postUrlEncoded: jest.fn(),
+    postFormData: jest.fn(),
+    getApiFeatures: jest.fn(() => ({ useStartStopEndpoints: false })),
+  },
+}));
+
+import { AxiosError } from 'axios';
+import { torrentsApi } from '@/services/api/torrents';
+import { apiClient } from '@/services/api/client';
+
+const mockGet = apiClient.get as jest.Mock;
+const mockPost = apiClient.postUrlEncoded as jest.Mock;
+const mockPostFormData = apiClient.postFormData as jest.Mock;
+const mockGetApiFeatures = apiClient.getApiFeatures as jest.Mock;
+
+describe('torrentsApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetApiFeatures.mockReturnValue({ useStartStopEndpoints: false });
+  });
+
+  describe('getTorrentList', () => {
+    it('sends only provided params', async () => {
+      mockGet.mockResolvedValueOnce([{ hash: 'a' }]);
+      const result = await torrentsApi.getTorrentList('downloading');
+      expect(result).toEqual([{ hash: 'a' }]);
+      expect(mockGet).toHaveBeenCalledWith('/api/v2/torrents/info', { filter: 'downloading' });
+    });
+
+    it('sends all params when provided, joining hashes with pipe', async () => {
+      mockGet.mockResolvedValueOnce([]);
+      await torrentsApi.getTorrentList('all', 'Movies', 'tag1', 'name', true, 10, 0, ['h1', 'h2']);
+      expect(mockGet).toHaveBeenCalledWith('/api/v2/torrents/info', {
+        filter: 'all',
+        category: 'Movies',
+        tag: 'tag1',
+        sort: 'name',
+        reverse: true,
+        limit: 10,
+        offset: 0,
+        hashes: 'h1|h2',
+      });
+    });
+
+    it('returns [] for non-array response', async () => {
+      mockGet.mockResolvedValueOnce(null);
+      const result = await torrentsApi.getTorrentList();
+      expect(result).toEqual([]);
+    });
+  });
+
+  it('getTorrentProperties', async () => {
+    mockGet.mockResolvedValueOnce({ name: 'X' });
+    const result = await torrentsApi.getTorrentProperties('h1');
+    expect(result).toEqual({ name: 'X' });
+    expect(mockGet).toHaveBeenCalledWith('/api/v2/torrents/properties', { hash: 'h1' });
+  });
+
+  describe('getTorrentTrackers', () => {
+    it('returns array', async () => {
+      mockGet.mockResolvedValueOnce([{ url: 'x' }]);
+      const result = await torrentsApi.getTorrentTrackers('h1');
+      expect(result).toEqual([{ url: 'x' }]);
+    });
+    it('returns [] for non-array', async () => {
+      mockGet.mockResolvedValueOnce(null);
+      expect(await torrentsApi.getTorrentTrackers('h1')).toEqual([]);
+    });
+  });
+
+  describe('getTorrentWebSeeds', () => {
+    it('returns array', async () => {
+      mockGet.mockResolvedValueOnce([{ url: 'x' }]);
+      expect(await torrentsApi.getTorrentWebSeeds('h1')).toEqual([{ url: 'x' }]);
+    });
+    it('returns [] for non-array', async () => {
+      mockGet.mockResolvedValueOnce(undefined);
+      expect(await torrentsApi.getTorrentWebSeeds('h1')).toEqual([]);
+    });
+  });
+
+  describe('getTorrentContents', () => {
+    it('without indexes', async () => {
+      mockGet.mockResolvedValueOnce([{ name: 'f' }]);
+      const result = await torrentsApi.getTorrentContents('h1');
+      expect(result).toEqual([{ name: 'f' }]);
+      expect(mockGet).toHaveBeenCalledWith('/api/v2/torrents/files', { hash: 'h1' });
+    });
+    it('with indexes joined by pipe', async () => {
+      mockGet.mockResolvedValueOnce([]);
+      await torrentsApi.getTorrentContents('h1', [0, 1]);
+      expect(mockGet).toHaveBeenCalledWith('/api/v2/torrents/files', { hash: 'h1', indexes: '0|1' });
+    });
+    it('returns [] for non-array', async () => {
+      mockGet.mockResolvedValueOnce(null);
+      expect(await torrentsApi.getTorrentContents('h1')).toEqual([]);
+    });
+  });
+
+  it('getTorrentPiecesStates', async () => {
+    mockGet.mockResolvedValueOnce([2, 2, 1]);
+    const result = await torrentsApi.getTorrentPiecesStates('h1');
+    expect(result).toEqual([2, 2, 1]);
+    expect(mockGet).toHaveBeenCalledWith('/api/v2/torrents/pieceStates', { hash: 'h1' });
+  });
+
+  it('getTorrentPiecesHashes', async () => {
+    mockGet.mockResolvedValueOnce(['abc']);
+    const result = await torrentsApi.getTorrentPiecesHashes('h1');
+    expect(result).toEqual(['abc']);
+    expect(mockGet).toHaveBeenCalledWith('/api/v2/torrents/pieceHashes', { hash: 'h1' });
+  });
+
+  describe('pauseTorrents', () => {
+    it('uses pause endpoint on 4.x', async () => {
+      mockGetApiFeatures.mockReturnValue({ useStartStopEndpoints: false });
+      mockPost.mockResolvedValueOnce(undefined);
+      await torrentsApi.pauseTorrents(['h1', 'h2']);
+      expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/pause', { hashes: 'h1|h2' });
+    });
+
+    it('uses stop endpoint on 5.x', async () => {
+      mockGetApiFeatures.mockReturnValue({ useStartStopEndpoints: true });
+      mockPost.mockResolvedValueOnce(undefined);
+      await torrentsApi.pauseTorrents(['h1']);
+      expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/stop', { hashes: 'h1' });
+    });
+
+    it('logs and rethrows AxiosError', async () => {
+      const err = new AxiosError('fail');
+      err.response = { status: 500, data: 'oops' } as never;
+      mockPost.mockRejectedValueOnce(err);
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      await expect(torrentsApi.pauseTorrents(['h1'])).rejects.toThrow(err);
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('rethrows non-axios errors without logging extra info', async () => {
+      mockPost.mockRejectedValueOnce(new Error('plain'));
+      await expect(torrentsApi.pauseTorrents(['h1'])).rejects.toThrow('plain');
+    });
+  });
+
+  describe('resumeTorrents', () => {
+    it('uses resume endpoint on 4.x', async () => {
+      mockGetApiFeatures.mockReturnValue({ useStartStopEndpoints: false });
+      mockPost.mockResolvedValueOnce(undefined);
+      await torrentsApi.resumeTorrents(['h1']);
+      expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/resume', { hashes: 'h1' });
+    });
+
+    it('uses start endpoint on 5.x', async () => {
+      mockGetApiFeatures.mockReturnValue({ useStartStopEndpoints: true });
+      mockPost.mockResolvedValueOnce(undefined);
+      await torrentsApi.resumeTorrents(['h1']);
+      expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/start', { hashes: 'h1' });
+    });
+
+    it('logs and rethrows AxiosError', async () => {
+      const err = new AxiosError('fail');
+      err.response = { status: 500, data: 'oops' } as never;
+      mockPost.mockRejectedValueOnce(err);
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      await expect(torrentsApi.resumeTorrents(['h1'])).rejects.toThrow(err);
+      consoleSpy.mockRestore();
+    });
+  });
+
+  it('deleteTorrents with deleteFiles true', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.deleteTorrents(['h1', 'h2'], true);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/delete', {
+      hashes: 'h1|h2',
+      deleteFiles: 'true',
+    });
+  });
+
+  it('deleteTorrents defaults deleteFiles to false', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.deleteTorrents(['h1']);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/delete', {
+      hashes: 'h1',
+      deleteFiles: 'false',
+    });
+  });
+
+  it('recheckTorrents', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.recheckTorrents(['h1']);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/recheck', { hashes: 'h1' });
+  });
+
+  it('reannounceTorrents', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.reannounceTorrents(['h1']);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/reannounce', { hashes: 'h1' });
+  });
+
+  describe('addTorrent', () => {
+    it('handles a single url string with no options', async () => {
+      mockPostFormData.mockResolvedValueOnce(undefined);
+      await torrentsApi.addTorrent('magnet:?xt=1');
+      expect(mockPostFormData).toHaveBeenCalledWith('/api/v2/torrents/add', expect.any(FormData));
+    });
+
+    it('handles an array of urls and full options', async () => {
+      mockPostFormData.mockResolvedValueOnce(undefined);
+      await torrentsApi.addTorrent(['magnet:1', 'magnet:2'], {
+        savepath: '/dl',
+        cookie: 'c=1',
+        category: 'Movies',
+        tags: ['a', 'b'],
+        skip_checking: true,
+        stopped: false,
+        root_folder: true,
+        rename: 'newname',
+        upLimit: 100,
+        dlLimit: 200,
+        ratioLimit: 1.5,
+        seedingTimeLimit: 60,
+        sequentialDownload: true,
+        firstLastPiecePrio: true,
+        autoTMM: false,
+      });
+      const formData = mockPostFormData.mock.calls[0][1] as FormData;
+      expect(formData).toBeInstanceOf(FormData);
+    });
+  });
+
+  describe('addTorrentFile', () => {
+    it('handles file with no options', async () => {
+      mockPostFormData.mockResolvedValueOnce(undefined);
+      await torrentsApi.addTorrentFile({ uri: 'file:///a.torrent', name: 'a.torrent' });
+      expect(mockPostFormData).toHaveBeenCalledWith('/api/v2/torrents/add', expect.any(FormData));
+    });
+
+    it('handles file with type and full options', async () => {
+      mockPostFormData.mockResolvedValueOnce(undefined);
+      await torrentsApi.addTorrentFile(
+        { uri: 'file:///a.torrent', name: 'a.torrent', type: 'application/x-bittorrent' },
+        {
+          savepath: '/dl',
+          category: 'Movies',
+          tags: ['a'],
+          skip_checking: true,
+          stopped: true,
+          root_folder: false,
+          rename: 'n',
+          upLimit: 1,
+          dlLimit: 2,
+          ratioLimit: 1,
+          seedingTimeLimit: 1,
+          sequentialDownload: false,
+          firstLastPiecePrio: false,
+          autoTMM: true,
+        }
+      );
+      expect(mockPostFormData).toHaveBeenCalledWith('/api/v2/torrents/add', expect.any(FormData));
+    });
+  });
+
+  it('addTrackers joins with newline', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.addTrackers('h1', ['url1', 'url2']);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/addTrackers', { hash: 'h1', urls: 'url1\nurl2' });
+  });
+
+  it('editTrackers', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.editTrackers('h1', 'old', 'new');
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/editTracker', { hash: 'h1', origUrl: 'old', newUrl: 'new' });
+  });
+
+  it('removeTrackers joins with pipe', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.removeTrackers('h1', ['url1', 'url2']);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/removeTrackers', { hash: 'h1', urls: 'url1|url2' });
+  });
+
+  it('addPeers', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.addPeers(['h1', 'h2'], ['1.2.3.4:80']);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/addPeers', { hashes: 'h1|h2', peers: '1.2.3.4:80' });
+  });
+
+  it('increasePriority', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.increasePriority(['h1']);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/increasePrio', { hashes: 'h1' });
+  });
+
+  it('decreasePriority', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.decreasePriority(['h1']);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/decreasePrio', { hashes: 'h1' });
+  });
+
+  it('setMaximalPriority', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.setMaximalPriority(['h1']);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/topPrio', { hashes: 'h1' });
+  });
+
+  it('setMinimalPriority', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.setMinimalPriority(['h1']);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/bottomPrio', { hashes: 'h1' });
+  });
+
+  it('setFilePriority', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.setFilePriority('h1', [0, 1], 7 as never);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/filePrio', { hash: 'h1', id: '0|1', priority: '7' });
+  });
+
+  describe('getTorrentDownloadLimit', () => {
+    it('returns map', async () => {
+      mockGet.mockResolvedValueOnce({ h1: 100 });
+      const result = await torrentsApi.getTorrentDownloadLimit(['h1']);
+      expect(result).toEqual({ h1: 100 });
+      expect(mockGet).toHaveBeenCalledWith('/api/v2/torrents/downloadLimit', { hashes: 'h1' });
+    });
+    it('returns {} when response falsy', async () => {
+      mockGet.mockResolvedValueOnce(null);
+      expect(await torrentsApi.getTorrentDownloadLimit(['h1'])).toEqual({});
+    });
+  });
+
+  it('setTorrentDownloadLimit', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.setTorrentDownloadLimit(['h1'], 100);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/setDownloadLimit', { hashes: 'h1', limit: 100 });
+  });
+
+  describe('setTorrentShareLimits', () => {
+    it('sends only provided limits', async () => {
+      mockPost.mockResolvedValueOnce(undefined);
+      await torrentsApi.setTorrentShareLimits(['h1']);
+      expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/setShareLimits', { hashes: 'h1' });
+    });
+    it('sends both limits when provided', async () => {
+      mockPost.mockResolvedValueOnce(undefined);
+      await torrentsApi.setTorrentShareLimits(['h1'], 2, 60);
+      expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/setShareLimits', {
+        hashes: 'h1',
+        ratioLimit: 2,
+        seedingTimeLimit: 60,
+      });
+    });
+  });
+
+  describe('getTorrentUploadLimit', () => {
+    it('returns map', async () => {
+      mockGet.mockResolvedValueOnce({ h1: 50 });
+      expect(await torrentsApi.getTorrentUploadLimit(['h1'])).toEqual({ h1: 50 });
+    });
+    it('returns {} when response falsy', async () => {
+      mockGet.mockResolvedValueOnce(undefined);
+      expect(await torrentsApi.getTorrentUploadLimit(['h1'])).toEqual({});
+    });
+  });
+
+  it('setTorrentUploadLimit', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.setTorrentUploadLimit(['h1'], 300);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/setUploadLimit', { hashes: 'h1', limit: 300 });
+  });
+
+  it('setTorrentLocation', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.setTorrentLocation(['h1'], '/new/path');
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/setLocation', { hashes: 'h1', location: '/new/path' });
+  });
+
+  it('setTorrentName', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.setTorrentName('h1', 'New Name');
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/rename', { hash: 'h1', name: 'New Name' });
+  });
+
+  it('setTorrentCategory', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.setTorrentCategory(['h1'], 'Movies');
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/setCategory', { hashes: 'h1', category: 'Movies' });
+  });
+
+  it('addTorrentTags', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.addTorrentTags(['h1'], ['a', 'b']);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/addTags', { hashes: 'h1', tags: 'a,b' });
+  });
+
+  it('removeTorrentTags', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.removeTorrentTags(['h1'], ['a']);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/removeTags', { hashes: 'h1', tags: 'a' });
+  });
+
+  it('setAutomaticTorrentManagement', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.setAutomaticTorrentManagement(['h1'], true);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/setAutoManagement', { hashes: 'h1', enable: 'true' });
+  });
+
+  it('toggleSequentialDownload', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.toggleSequentialDownload(['h1']);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/toggleSequentialDownload', { hashes: 'h1' });
+  });
+
+  it('setFirstLastPiecePriority', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.setFirstLastPiecePriority(['h1']);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/toggleFirstLastPiecePrio', { hashes: 'h1' });
+  });
+
+  it('setForceStart', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.setForceStart(['h1'], true);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/setForceStart', { hashes: 'h1', value: 'true' });
+  });
+
+  it('setSuperSeeding', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.setSuperSeeding(['h1'], false);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/setSuperSeeding', { hashes: 'h1', value: 'false' });
+  });
+
+  it('renameFile', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.renameFile('h1', 'old.txt', 'new.txt');
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/renameFile', { hash: 'h1', oldPath: 'old.txt', newPath: 'new.txt' });
+  });
+
+  it('renameFolder', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await torrentsApi.renameFolder('h1', 'old', 'new');
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/renameFolder', { hash: 'h1', oldPath: 'old', newPath: 'new' });
+  });
+});

--- a/tests/services/transfer.test.ts
+++ b/tests/services/transfer.test.ts
@@ -1,0 +1,75 @@
+jest.mock('@/services/api/client', () => ({
+  apiClient: {
+    get: jest.fn(),
+    postUrlEncoded: jest.fn(),
+  },
+}));
+
+import { transferApi } from '@/services/api/transfer';
+import { apiClient } from '@/services/api/client';
+
+const mockGet = apiClient.get as jest.Mock;
+const mockPost = apiClient.postUrlEncoded as jest.Mock;
+
+describe('transferApi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('getGlobalTransferInfo', async () => {
+    mockGet.mockResolvedValueOnce({ dl_info_speed: 100 });
+    const result = await transferApi.getGlobalTransferInfo();
+    expect(result).toEqual({ dl_info_speed: 100 });
+    expect(mockGet).toHaveBeenCalledWith('/api/v2/transfer/info');
+  });
+
+  it('getAlternativeSpeedLimitsState true when response is 1', async () => {
+    mockGet.mockResolvedValueOnce(1);
+    const result = await transferApi.getAlternativeSpeedLimitsState();
+    expect(result).toBe(true);
+  });
+
+  it('getAlternativeSpeedLimitsState false when response is 0', async () => {
+    mockGet.mockResolvedValueOnce(0);
+    const result = await transferApi.getAlternativeSpeedLimitsState();
+    expect(result).toBe(false);
+  });
+
+  it('toggleAlternativeSpeedLimits', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await transferApi.toggleAlternativeSpeedLimits();
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/transfer/toggleSpeedLimitsMode', {});
+  });
+
+  it('getGlobalDownloadLimit', async () => {
+    mockGet.mockResolvedValueOnce(1000);
+    const result = await transferApi.getGlobalDownloadLimit();
+    expect(result).toBe(1000);
+  });
+
+  it('setGlobalDownloadLimit', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await transferApi.setGlobalDownloadLimit(500);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/transfer/setDownloadLimit', { limit: 500 });
+  });
+
+  it('getGlobalUploadLimit', async () => {
+    mockGet.mockResolvedValueOnce(2000);
+    const result = await transferApi.getGlobalUploadLimit();
+    expect(result).toBe(2000);
+  });
+
+  it('setGlobalUploadLimit', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await transferApi.setGlobalUploadLimit(700);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/transfer/setUploadLimit', { limit: 700 });
+  });
+
+  it('banPeers joins with pipe', async () => {
+    mockPost.mockResolvedValueOnce(undefined);
+    await transferApi.banPeers(['1.2.3.4:80', '5.6.7.8:81']);
+    expect(mockPost).toHaveBeenCalledWith('/api/v2/transfer/banPeers', {
+      peers: '1.2.3.4:80|5.6.7.8:81',
+    });
+  });
+});

--- a/tests/utils/apiVersion.test.ts
+++ b/tests/utils/apiVersion.test.ts
@@ -1,0 +1,82 @@
+import { parseApiVersion, getApiFeatures } from '@/utils/apiVersion';
+
+describe('parseApiVersion', () => {
+  it('parses a standard major.minor.patch string', () => {
+    expect(parseApiVersion('2.11.3')).toEqual({ major: 2, minor: 11, patch: 3 });
+  });
+
+  it('defaults patch to 0 when omitted', () => {
+    expect(parseApiVersion('2.8')).toEqual({ major: 2, minor: 8, patch: 0 });
+  });
+
+  it('trims whitespace', () => {
+    expect(parseApiVersion('  2.8.1  ')).toEqual({ major: 2, minor: 8, patch: 1 });
+  });
+
+  it('returns null when fewer than 2 parts are given', () => {
+    expect(parseApiVersion('2')).toBeNull();
+  });
+
+  it('returns null for non-numeric parts', () => {
+    expect(parseApiVersion('a.b.c')).toBeNull();
+    expect(parseApiVersion('2.x')).toBeNull();
+  });
+});
+
+describe('getApiFeatures', () => {
+  it('returns the full v5 feature set when apiVersion is null', () => {
+    const features = getApiFeatures(null);
+    expect(features).toEqual({
+      useStartStopEndpoints: true,
+      hasRatioLimitFields: true,
+      hasContentPath: true,
+      supportsInactiveSeedingLimit: true,
+      supportsSetCookies: true,
+      supportsSearchDownloadTorrent: true,
+    });
+  });
+
+  it('returns the full v5 feature set when apiVersion is unparseable', () => {
+    expect(getApiFeatures('garbage')).toEqual(getApiFeatures(null));
+  });
+
+  it('gates v5-only features off below 2.11', () => {
+    const features = getApiFeatures('2.9.0');
+    expect(features.useStartStopEndpoints).toBe(false);
+    expect(features.hasContentPath).toBe(false);
+    expect(features.supportsInactiveSeedingLimit).toBe(false);
+    expect(features.supportsSetCookies).toBe(false);
+    expect(features.supportsSearchDownloadTorrent).toBe(false);
+    // ratio limit fields only require 2.8+
+    expect(features.hasRatioLimitFields).toBe(true);
+  });
+
+  it('gates hasRatioLimitFields off below 2.8', () => {
+    const features = getApiFeatures('2.7.0');
+    expect(features.hasRatioLimitFields).toBe(false);
+  });
+
+  it('enables all v5 features at exactly 2.11.0', () => {
+    const features = getApiFeatures('2.11.0');
+    expect(features.useStartStopEndpoints).toBe(true);
+    expect(features.hasContentPath).toBe(true);
+    expect(features.supportsInactiveSeedingLimit).toBe(true);
+    expect(features.supportsSetCookies).toBe(true);
+    expect(features.supportsSearchDownloadTorrent).toBe(true);
+  });
+
+  it('enables v5 features above major version 2 (e.g. 3.0.0)', () => {
+    const features = getApiFeatures('3.0.0');
+    expect(features.useStartStopEndpoints).toBe(true);
+  });
+
+  it('handles a higher minor within the same major correctly via gte', () => {
+    expect(getApiFeatures('2.12.0').useStartStopEndpoints).toBe(true);
+  });
+
+  it('handles a lower major version correctly (1.x is below 2.11)', () => {
+    const features = getApiFeatures('1.9.0');
+    expect(features.useStartStopEndpoints).toBe(false);
+    expect(features.hasRatioLimitFields).toBe(false);
+  });
+});

--- a/tests/utils/error.test.ts
+++ b/tests/utils/error.test.ts
@@ -1,0 +1,40 @@
+import { AxiosError } from 'axios';
+import { getErrorMessage, isAxiosError } from '@/utils/error';
+
+describe('getErrorMessage', () => {
+  it('returns the message of an Error instance', () => {
+    expect(getErrorMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('stringifies non-Error values', () => {
+    expect(getErrorMessage('plain string')).toBe('plain string');
+    expect(getErrorMessage(42)).toBe('42');
+    expect(getErrorMessage(null)).toBe('null');
+    expect(getErrorMessage(undefined)).toBe('undefined');
+    expect(getErrorMessage({ foo: 'bar' })).toBe('[object Object]');
+  });
+});
+
+describe('isAxiosError', () => {
+  it('returns true for a real AxiosError instance', () => {
+    const err = new AxiosError('network fail');
+    expect(isAxiosError(err)).toBe(true);
+  });
+
+  it('returns true for an Error with isAxiosError property set', () => {
+    const err = new Error('fake axios error') as Error & { isAxiosError: boolean };
+    err.isAxiosError = true;
+    expect(isAxiosError(err)).toBe(true);
+  });
+
+  it('returns false for a plain Error', () => {
+    expect(isAxiosError(new Error('plain'))).toBe(false);
+  });
+
+  it('returns false for non-Error values', () => {
+    expect(isAxiosError('string')).toBe(false);
+    expect(isAxiosError(null)).toBe(false);
+    expect(isAxiosError(undefined)).toBe(false);
+    expect(isAxiosError({ isAxiosError: true })).toBe(false);
+  });
+});

--- a/tests/utils/format.test.ts
+++ b/tests/utils/format.test.ts
@@ -315,3 +315,26 @@ describe('formatAvailability', () => {
     expect(formatAvailability(1.005)).toBe('1.005');
   });
 });
+
+describe('formatDate', () => {
+  it('returns "Not provided" for a value that produces an invalid Date', () => {
+    expect(formatDate(Infinity)).toBe('Not provided');
+  });
+
+  it('returns "Not provided" when Date construction throws', () => {
+    const RealDate = global.Date;
+    function ThrowingDate(): never {
+      throw new Error('boom');
+    }
+    global.Date = ThrowingDate as unknown as DateConstructor;
+    try {
+      expect(formatDate(1700000000)).toBe('Not provided');
+    } finally {
+      global.Date = RealDate;
+    }
+  });
+
+  it('formats a valid timestamp', () => {
+    expect(formatDate(1700000000)).not.toBe('Not provided');
+  });
+});

--- a/tests/utils/haptics.test.ts
+++ b/tests/utils/haptics.test.ts
@@ -1,0 +1,87 @@
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn(),
+  notificationAsync: jest.fn(),
+  selectionAsync: jest.fn(),
+  ImpactFeedbackStyle: { Light: 'light', Medium: 'medium', Heavy: 'heavy' },
+  NotificationFeedbackType: { Success: 'success', Error: 'error', Warning: 'warning' },
+}));
+
+jest.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+}));
+
+import * as Haptics from 'expo-haptics';
+import { Platform } from 'react-native';
+import { haptics, setHapticsEnabled } from '@/utils/haptics';
+
+describe('haptics', () => {
+  const mockPlatform = Platform as unknown as { OS: string };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPlatform.OS = 'ios';
+    setHapticsEnabled(true);
+  });
+
+  it('light triggers impactAsync with Light style on iOS when enabled', () => {
+    haptics.light();
+    expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Light);
+  });
+
+  it('medium triggers impactAsync with Medium style', () => {
+    haptics.medium();
+    expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Medium);
+  });
+
+  it('heavy triggers impactAsync with Heavy style', () => {
+    haptics.heavy();
+    expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Heavy);
+  });
+
+  it('success triggers notificationAsync with Success type', () => {
+    haptics.success();
+    expect(Haptics.notificationAsync).toHaveBeenCalledWith(Haptics.NotificationFeedbackType.Success);
+  });
+
+  it('error triggers notificationAsync with Error type', () => {
+    haptics.error();
+    expect(Haptics.notificationAsync).toHaveBeenCalledWith(Haptics.NotificationFeedbackType.Error);
+  });
+
+  it('warning triggers notificationAsync with Warning type', () => {
+    haptics.warning();
+    expect(Haptics.notificationAsync).toHaveBeenCalledWith(Haptics.NotificationFeedbackType.Warning);
+  });
+
+  it('selection triggers selectionAsync', () => {
+    haptics.selection();
+    expect(Haptics.selectionAsync).toHaveBeenCalled();
+  });
+
+  it('does nothing on non-iOS platforms', () => {
+    mockPlatform.OS = 'android';
+    haptics.light();
+    haptics.success();
+    haptics.selection();
+    expect(Haptics.impactAsync).not.toHaveBeenCalled();
+    expect(Haptics.notificationAsync).not.toHaveBeenCalled();
+    expect(Haptics.selectionAsync).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when haptics are disabled via setHapticsEnabled(false)', () => {
+    setHapticsEnabled(false);
+    haptics.light();
+    haptics.success();
+    haptics.selection();
+    expect(Haptics.impactAsync).not.toHaveBeenCalled();
+    expect(Haptics.notificationAsync).not.toHaveBeenCalled();
+    expect(Haptics.selectionAsync).not.toHaveBeenCalled();
+  });
+
+  it('resumes firing once re-enabled', () => {
+    setHapticsEnabled(false);
+    setHapticsEnabled(true);
+    haptics.light();
+    expect(Haptics.impactAsync).toHaveBeenCalled();
+  });
+});

--- a/tests/utils/magnet.test.ts
+++ b/tests/utils/magnet.test.ts
@@ -49,4 +49,14 @@ describe('extractMagnetLink', () => {
     const incomingText = `Hey, use this ${sampleMagnet} thanks`;
     expect(extractMagnetLink(incomingText)).toBe(sampleMagnet);
   });
+
+  it('handles malformed percent-encoding without throwing (safeDecode catch)', () => {
+    // "%" alone is an invalid escape sequence for decodeURIComponent
+    expect(extractMagnetLink('%')).toBeNull();
+  });
+
+  it('returns the raw magnet unchanged when it contains invalid percent-encoding', () => {
+    const malformed = 'magnet:?xt=urn:btih:abc%zz123';
+    expect(extractMagnetLink(malformed)).toBe(malformed);
+  });
 });

--- a/tests/utils/searchResult.test.ts
+++ b/tests/utils/searchResult.test.ts
@@ -22,6 +22,11 @@ describe('siteHost', () => {
   it('returns empty string for empty input', () => {
     expect(siteHost('')).toBe('');
   });
+
+  it('falls back to the full stripped string when it starts with a slash', () => {
+    // split('/')[0] is '' for a leading slash, so the `|| stripped` fallback fires
+    expect(siteHost('/relative/path')).toBe('/relative/path');
+  });
 });
 
 describe('extractBracketTag', () => {

--- a/tests/utils/server.test.ts
+++ b/tests/utils/server.test.ts
@@ -1,0 +1,190 @@
+import {
+  AVATAR_PALETTE,
+  avatarColor,
+  serverAddress,
+  hasFallback,
+  resolveServerEndpoint,
+  getServerEndpointLabel,
+  getActiveEndpoint,
+} from '@/utils/server';
+import { ServerConfig } from '@/types/api';
+
+const baseServer: ServerConfig = {
+  id: 'srv1',
+  name: 'My Server',
+  host: 'example.com',
+  port: 8080,
+  username: 'user',
+  password: 'pass',
+  useHttps: false,
+};
+
+describe('avatarColor', () => {
+  it('returns a color from the palette', () => {
+    expect(AVATAR_PALETTE).toContain(avatarColor('Home Server'));
+  });
+
+  it('is deterministic for the same name', () => {
+    expect(avatarColor('Home Server')).toBe(avatarColor('Home Server'));
+  });
+
+  it('handles empty string', () => {
+    expect(AVATAR_PALETTE).toContain(avatarColor(''));
+  });
+});
+
+describe('serverAddress', () => {
+  it('includes the port when set and positive', () => {
+    expect(serverAddress(baseServer)).toBe('example.com:8080');
+  });
+
+  it('omits the port when 0', () => {
+    expect(serverAddress({ ...baseServer, port: 0 })).toBe('example.com');
+  });
+
+  it('omits the port when undefined', () => {
+    expect(serverAddress({ ...baseServer, port: undefined })).toBe('example.com');
+  });
+});
+
+describe('hasFallback', () => {
+  it('returns false when useFallback is not set', () => {
+    expect(hasFallback(baseServer)).toBe(false);
+  });
+
+  it('returns false when useFallback is true but fallbackHost is empty', () => {
+    expect(hasFallback({ ...baseServer, useFallback: true, fallbackHost: '   ' })).toBe(false);
+  });
+
+  it('returns false when useFallback is true but fallbackHost is undefined', () => {
+    expect(hasFallback({ ...baseServer, useFallback: true })).toBe(false);
+  });
+
+  it('returns true when useFallback is true and fallbackHost is set', () => {
+    expect(hasFallback({ ...baseServer, useFallback: true, fallbackHost: 'fallback.com' })).toBe(
+      true,
+    );
+  });
+});
+
+describe('resolveServerEndpoint', () => {
+  it('returns the trimmed primary host/basePath for "primary"', () => {
+    const server = { ...baseServer, host: '  example.com  ', basePath: undefined };
+    const resolved = resolveServerEndpoint(server, 'primary');
+    expect(resolved.host).toBe('example.com');
+    expect(resolved.basePath).toBe('/');
+  });
+
+  it('keeps an explicit basePath for primary', () => {
+    const resolved = resolveServerEndpoint({ ...baseServer, basePath: '/qbt' }, 'primary');
+    expect(resolved.basePath).toBe('/qbt');
+  });
+
+  it('falls back to primary resolution when endpoint is "fallback" but no fallback is configured', () => {
+    const resolved = resolveServerEndpoint(baseServer, 'fallback');
+    expect(resolved.host).toBe('example.com');
+  });
+
+  it('resolves the fallback host/port/https/basePath when configured', () => {
+    const server: ServerConfig = {
+      ...baseServer,
+      useFallback: true,
+      fallbackHost: ' fallback.com ',
+      fallbackPort: 9090,
+      fallbackUseHttps: true,
+      fallbackBasePath: '/alt',
+    };
+    const resolved = resolveServerEndpoint(server, 'fallback');
+    expect(resolved.host).toBe('fallback.com');
+    expect(resolved.port).toBe(9090);
+    expect(resolved.useHttps).toBe(true);
+    expect(resolved.basePath).toBe('/alt');
+  });
+
+  it('falls back to primary useHttps/basePath when fallback overrides are unset', () => {
+    const server: ServerConfig = {
+      ...baseServer,
+      useHttps: true,
+      basePath: '/primary-path',
+      useFallback: true,
+      fallbackHost: 'fallback.com',
+    };
+    const resolved = resolveServerEndpoint(server, 'fallback');
+    expect(resolved.useHttps).toBe(true);
+    expect(resolved.basePath).toBe('/primary-path');
+  });
+
+  it('defaults fallback basePath to "/" when neither fallback nor primary basePath is set', () => {
+    const server: ServerConfig = {
+      ...baseServer,
+      basePath: undefined,
+      useFallback: true,
+      fallbackHost: 'fallback.com',
+    };
+    const resolved = resolveServerEndpoint(server, 'fallback');
+    expect(resolved.basePath).toBe('/');
+  });
+});
+
+describe('getServerEndpointLabel', () => {
+  it('returns the address string for the primary endpoint', () => {
+    expect(getServerEndpointLabel(baseServer, 'primary')).toBe('example.com:8080');
+  });
+
+  it('returns the address string for the fallback endpoint', () => {
+    const server: ServerConfig = {
+      ...baseServer,
+      useFallback: true,
+      fallbackHost: 'fallback.com',
+      fallbackPort: 443,
+    };
+    expect(getServerEndpointLabel(server, 'fallback')).toBe('fallback.com:443');
+  });
+});
+
+describe('getActiveEndpoint', () => {
+  it('returns null when activeServer is null', () => {
+    expect(getActiveEndpoint(baseServer, null)).toBeNull();
+  });
+
+  it('returns null when activeServer has a different id', () => {
+    expect(getActiveEndpoint(baseServer, { ...baseServer, id: 'other' })).toBeNull();
+  });
+
+  it('returns "primary" when activeServer matches the primary endpoint', () => {
+    expect(getActiveEndpoint(baseServer, { ...baseServer })).toBe('primary');
+  });
+
+  it('returns null when active matches neither primary nor a configured fallback', () => {
+    const activeServer: ServerConfig = { ...baseServer, host: 'other.com' };
+    expect(getActiveEndpoint(baseServer, activeServer)).toBeNull();
+  });
+
+  it('returns "fallback" when activeServer matches the fallback endpoint', () => {
+    const server: ServerConfig = {
+      ...baseServer,
+      useFallback: true,
+      fallbackHost: 'fallback.com',
+      fallbackPort: 9090,
+      fallbackUseHttps: true,
+    };
+    const activeServer: ServerConfig = {
+      ...server,
+      host: 'fallback.com',
+      port: 9090,
+      useHttps: true,
+    };
+    expect(getActiveEndpoint(server, activeServer)).toBe('fallback');
+  });
+
+  it('returns null when active matches neither primary nor fallback and fallback is not configured', () => {
+    const activeServer: ServerConfig = { ...baseServer, host: 'unrelated.com' };
+    expect(getActiveEndpoint(baseServer, activeServer)).toBeNull();
+  });
+
+  it('treats port 0/undefined as equivalent when comparing to primary', () => {
+    const server = { ...baseServer, port: undefined };
+    const activeServer: ServerConfig = { ...baseServer, port: 0 };
+    expect(getActiveEndpoint(server, activeServer)).toBe('primary');
+  });
+});

--- a/tests/utils/torrent-file.test.ts
+++ b/tests/utils/torrent-file.test.ts
@@ -71,4 +71,10 @@ describe('extractTorrentFile', () => {
     expect(extractTorrentFile(null)).toBeNull();
     expect(extractTorrentFile('')).toBeNull();
   });
+
+  it('falls back to the raw segment when percent-decoding fails (safeDecode catch)', () => {
+    // "%zz" is an invalid escape sequence for decodeURIComponent
+    const result = extractTorrentFile('file:///Inbox/bad%zzname.torrent');
+    expect(result?.name).toBe('bad%zzname.torrent');
+  });
 });

--- a/tests/utils/version.test.ts
+++ b/tests/utils/version.test.ts
@@ -1,0 +1,30 @@
+jest.mock('expo-constants', () => ({
+  __esModule: true,
+  default: {
+    expoConfig: { version: '1.2.3' },
+  },
+}));
+
+describe('APP_VERSION / getAppVersion', () => {
+  it('reads the version from Constants.expoConfig', () => {
+    jest.isolateModules(() => {
+      const { APP_VERSION, getAppVersion } = require('@/utils/version');
+      expect(APP_VERSION).toBe('1.2.3');
+      expect(getAppVersion()).toBe('1.2.3');
+    });
+  });
+
+  it('falls back to "N/A" when expoConfig is missing', () => {
+    jest.resetModules();
+    jest.doMock('expo-constants', () => ({
+      __esModule: true,
+      default: {},
+    }));
+    jest.isolateModules(() => {
+      const { APP_VERSION, getAppVersion } = require('@/utils/version');
+      expect(APP_VERSION).toBe('N/A');
+      expect(getAppVersion()).toBe('N/A');
+    });
+    jest.dontMock('expo-constants');
+  });
+});


### PR DESCRIPTION
- Split Jest into "node" and "rn" projects (jest-expo + @testing-library/react-native)
  to cover components, contexts, and hooks that need a React Native runtime.
- Add ~280 new tests across components, contexts, hooks, and services.
- Fix storageService.saveServer stripping a trailing slash from a pasted
  host URL, not just the protocol.