### PR TITLE
Use theme-colored outline stars in rate row

### DIFF
--- a/app/settings/about.tsx
+++ b/app/settings/about.tsx
@@ -199,7 +199,7 @@ export default function AboutScreen() {
                 </View>
                 <View style={styles.starsRow}>
                   {[0, 1, 2, 3, 4].map((i) => (
-                    <Ionicons key={i} name="star" size={14} color={colors.warning} />
+                    <Ionicons key={i} name="star-outline" size={14} color={colors.primary} />
                   ))}
                 </View>
               </TouchableOpacity>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Follow-up to the rate-app button merged in #141: the 5-star graphic used a hardcoded yellow fill (`star` icon, `colors.warning`), not the theme. Switches to `star-outline` (transparent fill) in `colors.primary` so it aligns with the theme like the row's other icons.

## Testing
- `npx tsc --noEmit` — clean
- Trivial icon/color change scoped to one line in `app/settings/about.tsx`; no logic change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7ac3-2fee-71bf-91a4-06270e901c1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7ac3-2fee-71bf-91a4-06270e901c1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

