### PR TITLE
Fix iOS launch/background crash risk and add UIScene lifecycle plugin

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -105,7 +105,17 @@ module.exports = {
     web: {
       favicon: './assets/favicon.png',
     },
-    plugins: ['expo-router', 'expo-font', 'expo-localization', "expo-mail-composer", "expo-secure-store", "expo-sharing", "expo-status-bar"],
+    plugins: [
+      'expo-router',
+      'expo-font',
+      'expo-localization',
+      'expo-mail-composer',
+      'expo-secure-store',
+      'expo-sharing',
+      'expo-status-bar',
+      // Temporary: Xcode 27 requires UIScene lifecycle; remove when Expo 57 ships it.
+      './plugins/withIosSceneLifecycle',
+    ],
     extra: {
       router: {},
       eas: {

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -21,6 +21,7 @@ import {
   Platform,
   Alert,
   LayoutAnimation,
+  InteractionManager,
 } from 'react-native';
 import { Swipeable, RectButton } from 'react-native-gesture-handler';
 import { useTranslation } from 'react-i18next';
@@ -246,18 +247,20 @@ export default function TorrentsScreen() {
       }
 
       if (variant === 'full') {
-        router.push({
-          pathname: '/torrents/add',
-          params: { magnet: magnetLink },
+        router.setParams({ magnet: undefined });
+        InteractionManager.runAfterInteractions(() => {
+          router.push({
+            pathname: '/torrents/add',
+            params: { magnet: magnetLink },
+          });
         });
-        router.replace('/');
         return;
       }
 
       setTorrentUrl(magnetLink);
       setSelectedFile(null);
       setShowAddModal(true);
-      router.replace('/');
+      router.setParams({ magnet: undefined });
     };
 
     void handleIncomingMagnet();
@@ -289,18 +292,26 @@ export default function TorrentsScreen() {
       }
 
       if (variant === 'full') {
-        router.push({
-          pathname: '/torrents/add',
-          params: { torrentFileUri: fileUri, torrentFileName: fileName },
+        router.setParams({
+          torrentFileUri: undefined,
+          torrentFileName: undefined,
         });
-        router.replace('/');
+        InteractionManager.runAfterInteractions(() => {
+          router.push({
+            pathname: '/torrents/add',
+            params: { torrentFileUri: fileUri, torrentFileName: fileName },
+          });
+        });
         return;
       }
 
       setSelectedFile({ uri: fileUri, name: fileName, mimeType: 'application/x-bittorrent' });
       setTorrentUrl('');
       setShowAddModal(true);
-      router.replace('/');
+      router.setParams({
+        torrentFileUri: undefined,
+        torrentFileName: undefined,
+      });
     };
 
     void handleIncomingTorrentFile();

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,6 +1,6 @@
 import '@/i18n';
-import { Stack, useRouter } from 'expo-router';
-import { Dimensions, Linking, View } from 'react-native';
+import { Stack, useRootNavigationState, useRouter } from 'expo-router';
+import { Dimensions, InteractionManager, Linking, View } from 'react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { useEffect, useRef } from 'react';
@@ -25,11 +25,19 @@ const { width } = Dimensions.get('window');
 function StackNavigator() {
   const { colors } = useTheme();
   const router = useRouter();
+  const rootNavigationState = useRootNavigationState();
   const lastHandledMagnetRef = useRef<{ value: string; at: number } | null>(null);
   const lastHandledTorrentFileRef = useRef<{ value: string; at: number } | null>(null);
+  const pendingInitialUrlRef = useRef<string | null>(null);
+  const initialUrlCheckedRef = useRef(false);
 
   useEffect(() => {
-    const handleIncomingUrl = (incomingUrl?: string | null) => {
+    const dispatchDeepLink = (incomingUrl?: string | null) => {
+      if (!rootNavigationState?.key) {
+        pendingInitialUrlRef.current = incomingUrl ?? null;
+        return;
+      }
+
       const magnetLink = extractMagnetLink(incomingUrl);
       if (magnetLink) {
         const now = Date.now();
@@ -42,9 +50,11 @@ function StackNavigator() {
         }
         lastHandledMagnetRef.current = { value: magnetLink, at: now };
 
-        router.push({
-          pathname: '/',
-          params: { magnet: magnetLink },
+        InteractionManager.runAfterInteractions(() => {
+          router.replace({
+            pathname: '/',
+            params: { magnet: magnetLink },
+          });
         });
         return;
       }
@@ -62,28 +72,39 @@ function StackNavigator() {
       }
       lastHandledTorrentFileRef.current = { value: torrentFile.uri, at: now };
 
-      router.push({
-        pathname: '/',
-        params: { torrentFileUri: torrentFile.uri, torrentFileName: torrentFile.name },
+      InteractionManager.runAfterInteractions(() => {
+        router.replace({
+          pathname: '/',
+          params: { torrentFileUri: torrentFile.uri, torrentFileName: torrentFile.name },
+        });
       });
     };
 
     const subscription = Linking.addEventListener('url', ({ url }) => {
-      handleIncomingUrl(url);
+      dispatchDeepLink(url);
     });
 
-    Linking.getInitialURL()
-      .then((url) => {
-        handleIncomingUrl(url);
-      })
-      .catch(() => {
-        // No initial URL — safe to ignore.
-      });
+    if (!initialUrlCheckedRef.current) {
+      initialUrlCheckedRef.current = true;
+      Linking.getInitialURL()
+        .then((url) => {
+          dispatchDeepLink(url);
+        })
+        .catch(() => {
+          // No initial URL — safe to ignore.
+        });
+    }
+
+    if (pendingInitialUrlRef.current) {
+      const pendingUrl = pendingInitialUrlRef.current;
+      pendingInitialUrlRef.current = null;
+      dispatchDeepLink(pendingUrl);
+    }
 
     return () => {
       subscription.remove();
     };
-  }, [router]);
+  }, [rootNavigationState?.key, router]);
 
   return (
     <View style={{ flex: 1, backgroundColor: colors.background }}>

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -16,6 +16,8 @@ export const CHANGELOG: ChangelogRelease[] = [
     date: '2026-07-18',
     changes: [
       'Fixed a bug where a server host pasted with a trailing slash (e.g. from a full URL) was saved with the slash intact instead of being stripped',
+      'Reduced iOS launch/navigation crash risk by deferring deep-link routing until navigation is ready and removing a push/replace race in magnet and .torrent open flows',
+      'Reduced iOS background/foreground crash risk by pausing heavy polling while the app is backgrounded and resuming sync/search after UI interactions complete',
     ],
   },
   {

--- a/context/TorrentContext.tsx
+++ b/context/TorrentContext.tsx
@@ -5,7 +5,7 @@
  * Known issues: isRecoveringFromBackground was a ref that didn't trigger re-renders (fixed to use state in Task 1.4d).
  */
 import React, { createContext, useContext, useState, useEffect, useCallback, useRef, ReactNode } from 'react';
-import { AppState, AppStateStatus } from 'react-native';
+import { AppState, AppStateStatus, InteractionManager } from 'react-native';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { TorrentInfo, MainData, ServerState, Category } from '@/types/api';
 import { syncApi } from '@/services/api/sync';
@@ -47,6 +47,7 @@ export function TorrentProvider({ children }: { children: ReactNode }) {
 
   const appStateRef = useRef(AppState.currentState);
   const lastActiveTime = useRef(Date.now());
+  const [isAppActive, setIsAppActive] = useState(AppState.currentState === 'active');
   const [isRecoveringState, setIsRecoveringState] = useState(false);
   const [initialLoadComplete, setInitialLoadComplete] = useState(false);
 
@@ -151,7 +152,7 @@ export function TorrentProvider({ children }: { children: ReactNode }) {
   } = useQuery<SyncState>({
     queryKey: ['torrents'],
     queryFn: syncQueryFn,
-    refetchInterval: 2000,
+    refetchInterval: isAppActive ? 2000 : false,
     enabled: isConnected,
   });
 
@@ -191,6 +192,7 @@ export function TorrentProvider({ children }: { children: ReactNode }) {
     const handleAppStateChange = async (nextAppState: AppStateStatus) => {
       const previousAppState = appStateRef.current;
       appStateRef.current = nextAppState;
+      setIsAppActive(nextAppState === 'active');
 
       if (previousAppState === 'background' && nextAppState === 'active') {
         lastActiveTime.current = Date.now();
@@ -213,7 +215,13 @@ export function TorrentProvider({ children }: { children: ReactNode }) {
           // Force full re-sync on foreground
           syncVersionRef.current++;
           ridRef.current = 0;
-          await queryClient.invalidateQueries({ queryKey: ['torrents'] });
+          await new Promise<void>((resolve) => {
+            InteractionManager.runAfterInteractions(() => {
+              queryClient
+                .invalidateQueries({ queryKey: ['torrents'] })
+                .finally(() => resolve());
+            });
+          });
           setIsRecoveringState(false);
         }
       } else if (nextAppState === 'background') {

--- a/context/TransferContext.tsx
+++ b/context/TransferContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, useEffect, useCallback, useRef, ReactNode } from 'react';
-import { AppState, AppStateStatus } from 'react-native';
+import { AppState, AppStateStatus, InteractionManager } from 'react-native';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { GlobalTransferInfo } from '@/types/api';
 import { transferApi } from '@/services/api/transfer';
@@ -46,6 +46,7 @@ export function TransferProvider({ children }: { children: ReactNode }) {
 
   const appStateRef = useRef(AppState.currentState);
   const lastActiveTime = useRef(Date.now());
+  const [isAppActive, setIsAppActive] = useState(AppState.currentState === 'active');
   const [isRecoveringState, setIsRecoveringState] = useState(false);
   const [mutationError, setMutationError] = useState<string | null>(null);
 
@@ -57,7 +58,7 @@ export function TransferProvider({ children }: { children: ReactNode }) {
   } = useQuery<GlobalTransferInfo>({
     queryKey: ['transfer'],
     queryFn: fetchTransferInfo,
-    refetchInterval: 3000,
+    refetchInterval: isAppActive ? 3000 : false,
     enabled: isConnected,
   });
 
@@ -82,6 +83,7 @@ export function TransferProvider({ children }: { children: ReactNode }) {
     const handleAppStateChange = async (nextState: AppStateStatus) => {
       const prevState = appStateRef.current;
       appStateRef.current = nextState;
+      setIsAppActive(nextState === 'active');
 
       if (prevState === 'background' && nextState === 'active') {
         lastActiveTime.current = Date.now();
@@ -98,7 +100,13 @@ export function TransferProvider({ children }: { children: ReactNode }) {
           // torrents sync poll fails the same way and TorrentContext's
           // reactive reconnect effect recovers the shared session for this
           // query too — only when it's actually needed.
-          await queryClient.invalidateQueries({ queryKey: ['transfer'] });
+          await new Promise<void>((resolve) => {
+            InteractionManager.runAfterInteractions(() => {
+              queryClient
+                .invalidateQueries({ queryKey: ['transfer'] })
+                .finally(() => resolve());
+            });
+          });
           setIsRecoveringState(false);
         }
       } else if (nextState === 'background') {

--- a/hooks/useSearchJob.ts
+++ b/hooks/useSearchJob.ts
@@ -13,7 +13,7 @@
  */
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { AppState, AppStateStatus } from 'react-native';
+import { AppState, AppStateStatus, InteractionManager } from 'react-native';
 import { searchApi } from '@/services/api/search';
 import {
   SearchJobStatus,
@@ -79,8 +79,10 @@ export function useSearchJob(): UseSearchJobResult {
   const [jobId, setJobId] = useState<number | null>(null);
   const [mutationError, setMutationError] = useState<string | null>(null);
   const [isStarting, setIsStarting] = useState(false);
+  const [isAppActive, setIsAppActive] = useState(AppState.currentState === 'active');
   // Track active job in a ref so unmount cleanup always sees the latest value.
   const activeJobRef = useRef<number | null>(null);
+  const appStateRef = useRef<AppStateStatus>(AppState.currentState);
 
   const queryKey = jobId !== null ? ['search', 'job', jobId] : ['search', 'job', 'idle'];
 
@@ -95,6 +97,7 @@ export function useSearchJob(): UseSearchJobResult {
     enabled: isConnected && jobId !== null,
     // Stop polling once the server reports the job is Stopped.
     refetchInterval: (query) => {
+      if (!isAppActive) return false;
       const latest = query.state.data;
       if (!latest) return POLL_INTERVAL_MS;
       return latest.status === 'Running' ? POLL_INTERVAL_MS : false;
@@ -224,9 +227,13 @@ export function useSearchJob(): UseSearchJobResult {
   // below picks it up and reconnects — but only when it's actually needed.
   useEffect(() => {
     const handle = (next: AppStateStatus) => {
+      appStateRef.current = next;
+      setIsAppActive(next === 'active');
       if (next === 'active' && activeJobRef.current !== null) {
-        queryClient.invalidateQueries({
-          queryKey: ['search', 'job', activeJobRef.current],
+        InteractionManager.runAfterInteractions(() => {
+          queryClient.invalidateQueries({
+            queryKey: ['search', 'job', activeJobRef.current],
+          });
         });
       }
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "react-native-gesture-handler": "~2.32.0",
         "react-native-reanimated": "4.5.0",
         "react-native-safe-area-context": "~5.7.0",
-        "react-native-screens": "4.25.2",
+        "react-native-screens": "4.26.2",
         "react-native-svg": "15.15.4",
         "react-native-web": "^0.21.0",
         "react-native-worklets": "0.10.0"
@@ -12061,9 +12061,9 @@
       }
     },
     "node_modules/react-native-screens": {
-      "version": "4.25.2",
-      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.25.2.tgz",
-      "integrity": "sha512-1Nj1fusFd+rIMKU/qC9yGKVG+3ofh11d3OdBQKL1iVvQfKvcB8vhvTGQf2TkfxW3bamxN+hCZIXmNuU0mRkyDg==",
+      "version": "4.26.2",
+      "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.26.2.tgz",
+      "integrity": "sha512-2XnWsZToKj76trGtEZzx5ELD/qOICFEprEeUntImmitQFVUkea27fiWdUSITArI356Y1qynpXZINW+Unbhky/A==",
       "license": "MIT",
       "dependencies": {
         "react-freeze": "^1.0.0",
@@ -12071,7 +12071,7 @@
       },
       "peerDependencies": {
         "react": "*",
-        "react-native": ">=0.82.0"
+        "react-native": "*"
       }
     },
     "node_modules/react-native-svg": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qRemote",
-  "version": "3.7.13",
+  "version": "3.7.14",
   "main": "index.ts",
   "scripts": {
     "start": "expo start --go",
@@ -41,7 +41,7 @@
     "react-native-gesture-handler": "~2.32.0",
     "react-native-reanimated": "4.5.0",
     "react-native-safe-area-context": "~5.7.0",
-    "react-native-screens": "4.25.2",
+    "react-native-screens": "4.26.2",
     "react-native-svg": "15.15.4",
     "react-native-web": "^0.21.0",
     "react-native-worklets": "0.10.0"

--- a/plugins/IOS_SCENE_LIFECYCLE_LICENSE.txt
+++ b/plugins/IOS_SCENE_LIFECYCLE_LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 YesterdaysLemon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/withIosSceneLifecycle.js
+++ b/plugins/withIosSceneLifecycle.js
@@ -1,0 +1,173 @@
+/**
+ * Temporary Expo config plugin for Xcode 27 / iOS 27 SDK:
+ * "Application failed to launch: UIScene life cycle is required..."
+ *
+ * Adapted from https://github.com/YesterdaysLemon/expo-ios-scene-lifecycle-plugin
+ * (MIT). Remove once Expo ships SceneDelegate in the SDK 57 template.
+ */
+const { withAppDelegate, withInfoPlist } = require('@expo/config-plugins');
+
+const sceneConfigurationMethod = `  public func application(
+    _ application: UIApplication,
+    configurationForConnecting connectingSceneSession: UISceneSession,
+    options: UIScene.ConnectionOptions
+  ) -> UISceneConfiguration {
+    let configuration = UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    configuration.delegateClass = SceneDelegate.self
+    return configuration
+  }
+`;
+
+const sceneDelegateClass = `class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+  var window: UIWindow?
+
+  func scene(
+    _ scene: UIScene,
+    willConnectTo session: UISceneSession,
+    options connectionOptions: UIScene.ConnectionOptions
+  ) {
+    guard let windowScene = scene as? UIWindowScene else {
+      return
+    }
+
+    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate,
+      let factory = appDelegate.reactNativeFactory else {
+      return
+    }
+
+    let nextWindow = UIWindow(windowScene: windowScene)
+    window = nextWindow
+    appDelegate.window = nextWindow
+
+    // Rebuild launch options from scene connection options so Linking.getInitialURL()
+    // still sees cold-start magnet / file URLs under the scene life cycle.
+    var launchOptions: [UIApplication.LaunchOptionsKey: Any] = [:]
+    if let url = connectionOptions.urlContexts.first?.url {
+      launchOptions[UIApplication.LaunchOptionsKey(rawValue: "UIApplicationLaunchOptionsURLKey")] = url
+    }
+    if let userActivity = connectionOptions.userActivities.first(where: {
+      $0.activityType == NSUserActivityTypeBrowsingWeb
+    }) {
+      launchOptions[UIApplication.LaunchOptionsKey(rawValue: "UIApplicationLaunchOptionsUserActivityDictionaryKey")] = [
+        "UIApplicationLaunchOptionsUserActivityTypeKey": userActivity.activityType,
+        "UIApplicationLaunchOptionsUserActivityKey": userActivity,
+      ]
+    }
+
+    factory.startReactNative(
+      withModuleName: "main",
+      in: nextWindow,
+      launchOptions: launchOptions.isEmpty ? nil : launchOptions)
+
+    if !connectionOptions.urlContexts.isEmpty {
+      self.scene(scene, openURLContexts: connectionOptions.urlContexts)
+    }
+  }
+
+  func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+    guard let urlContext = URLContexts.first,
+      let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
+      return
+    }
+
+    var options: [UIApplication.OpenURLOptionsKey: Any] = [
+      .openInPlace: urlContext.options.openInPlace,
+    ]
+
+    if let sourceApplication = urlContext.options.sourceApplication {
+      options[.sourceApplication] = sourceApplication
+    }
+
+    if let annotation = urlContext.options.annotation {
+      options[.annotation] = annotation
+    }
+
+    _ = appDelegate.application(UIApplication.shared, open: urlContext.url, options: options)
+  }
+}
+`;
+
+function addInfoPlistSceneManifest(config) {
+  return withInfoPlist(config, (nextConfig) => {
+    nextConfig.modResults.UIApplicationSceneManifest = {
+      UIApplicationSupportsMultipleScenes: false,
+      UISceneConfigurations: {
+        UIWindowSceneSessionRoleApplication: [
+          {
+            UISceneConfigurationName: 'Default Configuration',
+            UISceneDelegateClassName: '$(PRODUCT_MODULE_NAME).SceneDelegate',
+          },
+        ],
+      },
+    };
+
+    return nextConfig;
+  });
+}
+
+function patchAppDelegate(contents) {
+  if (contents.includes('class SceneDelegate: UIResponder, UIWindowSceneDelegate')) {
+    return contents;
+  }
+
+  let nextContents = contents;
+
+  const startupBlockPattern =
+    /#if os\(iOS\) \|\| os\(tvOS\)\n\s*window = UIWindow\(frame: UIScreen\.main\.bounds\)\n\s*factory\.startReactNative\(\n\s*withModuleName: "main",\n\s*in: window,\n\s*launchOptions: launchOptions\)\n#endif/;
+
+  if (!startupBlockPattern.test(nextContents)) {
+    throw new Error(
+      'Could not find the Expo AppDelegate React Native startup block to patch for UIScene lifecycle.',
+    );
+  }
+
+  nextContents = nextContents.replace(
+    startupBlockPattern,
+    `#if os(iOS) || os(tvOS)
+    if #unavailable(iOS 13.0) {
+      window = UIWindow(frame: UIScreen.main.bounds)
+      factory.startReactNative(
+        withModuleName: "main",
+        in: window,
+        launchOptions: launchOptions)
+    }
+#endif`,
+  );
+
+  if (!nextContents.includes('configurationForConnecting connectingSceneSession')) {
+    const linkingMarker = '\n  // Linking API';
+
+    if (!nextContents.includes(linkingMarker)) {
+      throw new Error(
+        'Could not find the AppDelegate linking section to insert the UIScene configuration method.',
+      );
+    }
+
+    nextContents = nextContents.replace(linkingMarker, `\n${sceneConfigurationMethod}\n  // Linking API`);
+  }
+
+  const reactNativeDelegateMarker = '\nclass ReactNativeDelegate: ExpoReactNativeFactoryDelegate';
+
+  if (!nextContents.includes(reactNativeDelegateMarker)) {
+    throw new Error('Could not find ReactNativeDelegate to insert SceneDelegate.');
+  }
+
+  return nextContents.replace(reactNativeDelegateMarker, `\n${sceneDelegateClass}${reactNativeDelegateMarker}`);
+}
+
+function addAppDelegateSceneLifecycle(config) {
+  return withAppDelegate(config, (nextConfig) => {
+    if (nextConfig.modResults.language !== 'swift') {
+      throw new Error(
+        `Cannot apply iOS scene lifecycle plugin to ${nextConfig.modResults.language} AppDelegate. Swift is required.`,
+      );
+    }
+
+    nextConfig.modResults.contents = patchAppDelegate(nextConfig.modResults.contents);
+    return nextConfig;
+  });
+}
+
+module.exports = function withIosSceneLifecycle(config) {
+  return addAppDelegateSceneLifecycle(addInfoPlistSceneManifest(config));
+};


### PR DESCRIPTION
## Summary
- Defer deep-link routing until navigation is ready and remove a push/replace race in the magnet/.torrent open flows, which could crash the app on cold launch or when two navigations raced
- Pause heavy polling (torrents, transfer, search) while the app is backgrounded and resume via `InteractionManager` once UI interactions settle, reducing background/foreground crash risk
- Add a temporary `withIosSceneLifecycle` Expo config plugin (MIT, adapted from `YesterdaysLemon/expo-ios-scene-lifecycle-plugin`) to satisfy Xcode 27's UIScene lifecycle requirement until Expo SDK 57 ships it natively
- Bump `react-native-screens` to 4.26.2
- Add changelog entries for the two crash-risk fixes (v3.7.14)

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 751 tests passing across 56 suites
- [x] `npm run lint` — 0 errors (188 pre-existing warnings, baseline noise)
- [ ] Manual verification on a device/simulator (not available in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)