### PR TITLE
Fix connection state bugs: persistent disconnect, servers page card, torrents not-connected splash

### DIFF
--- a/app/(tabs)/(torrents)/index.tsx
+++ b/app/(tabs)/(torrents)/index.tsx
@@ -76,7 +76,7 @@ export default function TorrentsScreen() {
     isRecoveringFromBackground,
     initialLoadComplete,
   } = useTorrents();
-  const { isConnected, currentServer, isLoading: serverIsLoading, connectToServer } = useServer();
+  const { isConnected, isLoading: serverIsLoading, connectToServer } = useServer();
   const { colors, isDark } = useTheme();
   const params = useLocalSearchParams<{
     magnet?: string | string[];
@@ -683,7 +683,7 @@ export default function TorrentsScreen() {
   const [connectErrors, setConnectErrors] = useState<Record<string, string>>({});
 
   useEffect(() => {
-    if (!isConnected && !currentServer) {
+    if (!isConnected) {
       setServersLoaded(false);
       ServerManager.getServers()
         .then((s) => {
@@ -695,7 +695,7 @@ export default function TorrentsScreen() {
           setServersLoaded(true);
         });
     }
-  }, [isConnected, currentServer]);
+  }, [isConnected]);
 
   const handleQuickConnect = useCallback(
     async (server: ServerConfig) => {
@@ -1065,8 +1065,11 @@ export default function TorrentsScreen() {
   ];
 
   // Early returns
-  // Only show "Not Connected" screen if no server is configured (check this FIRST)
-  if (!isConnected && !currentServer && !serverIsLoading) {
+  // Show the "Not Connected" quick-connect screen whenever there is no live
+  // connection (check this FIRST). currentServer intentionally survives a
+  // disconnect for one-tap reconnect, so it must NOT gate this screen —
+  // otherwise a disconnected app falls through to the empty torrent list.
+  if (!isConnected && !serverIsLoading) {
     return (
       <QuickConnectPanel
         savedServers={savedServers}

--- a/app/(tabs)/logs.tsx
+++ b/app/(tabs)/logs.tsx
@@ -26,7 +26,7 @@ import { LogEntry, PeerLogEntry } from '@/types/api';
 
 export default function LogsScreen() {
   const { t } = useTranslation();
-  const { isConnected, currentServer, isLoading: serverIsLoading } = useServer();
+  const { isConnected, isLoading: serverIsLoading } = useServer();
   const { initialLoadComplete } = useTorrents();
   const { colors, isDark } = useTheme();
   const [activeTab, setActiveTab] = useState<'app' | 'peer'>('app');
@@ -43,6 +43,21 @@ export default function LogsScreen() {
     warning: true,
     critical: true,
   });
+
+  // Drop the previous session's logs the moment the connection ends:
+  // last-log-id incremental fetching assumes a single server, so stale
+  // entries would mix with (and suppress) logs from the next connection.
+  // Render-time state adjustment (not an effect) per React guidance.
+  const [wasConnected, setWasConnected] = useState(isConnected);
+  if (wasConnected !== isConnected) {
+    setWasConnected(isConnected);
+    if (!isConnected) {
+      setAppLogs([]);
+      setPeerLogs([]);
+      setLastAppLogId(undefined);
+      setLastPeerLogId(undefined);
+    }
+  }
 
   useEffect(() => {
     if (isConnected) {
@@ -145,8 +160,10 @@ export default function LogsScreen() {
     );
   }, [peerLogs, searchQuery]);
 
-  // Only show "Not Connected" screen if no server is configured (check FIRST)
-  if (!isConnected && !currentServer && !serverIsLoading) {
+  // Show the "Not Connected" screen whenever there is no live connection
+  // (check FIRST). currentServer intentionally survives a disconnect, so it
+  // must not gate this screen.
+  if (!isConnected && !serverIsLoading) {
     return (
       <View style={[styles.center, { backgroundColor: colors.background }]}>
         <FocusAwareStatusBar barStyle={isDark ? 'light-content' : 'dark-content'} />

--- a/app/(tabs)/settings/servers.tsx
+++ b/app/(tabs)/settings/servers.tsx
@@ -35,6 +35,7 @@ import { parseServerImport } from '@/utils/server-export';
 function SwipeableServerItem({
   server,
   currentServer,
+  isConnected,
   colors,
   onPress,
   onConnect,
@@ -44,6 +45,7 @@ function SwipeableServerItem({
 }: {
   server: ServerConfig;
   currentServer: ServerConfig | null;
+  isConnected: boolean;
   colors: ThemeColors;
   onPress: () => void;
   onConnect: () => void;
@@ -117,7 +119,10 @@ function SwipeableServerItem({
   };
 
   const serverAddress = `${server.host}${server.port != null && server.port > 0 ? `:${server.port}` : ''}`;
-  const isConnectedToThis = currentServer?.id === server.id;
+  // currentServer is kept after a disconnect (for one-tap reconnect), so the
+  // live connection state must be checked too or this row would keep showing
+  // "Disconnect" forever.
+  const isConnectedToThis = isConnected && currentServer?.id === server.id;
 
   return (
     <View>
@@ -472,6 +477,7 @@ export default function ServersSettingsScreen() {
                     key={server.id}
                     server={server}
                     currentServer={currentServer}
+                    isConnected={isConnected}
                     colors={colors}
                     onPress={() => handleEditServer(server)}
                     onConnect={() => handleConnect(server)}

--- a/app/(tabs)/transfer.tsx
+++ b/app/(tabs)/transfer.tsx
@@ -79,7 +79,7 @@ export default function TransferScreen() {
     setAltDownloadLimit,
     setAltUploadLimit,
   } = useTransfer();
-  const { isConnected, currentServer, isLoading: serverIsLoading, connectToServer } = useServer();
+  const { isConnected, isLoading: serverIsLoading, connectToServer } = useServer();
   const {
     torrents,
     serverState,
@@ -99,7 +99,7 @@ export default function TransferScreen() {
   const [connectErrors, setConnectErrors] = useState<Record<string, string>>({});
 
   useEffect(() => {
-    if (!isConnected && !currentServer) {
+    if (!isConnected) {
       setServersLoaded(false);
       ServerManager.getServers()
         .then((s) => {
@@ -111,7 +111,7 @@ export default function TransferScreen() {
           setServersLoaded(true);
         });
     }
-  }, [isConnected, currentServer]);
+  }, [isConnected]);
 
   const handleQuickConnect = useCallback(
     async (server: ServerConfig) => {
@@ -380,7 +380,10 @@ export default function TransferScreen() {
 
   // --- Early returns for disconnected / loading / error states ---
 
-  if (!isConnected && !currentServer && !serverIsLoading) {
+  // Show the quick-connect screen whenever there is no live connection.
+  // currentServer intentionally survives a disconnect (for one-tap
+  // reconnect), so it must NOT gate this screen.
+  if (!isConnected && !serverIsLoading) {
     return (
       <QuickConnectPanel
         savedServers={savedServers}

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -20,6 +20,20 @@ export interface ChangelogRelease {
 
 export const CHANGELOG: ChangelogRelease[] = [
   {
+    version: '3.8.31',
+    date: '2026-07-26',
+    sections: [
+      {
+        title: 'Bugs Fixed',
+        items: [
+          'Disconnecting from a server now sticks across app launches — the app no longer auto-reconnects until you tap Connect again',
+          'Settings → Servers now correctly shows Connect after disconnecting instead of always showing Disconnect',
+          'The Torrents tab shows the Not Connected quick-connect screen when disconnected instead of the "No Torrents" empty state',
+        ],
+      },
+    ],
+  },
+  {
     version: '3.8.3',
     date: '2026-07-25',
     sections: [
@@ -48,7 +62,7 @@ export const CHANGELOG: ChangelogRelease[] = [
           'Editing a server updates the Settings connection card immediately, so one-tap Connect no longer retries the old address or credentials',
           'Path autocomplete no longer doubles the path when picking a suggestion, and filters while typing a partial folder name (e.g. /dat)',
         ],
-      }
+      },
     ],
   },
   {

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -24,22 +24,6 @@ export const CHANGELOG: ChangelogRelease[] = [
     date: '2026-07-26',
     sections: [
       {
-        title: 'Bugs Fixed',
-        items: [
-          'Disconnecting from a server now sticks across app launches — the app no longer auto-reconnects until you tap Connect again',
-          'Settings → Servers now correctly shows Connect after disconnecting instead of always showing Disconnect',
-          'The Torrents tab shows the Not Connected quick-connect screen when disconnected instead of the "No Torrents" empty state',
-          'The Transfer tab shows the Not Connected quick-connect screen when disconnected instead of "No transfer information"',
-          'The Logs screen shows its Not Connected message when disconnected, and clears the previous session\u2019s logs so they can\u2019t mix with the next server\u2019s',
-        ],
-      },
-    ],
-  },
-  {
-    version: '3.8.3',
-    date: '2026-07-25',
-    sections: [
-      {
         title: 'New Features',
         items: [
           'qBittorrent API key authentication (v5.2.0+ / WebAPI 2.14.1+) alongside username/password and bypass',
@@ -63,6 +47,11 @@ export const CHANGELOG: ChangelogRelease[] = [
           'Torrents sort menu opens under the sort button',
           'Editing a server updates the Settings connection card immediately, so one-tap Connect no longer retries the old address or credentials',
           'Path autocomplete no longer doubles the path when picking a suggestion, and filters while typing a partial folder name (e.g. /dat)',
+          'Disconnecting from a server now sticks across app launches — the app no longer auto-reconnects until you tap Connect again',
+          'Settings → Servers now correctly shows Connect after disconnecting instead of always showing Disconnect',
+          'The Torrents tab shows the Not Connected quick-connect screen when disconnected instead of the "No Torrents" empty state',
+          'The Transfer tab shows the Not Connected quick-connect screen when disconnected instead of "No transfer information"',
+          'The Logs screen shows its Not Connected message when disconnected, and clears the previous session\u2019s logs so they can\u2019t mix with the next server\u2019s',
         ],
       },
     ],

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -29,6 +29,8 @@ export const CHANGELOG: ChangelogRelease[] = [
           'Disconnecting from a server now sticks across app launches — the app no longer auto-reconnects until you tap Connect again',
           'Settings → Servers now correctly shows Connect after disconnecting instead of always showing Disconnect',
           'The Torrents tab shows the Not Connected quick-connect screen when disconnected instead of the "No Torrents" empty state',
+          'The Transfer tab shows the Not Connected quick-connect screen when disconnected instead of "No transfer information"',
+          'The Logs screen shows its Not Connected message when disconnected, and clears the previous session\u2019s logs so they can\u2019t mix with the next server\u2019s',
         ],
       },
     ],

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -33,12 +33,12 @@ export const CHANGELOG: ChangelogRelease[] = [
           'Custom category and tag sticker colors (Theme & Colors → Category & Tag Colors)',
           'Directory path autocomplete on save-path fields when connected to qBittorrent 5.0+',
           'Settings hub reorganized (Servers → Appearance → Server Settings → RSS → Search Plugins → Advanced), with Community links, Beer Fund / Rate, and a Connection card for Connect or Add Server',
-          'Search can auto-tag downloads by tracker when the preference is enabled (label clarified; preference key unchanged)',
         ],
       },
       {
         title: 'Bugs Fixed',
         items: [
+          'The auto-tag-by-tracker search setting now actually works — the toggle previously did nothing (label clarified; preference key unchanged)',
           'Tab bar: active tab icon and label both use the accent color so the selected tab is clear',
           'RSS "Search for This" re-runs the search when tapped again for the same title',
           'Category rename migrates custom sticker colors, cleans up orphan categories on partial failure, and ignores double-tap Confirm',

--- a/context/ServerContext.tsx
+++ b/context/ServerContext.tsx
@@ -64,6 +64,7 @@ export function ServerProvider({ children }: { children: ReactNode }) {
       try {
         const prefs = await storageService.getPreferences();
         const autoConnectLastServer = prefs.autoConnectLastServer !== false;
+        const manualDisconnect = await storageService.getManualDisconnect();
 
         let server: ServerConfig | null = null;
 
@@ -78,7 +79,15 @@ export function ServerProvider({ children }: { children: ReactNode }) {
           }
         }
 
-        if (server) {
+        if (server && manualDisconnect) {
+          // The user explicitly disconnected last session. Keep the server
+          // remembered so Settings can offer one-tap Connect, but stay
+          // offline until the user connects again.
+          clogInfo('CONN', 'Skipping startup auto-connect — user disconnected last session');
+          setCurrentServer(server);
+          setIsConnected(false);
+          setActiveEndpoint(null);
+        } else if (server) {
           setCurrentServer(server);
           try {
             const connected = await ServerManager.connectToServer(server);

--- a/services/server-manager.ts
+++ b/services/server-manager.ts
@@ -88,6 +88,9 @@ export class ServerManager {
       );
       apiClient.setServer(null);
       await storageService.setCurrentServerId(null);
+      // The remembered "user disconnected" state belonged to this server;
+      // don't let it suppress auto-connect for a different server later.
+      await storageService.setManualDisconnect(false);
     }
     await storageService.deleteServer(id);
   }
@@ -209,6 +212,7 @@ export class ServerManager {
         try {
           const versionInfo = await applicationApi.getVersion();
           await storageService.setCurrentServerId(server.id);
+          await storageService.setManualDisconnect(false);
           apiClient.setApiVersion(versionInfo.apiVersion);
           clogInfo(
             'CONN',
@@ -240,6 +244,7 @@ export class ServerManager {
         try {
           const versionInfo = await applicationApi.getVersion();
           await storageService.setCurrentServerId(server.id);
+          await storageService.setManualDisconnect(false);
           apiClient.setApiVersion(versionInfo.apiVersion);
           clogInfo(
             'CONN',
@@ -305,7 +310,15 @@ export class ServerManager {
     );
     apiClient.setServer(null);
     // Keep currentServerId so Settings can offer one-tap reconnect to the
-    // last server, and so auto-connect-last-server still has a target.
+    // last server, and so auto-connect-last-server still has a target — but
+    // remember the explicit disconnect so startup auto-connect skips it
+    // until the user connects again. Only when a server was actually
+    // connected: the disconnect that follows deleting the current server
+    // (apiClient already cleared) must not suppress auto-connect for a
+    // different server later.
+    if (previousServer) {
+      await storageService.setManualDisconnect(true);
+    }
   }
 
   /**

--- a/services/storage.ts
+++ b/services/storage.ts
@@ -7,6 +7,7 @@ const STORAGE_KEYS = {
   SERVERS: 'servers',
   CURRENT_SERVER_ID: 'current_server_id',
   PREFERENCES: 'preferences',
+  MANUAL_DISCONNECT: 'manual_disconnect',
 } as const;
 
 const stripProtocol = (host: string): string =>
@@ -185,6 +186,26 @@ export const storageService = {
     const id = await this.getCurrentServerId();
     if (!id) return null;
     return await this.getServer(id);
+  },
+
+  /**
+   * Remember that the user explicitly disconnected, so startup auto-connect
+   * doesn't immediately re-establish the session. Cleared on any successful
+   * connect.
+   */
+  async setManualDisconnect(value: boolean): Promise<void> {
+    if (value) {
+      await AsyncStorage.setItem(STORAGE_KEYS.MANUAL_DISCONNECT, 'true');
+    } else {
+      await AsyncStorage.removeItem(STORAGE_KEYS.MANUAL_DISCONNECT);
+    }
+  },
+
+  /**
+   * Whether the last session ended with an explicit user disconnect
+   */
+  async getManualDisconnect(): Promise<boolean> {
+    return (await AsyncStorage.getItem(STORAGE_KEYS.MANUAL_DISCONNECT)) === 'true';
   },
 
   /**

--- a/tests/rn/context/ServerContext.test.tsx
+++ b/tests/rn/context/ServerContext.test.tsx
@@ -27,6 +27,7 @@ jest.mock('@/services/api/client', () => ({
 jest.mock('@/services/storage', () => ({
   storageService: {
     getPreferences: jest.fn(),
+    getManualDisconnect: jest.fn(),
   },
 }));
 
@@ -68,6 +69,7 @@ async function renderProvider() {
 beforeEach(() => {
   jest.clearAllMocks();
   (storageService.getPreferences as jest.Mock).mockResolvedValue({});
+  (storageService.getManualDisconnect as jest.Mock).mockResolvedValue(false);
   (ServerManager.getCurrentServer as jest.Mock).mockResolvedValue(null);
   (ServerManager.getServers as jest.Mock).mockResolvedValue([]);
   (apiClient.getServer as jest.Mock).mockReturnValue(null);
@@ -125,6 +127,31 @@ describe('ServerContext', () => {
     await waitFor(() => expect(getLatest().isLoading).toBe(false));
     expect(ServerManager.getCurrentServer).not.toHaveBeenCalled();
     expect(getLatest().isConnected).toBe(true);
+  });
+
+  it('skips startup auto-connect after a manual disconnect but keeps the server for one-tap Connect', async () => {
+    (ServerManager.getCurrentServer as jest.Mock).mockResolvedValue(server1);
+    (storageService.getManualDisconnect as jest.Mock).mockResolvedValue(true);
+
+    const getLatest = await renderProvider();
+    await waitFor(() => expect(getLatest().isLoading).toBe(false));
+    expect(ServerManager.connectToServer).not.toHaveBeenCalled();
+    expect(getLatest().isConnected).toBe(false);
+    expect(getLatest().currentServer).toEqual(server1);
+  });
+
+  it('manual disconnect also suppresses the single-server fallback auto-connect', async () => {
+    (storageService.getPreferences as jest.Mock).mockResolvedValue({
+      autoConnectLastServer: false,
+    });
+    (ServerManager.getServers as jest.Mock).mockResolvedValue([server1]);
+    (storageService.getManualDisconnect as jest.Mock).mockResolvedValue(true);
+
+    const getLatest = await renderProvider();
+    await waitFor(() => expect(getLatest().isLoading).toBe(false));
+    expect(ServerManager.connectToServer).not.toHaveBeenCalled();
+    expect(getLatest().isConnected).toBe(false);
+    expect(getLatest().currentServer).toEqual(server1);
   });
 
   it('keeps currentServer when auto-connect fails so Settings can offer Connect', async () => {

--- a/tests/services/server-manager.test.ts
+++ b/tests/services/server-manager.test.ts
@@ -7,6 +7,8 @@ jest.mock('@/services/storage', () => ({
     setCurrentServerId: jest.fn(),
     getCurrentServerId: jest.fn(),
     getCurrentServer: jest.fn(),
+    setManualDisconnect: jest.fn(),
+    getManualDisconnect: jest.fn(),
   },
 }));
 
@@ -122,6 +124,7 @@ describe('ServerManager', () => {
       await ServerManager.deleteServer('s1');
       expect(mockApiClient.setServer).toHaveBeenCalledWith(null);
       expect(mockStorage.setCurrentServerId).toHaveBeenCalledWith(null);
+      expect(mockStorage.setManualDisconnect).toHaveBeenCalledWith(false);
       expect(mockStorage.deleteServer).toHaveBeenCalledWith('s1');
     });
 
@@ -200,6 +203,7 @@ describe('ServerManager', () => {
       const result = await ServerManager.connectToServer(makeServer());
       expect(result).toBe(true);
       expect(mockStorage.setCurrentServerId).toHaveBeenCalledWith('s1');
+      expect(mockStorage.setManualDisconnect).toHaveBeenCalledWith(false);
       expect(mockApiClient.setApiVersion).toHaveBeenCalledWith('2.9');
     });
 
@@ -345,6 +349,13 @@ describe('ServerManager', () => {
       expect(mockAuth.logout).toHaveBeenCalled();
       expect(mockApiClient.setServer).toHaveBeenCalledWith(null);
       expect(mockStorage.setCurrentServerId).not.toHaveBeenCalled();
+    });
+
+    it('disconnect records the manual disconnect so startup auto-connect skips it', async () => {
+      mockApiClient.getServer.mockReturnValue(makeServer());
+      mockAuth.logout.mockResolvedValueOnce(undefined);
+      await ServerManager.disconnect();
+      expect(mockStorage.setManualDisconnect).toHaveBeenCalledWith(true);
     });
 
     it('disconnect swallows logout errors', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes five connection-state bugs, all rooted in the same design: `currentServer` is intentionally kept after a disconnect (for one-tap reconnect), but several places treated "has a remembered server" as "is connected".

### 1. Manual disconnect now persists across launches
- New `manual_disconnect` AsyncStorage flag in `services/storage.ts`
- `ServerManager.disconnect()` sets it (only when a server was actually connected); every successful connect clears it; deleting the current server clears it so it can't suppress auto-connect for a different server
- `ServerContext`'s startup auto-connect honors the flag: the remembered server is still shown in the Settings hub with a Connect badge, but no connection is made until the user taps Connect

### 2. Settings → Servers card always said "Disconnect"
- `SwipeableServerItem` now receives `isConnected` and computes `isConnectedToThis = isConnected && currentServer?.id === server.id`, so the button correctly flips to "Connect" after any disconnect

### 3. Torrents tab showed "No Torrents" instead of the not-connected splash
- The `QuickConnectPanel` early return no longer requires `!currentServer` — it now shows whenever there's no live connection (`!isConnected && !serverIsLoading`), and the saved-servers list loads on the same condition

### 4. Transfer tab showed "No transfer information" instead of the not-connected splash (audit find)
- Same pattern and same fix as the Torrents tab: `QuickConnectPanel` shows whenever disconnected

### 5. Logs screen showed stale logs instead of its Not Connected message (audit find)
- Same early-return fix, plus the previous session's logs are cleared when the connection ends — the `last_known_id` incremental fetch assumes a single server, so stale entries would otherwise mix with (and suppress) the next server's logs

An audit of every other `useServer()` consumer (search, RSS screens, torrent detail/files, settings sub-screens, tab layout, TorrentContext/TransferContext/ApiVersionContext) confirmed they already gate on `isConnected` correctly.

### Changelog
- The unreleased top entry was consolidated: the five fixes were folded into the `3.8.3` entry, which was renamed to `3.8.31` (dated 2026-07-26) so the changelog carries a single upcoming release instead of a separate never-released entry. `package.json` untouched per release process.

## Testing
- `npx tsc --noEmit` — clean
- `npm test` — 63 suites / 868 tests pass, including new tests: disconnect records the manual-disconnect flag, connect clears it, startup skips auto-connect after a manual disconnect (both the last-server path and the single-server fallback) while keeping the server for one-tap Connect
- `npm run lint` — 0 errors, 201 warnings (exactly the pre-existing baseline)
- `npm run format` — clean

No device/simulator available in this environment, so no on-device verification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9d7b-53ee-77ce-bc37-f0ac863bc474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9d7b-53ee-77ce-bc37-f0ac863bc474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

