### PR TITLE
Fix inability to type "-1" for torrent share limits

### DIFF
--- a/app/(tabs)/(torrents)/torrent/[hash].tsx
+++ b/app/(tabs)/(torrents)/torrent/[hash].tsx
@@ -37,7 +37,7 @@ import { FocusAwareStatusBar } from '@/components/FocusAwareStatusBar';
 import { AnimatedProgressBar } from '@/components/AnimatedProgressBar';
 import { SpeedGraph } from '@/components/SpeedGraph';
 import { PieceMap } from '@/components/PieceMap';
-import { InputModal } from '@/components/InputModal';
+import { InputModal, InputModalPreset } from '@/components/InputModal';
 import { ConfirmModal } from '@/components/ConfirmModal';
 import { OptionPicker } from '@/components/OptionPicker';
 import { TagsModal } from '@/components/TagsModal';
@@ -49,7 +49,14 @@ import { tagsApi } from '@/services/api/tags';
 import { categoriesApi } from '@/services/api/categories';
 import { TorrentProperties, Tracker, TorrentFile, TorrentInfo } from '@/types/api';
 import { formatDate, formatProgress, formatAvailability } from '@/utils/format';
-import { getErrorMessage } from '@/utils/error';
+import { getErrorMessage, getErrorStatus } from '@/utils/error';
+import {
+  describeShareLimit,
+  parseShareLimitInput,
+  parseSpeedLimitInput,
+  SHARE_LIMIT_GLOBAL,
+  SHARE_LIMIT_UNLIMITED,
+} from '@/utils/limit-input';
 import { haptics } from '@/utils/haptics';
 
 const SPEED_HISTORY_LEN = 30;
@@ -152,6 +159,8 @@ export default function TorrentDetail() {
     defaultValue?: string;
     keyboardType?: 'default' | 'numeric' | 'numbers-and-punctuation';
     allowEmpty?: boolean;
+    validate?: (value: string) => string | null;
+    presets?: InputModalPreset[];
     onConfirm: (value: string) => void;
   }>({ title: '', onConfirm: () => {} });
   const [deleteConfirmVisible, setDeleteConfirmVisible] = useState(false);
@@ -169,6 +178,7 @@ export default function TorrentDetail() {
   // ── Data loading ──────────────────────────────────────────────────────
 
   useEffect(() => {
+    torrentGoneRef.current = false;
     if (hash && isConnected) {
       loadTorrentData();
     }
@@ -180,6 +190,32 @@ export default function TorrentDetail() {
     setDlHistory((prev) => [...prev.slice(1), dl]);
     setUlHistory((prev) => [...prev.slice(1), ul]);
   };
+
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  /** Latch so the two independent refresh paths can't both pop the screen. */
+  const torrentGoneRef = useRef(false);
+
+  /**
+   * The torrent no longer exists on the server — it was removed elsewhere, or a
+   * share limit with a "Remove torrent" action fired. Stop polling (otherwise we
+   * keep 404-ing every 2s), say so plainly, and leave the dead screen.
+   */
+  const handleTorrentGone = useCallback(() => {
+    if (torrentGoneRef.current) return;
+    torrentGoneRef.current = true;
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    showToast(t('torrentDetail.torrentRemoved'), 'error');
+    // Deep links can land here with nothing to go back to.
+    if (router.canGoBack()) {
+      router.back();
+    } else {
+      router.replace('/');
+    }
+  }, [showToast, t, router]);
 
   const loadTorrentData = async () => {
     try {
@@ -202,7 +238,13 @@ export default function TorrentDetail() {
       ]);
 
       const next = torrentList.length > 0 ? torrentList[0] : null;
-      if (next) setTorrent(next);
+      // torrents/info answers 200 with an empty list for a hash that's gone,
+      // so this — not the 404 below — is the usual signal.
+      if (!next) {
+        handleTorrentGone();
+        return null;
+      }
+      setTorrent(next);
       setProperties(props);
       setTrackers(trackersData);
       setFiles(filesData);
@@ -211,6 +253,13 @@ export default function TorrentDetail() {
       setLastUpdatedAt(new Date());
       return next;
     } catch (error: unknown) {
+      // torrents/properties 404s for an unknown hash. The other calls here are
+      // core endpoints present since WebAPI 2.0, so a 404 means the torrent is
+      // gone rather than the endpoint being unsupported.
+      if (getErrorStatus(error) === 404) {
+        handleTorrentGone();
+        return null;
+      }
       showToast(getErrorMessage(error), 'error');
       return null;
     } finally {
@@ -244,26 +293,31 @@ export default function TorrentDetail() {
       ]);
 
       const next = torrentList.length > 0 ? torrentList[0] : null;
-      if (next) setTorrent(next);
+      if (!next) {
+        handleTorrentGone();
+        return;
+      }
+      setTorrent(next);
       setProperties(props);
       setTrackers(trackersData);
       setFiles(filesData);
       setPieceStates(normalizePieceStates(piecesData));
-      if (next) {
-        const dl = (next.dlspeed ?? 0) / 1024 / 1024;
-        const ul = (next.upspeed ?? 0) / 1024 / 1024;
-        setDlHistory((prev) => [...prev.slice(1), dl]);
-        setUlHistory((prev) => [...prev.slice(1), ul]);
-      }
+      const dl = (next.dlspeed ?? 0) / 1024 / 1024;
+      const ul = (next.upspeed ?? 0) / 1024 / 1024;
+      setDlHistory((prev) => [...prev.slice(1), dl]);
+      setUlHistory((prev) => [...prev.slice(1), ul]);
       setLastUpdatedAt(new Date());
-    } catch {
-      // Silent failure — don't interrupt the user
+    } catch (error: unknown) {
+      // Still silent for ordinary failures — but a vanished torrent has to be
+      // acted on, or this poll 404s every 2 seconds forever.
+      if (getErrorStatus(error) === 404) {
+        handleTorrentGone();
+      }
     }
-  }, [hash]);
+  }, [hash, handleTorrentGone]);
 
   // ── Polling ───────────────────────────────────────────────────────────
 
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const appStateRef = useRef(AppState.currentState);
 
   const startPolling = useCallback(() => {
@@ -448,36 +502,62 @@ export default function TorrentDetail() {
     }
   };
 
+  /**
+   * Everything setShareLimits needs in order to leave alone what the user isn't
+   * editing. The sentinels ('Default', -2) mean "use the global setting", NOT
+   * "unchanged", so a limit edit that doesn't echo these back silently resets
+   * them — and a global action of "Remove torrent" then deletes the torrent.
+   */
+  const currentShareLimits = () => ({
+    inactiveSeedingTimeLimit: torrent?.inactive_seeding_time_limit,
+    shareLimitAction: torrent?.share_limit_action,
+    shareLimitsMode: torrent?.share_limits_mode,
+  });
+
+  const shareLimitPresets: InputModalPreset[] = [
+    { label: t('common.unlimited'), value: String(SHARE_LIMIT_UNLIMITED) },
+    { label: t('torrentDetail.useGlobal'), value: String(SHARE_LIMIT_GLOBAL) },
+  ];
+
+  /** Describe a ratio limit the user just set, resolving both sentinels to words. */
+  const formatShareRatio = (ratioLimit: number): string => {
+    if (ratioLimit === SHARE_LIMIT_GLOBAL) return t('torrentDetail.useGlobal');
+    if (ratioLimit < 0) return t('common.unlimited');
+    return ratioLimit.toFixed(2);
+  };
+
   const handleSetRatioLimit = () => {
-    const current =
-      torrent?.ratio_limit != null && torrent.ratio_limit >= 0
-        ? torrent.ratio_limit.toString()
-        : '';
+    const current = torrent?.ratio_limit != null ? torrent.ratio_limit.toString() : '';
     setInputModalConfig({
       title: t('torrentDetail.setRatioLimit'),
       message: t('torrentDetail.enterRatioLimit'),
       defaultValue: current,
       keyboardType: 'numbers-and-punctuation',
       allowEmpty: true,
+      validate: (value: string) =>
+        parseShareLimitInput(value) === null ? t('errors.validNumber') : null,
+      presets: shareLimitPresets,
       onConfirm: async (value: string) => {
+        const ratioLimit = parseShareLimitInput(value);
+        // validate() already blocks this; belt and braces so a bad value can
+        // never reach the server as an accidental "unlimited".
+        if (ratioLimit === null) {
+          showToast(t('errors.validNumber'), 'error');
+          return;
+        }
         setInputModalVisible(false);
         try {
           setActionLoading(true);
-          const ratioLimit = value.trim() === '' ? -1 : parseFloat(value);
-          const seedingTimeLimit =
-            torrent?.seeding_time_limit != null ? torrent.seeding_time_limit : -2;
-          await torrentsApi.setTorrentShareLimits(
-            [torrent!.hash],
-            Number.isFinite(ratioLimit) ? ratioLimit : -1,
-            seedingTimeLimit,
-          );
+          await torrentsApi.setTorrentShareLimits([torrent!.hash], {
+            ratioLimit,
+            seedingTimeLimit: torrent?.seeding_time_limit ?? SHARE_LIMIT_GLOBAL,
+            ...currentShareLimits(),
+          });
           await new Promise((resolve) => setTimeout(resolve, 500));
           await loadTorrentData();
           haptics.success();
           showToast(
-            t('torrentDetail.ratioLimitSet', {
-              value: value.trim() === '' ? t('common.unlimited') : ratioLimit.toFixed(2),
-            }),
+            t('torrentDetail.ratioLimitSet', { value: formatShareRatio(ratioLimit) }),
             'success',
           );
         } catch (error: unknown) {
@@ -492,35 +572,41 @@ export default function TorrentDetail() {
 
   const handleSetSeedingTimeLimit = () => {
     const current =
-      torrent?.seeding_time_limit != null && torrent.seeding_time_limit >= 0
-        ? torrent.seeding_time_limit.toString()
-        : '';
+      torrent?.seeding_time_limit != null ? torrent.seeding_time_limit.toString() : '';
     setInputModalConfig({
       title: t('torrentDetail.setSeedingTimeLimit'),
       message: t('torrentDetail.enterSeedingTimeMinutes'),
       defaultValue: current,
       keyboardType: 'numbers-and-punctuation',
       allowEmpty: true,
+      validate: (value: string) =>
+        parseShareLimitInput(value, { integer: true }) === null ? t('errors.validNumber') : null,
+      presets: shareLimitPresets,
       onConfirm: async (value: string) => {
+        const seedingTimeLimit = parseShareLimitInput(value, { integer: true });
+        if (seedingTimeLimit === null) {
+          showToast(t('errors.validNumber'), 'error');
+          return;
+        }
         setInputModalVisible(false);
         try {
           setActionLoading(true);
-          const seedingTimeLimit = value.trim() === '' ? -1 : parseInt(value, 10);
-          const ratioLimit = torrent?.ratio_limit != null ? torrent.ratio_limit : -2;
-          await torrentsApi.setTorrentShareLimits(
-            [torrent!.hash],
-            ratioLimit,
-            Number.isFinite(seedingTimeLimit) ? seedingTimeLimit : -1,
-          );
+          await torrentsApi.setTorrentShareLimits([torrent!.hash], {
+            ratioLimit: torrent?.ratio_limit ?? SHARE_LIMIT_GLOBAL,
+            seedingTimeLimit,
+            ...currentShareLimits(),
+          });
           await new Promise((resolve) => setTimeout(resolve, 500));
           await loadTorrentData();
           haptics.success();
           showToast(
             t('torrentDetail.seedingTimeLimitSet', {
               value:
-                value.trim() === '' || seedingTimeLimit < 0
-                  ? t('common.unlimited')
-                  : formatTime(seedingTimeLimit * 60),
+                seedingTimeLimit === SHARE_LIMIT_GLOBAL
+                  ? t('torrentDetail.useGlobal')
+                  : seedingTimeLimit < 0
+                    ? t('common.unlimited')
+                    : formatTime(seedingTimeLimit * 60),
             }),
             'success',
           );
@@ -701,11 +787,17 @@ export default function TorrentDetail() {
       defaultValue: properties?.dl_limit?.toString() || '0',
       keyboardType: 'numeric',
       allowEmpty: true,
+      validate: (value: string) =>
+        parseSpeedLimitInput(value) === null ? t('errors.validNumber') : null,
       onConfirm: async (value: string) => {
+        const limit = parseSpeedLimitInput(value);
+        if (limit === null) {
+          showToast(t('errors.validNumber'), 'error');
+          return;
+        }
         setInputModalVisible(false);
         try {
           setActionLoading(true);
-          const limit = parseInt(value) || 0;
           await torrentsApi.setTorrentDownloadLimit([torrent!.hash], limit);
           await new Promise((resolve) => setTimeout(resolve, 500));
           await loadTorrentData();
@@ -733,11 +825,17 @@ export default function TorrentDetail() {
       defaultValue: properties?.up_limit?.toString() || '0',
       keyboardType: 'numeric',
       allowEmpty: true,
+      validate: (value: string) =>
+        parseSpeedLimitInput(value) === null ? t('errors.validNumber') : null,
       onConfirm: async (value: string) => {
+        const limit = parseSpeedLimitInput(value);
+        if (limit === null) {
+          showToast(t('errors.validNumber'), 'error');
+          return;
+        }
         setInputModalVisible(false);
         try {
           setActionLoading(true);
-          const limit = parseInt(value) || 0;
           await torrentsApi.setTorrentUploadLimit([torrent!.hash], limit);
           await new Promise((resolve) => setTimeout(resolve, 500));
           await loadTorrentData();
@@ -969,6 +1067,32 @@ export default function TorrentDetail() {
     { label: t('torrentDetail.decrease'), value: 'decrease' },
     { label: t('torrentDetail.minimum'), value: 'min' },
   ];
+
+  /**
+   * Render a share-limit row value.
+   *
+   * `own` is the torrent's own setting (-2 = follow the global limit, -1 = none);
+   * `effective` is the limit qBittorrent will actually enforce, with -2 already
+   * resolved. Showing `own` alone reads "Unlimited" for a torrent that is in fact
+   * capped by the global limit, which is what this fixes.
+   */
+  const shareLimitValue = (
+    own: number | null | undefined,
+    effective: number | null | undefined,
+    format: (value: number) => string,
+  ): string => {
+    const described = describeShareLimit(own, effective);
+    switch (described.kind) {
+      case 'unlimited':
+        return t('common.unlimited');
+      case 'global':
+        return described.effective == null
+          ? t('common.unlimited')
+          : t('torrentDetail.globalLimit', { value: format(described.effective) });
+      case 'value':
+        return format(described.value);
+    }
+  };
 
   // ── Row render helpers ────────────────────────────────────────────────
 
@@ -1430,21 +1554,23 @@ export default function TorrentDetail() {
             {renderRows([
               tappableRow(
                 t('torrentDetail.ratioLimit'),
-                torrent.ratio_limit !== undefined && torrent.ratio_limit >= 0
-                  ? torrent.ratio_limit.toFixed(2)
-                  : t('common.unlimited'),
+                shareLimitValue(torrent.ratio_limit, torrent.max_ratio, (value) =>
+                  value.toFixed(2),
+                ),
                 handleSetRatioLimit,
               ),
               tappableRow(
                 t('torrentDetail.seedingTimeLimit'),
-                torrent.seeding_time_limit != null && torrent.seeding_time_limit >= 0
-                  ? formatTime(torrent.seeding_time_limit * 60)
-                  : t('common.unlimited'),
+                shareLimitValue(torrent.seeding_time_limit, torrent.max_seeding_time, (value) =>
+                  formatTime(value * 60),
+                ),
                 handleSetSeedingTimeLimit,
               ),
               staticRow(
                 t('torrentDetail.maxRatio'),
-                torrent.max_ratio >= 0 ? torrent.max_ratio.toFixed(2) : t('common.unlimited'),
+                torrent.max_ratio != null && torrent.max_ratio >= 0
+                  ? torrent.max_ratio.toFixed(2)
+                  : t('common.unlimited'),
               ),
               staticRow(t('torrentDetail.seedingTime'), formatTime(torrent.seeding_time)),
               properties && pathRow(t('torrentDetail.savePath'), properties.save_path),
@@ -1579,6 +1705,8 @@ export default function TorrentDetail() {
           defaultValue={inputModalConfig.defaultValue}
           keyboardType={inputModalConfig.keyboardType}
           allowEmpty={inputModalConfig.allowEmpty}
+          validate={inputModalConfig.validate}
+          presets={inputModalConfig.presets}
           onCancel={() => setInputModalVisible(false)}
           onConfirm={inputModalConfig.onConfirm}
         />
@@ -1766,14 +1894,22 @@ export default function TorrentDetail() {
             {pathModal &&
               (() => {
                 const minLeft = insets.left + PATH_POPOVER_MARGIN;
-                const maxLeft = windowWidth - insets.right - PATH_POPOVER_MARGIN - PATH_POPOVER_WIDTH;
-                const left = Math.max(minLeft, Math.min(pathModal.anchor.x - PATH_POPOVER_WIDTH / 2, maxLeft));
+                const maxLeft =
+                  windowWidth - insets.right - PATH_POPOVER_MARGIN - PATH_POPOVER_WIDTH;
+                const left = Math.max(
+                  minLeft,
+                  Math.min(pathModal.anchor.x - PATH_POPOVER_WIDTH / 2, maxLeft),
+                );
 
                 const minTop = insets.top + PATH_POPOVER_MARGIN;
-                const maxPopoverHeight = windowHeight - insets.top - insets.bottom - PATH_POPOVER_MARGIN * 2;
+                const maxPopoverHeight =
+                  windowHeight - insets.top - insets.bottom - PATH_POPOVER_MARGIN * 2;
                 const effectiveHeight = Math.min(pathPopoverHeight ?? 0, maxPopoverHeight);
                 const maxTop = windowHeight - insets.bottom - PATH_POPOVER_MARGIN - effectiveHeight;
-                const top = Math.max(minTop, Math.min(pathModal.anchor.y + PATH_POPOVER_ANCHOR_GAP, maxTop));
+                const top = Math.max(
+                  minTop,
+                  Math.min(pathModal.anchor.y + PATH_POPOVER_ANCHOR_GAP, maxTop),
+                );
 
                 return (
                   <View

--- a/app/(tabs)/(torrents)/torrent/[hash].tsx
+++ b/app/(tabs)/(torrents)/torrent/[hash].tsx
@@ -150,7 +150,7 @@ export default function TorrentDetail() {
     message?: string;
     placeholder?: string;
     defaultValue?: string;
-    keyboardType?: 'default' | 'numeric';
+    keyboardType?: 'default' | 'numeric' | 'numbers-and-punctuation';
     allowEmpty?: boolean;
     onConfirm: (value: string) => void;
   }>({ title: '', onConfirm: () => {} });
@@ -457,7 +457,7 @@ export default function TorrentDetail() {
       title: t('torrentDetail.setRatioLimit'),
       message: t('torrentDetail.enterRatioLimit'),
       defaultValue: current,
-      keyboardType: 'numeric',
+      keyboardType: 'numbers-and-punctuation',
       allowEmpty: true,
       onConfirm: async (value: string) => {
         setInputModalVisible(false);
@@ -499,7 +499,7 @@ export default function TorrentDetail() {
       title: t('torrentDetail.setSeedingTimeLimit'),
       message: t('torrentDetail.enterSeedingTimeMinutes'),
       defaultValue: current,
-      keyboardType: 'numeric',
+      keyboardType: 'numbers-and-punctuation',
       allowEmpty: true,
       onConfirm: async (value: string) => {
         setInputModalVisible(false);

--- a/components/InputModal.tsx
+++ b/components/InputModal.tsx
@@ -14,7 +14,7 @@ interface InputModalProps {
   defaultValue?: string;
   onCancel: () => void;
   onConfirm: (value: string) => void;
-  keyboardType?: 'default' | 'numeric' | 'email-address' | 'phone-pad';
+  keyboardType?: 'default' | 'numeric' | 'email-address' | 'phone-pad' | 'numbers-and-punctuation';
   multiline?: boolean;
   allowEmpty?: boolean;
   /** Suggests directory names as the user types (qBittorrent 5.0+ only; see PathAutocompleteInput). */

--- a/components/InputModal.tsx
+++ b/components/InputModal.tsx
@@ -5,6 +5,13 @@ import { useTheme } from '@/context/ThemeContext';
 import { PathAutocompleteInput } from '@/components/PathAutocompleteInput';
 import { spacing, borderRadius } from '@/constants/spacing';
 import { shadows } from '@/constants/shadows';
+import { buttonStyles, buttonText } from '@/constants/buttons';
+
+/** A one-tap value, for inputs whose useful answers are hard to type (e.g. "-1"). */
+export interface InputModalPreset {
+  label: string;
+  value: string;
+}
 
 interface InputModalProps {
   visible: boolean;
@@ -19,6 +26,14 @@ interface InputModalProps {
   allowEmpty?: boolean;
   /** Suggests directory names as the user types (qBittorrent 5.0+ only; see PathAutocompleteInput). */
   pathAutocomplete?: boolean;
+  /**
+   * Returns an error message for an invalid entry, or null when it's acceptable.
+   * While it returns a message the error is shown under the field and Confirm is
+   * disabled, so bad input can't reach the API.
+   */
+  validate?: (value: string) => string | null;
+  /** Chips that fill the field in one tap. */
+  presets?: InputModalPreset[];
 }
 
 export function InputModal({
@@ -33,23 +48,36 @@ export function InputModal({
   multiline = false,
   allowEmpty = false,
   pathAutocomplete = false,
+  validate,
+  presets,
 }: InputModalProps) {
   const { colors } = useTheme();
   const { t } = useTranslation();
   const [value, setValue] = useState(defaultValue || '');
+  const [touched, setTouched] = useState(false);
 
   // Update value when defaultValue changes (e.g., when modal opens)
   useEffect(() => {
     if (visible && defaultValue !== undefined) {
       setValue(defaultValue);
+      setTouched(false);
     }
   }, [visible, defaultValue]);
 
+  const validationError = validate ? validate(value) : null;
+  const isEmpty = value.trim() === '';
+  const canConfirm = (allowEmpty || !isEmpty) && !validationError;
+  // Don't scold the user about input they haven't typed yet.
+  const shownError = touched && validationError ? validationError : null;
+
   const handleConfirm = () => {
-    if (allowEmpty || value.trim()) {
-      onConfirm(value.trim());
+    if (!canConfirm) {
+      setTouched(true);
+      return;
     }
+    onConfirm(value.trim());
     setValue('');
+    setTouched(false);
   };
 
   const handleCancel = () => {
@@ -97,18 +125,48 @@ export function InputModal({
                 multiline && styles.inputMultiline,
                 {
                   backgroundColor: colors.background,
-                  borderColor: colors.surfaceOutline,
+                  borderColor: shownError ? colors.error : colors.surfaceOutline,
                   color: colors.text,
                 },
+                shownError != null && styles.inputWithError,
               ]}
               value={value}
-              onChangeText={setValue}
+              onChangeText={(next) => {
+                setValue(next);
+                setTouched(true);
+              }}
               placeholder={placeholder}
               placeholderTextColor={colors.textSecondary}
               keyboardType={keyboardType}
               multiline={multiline}
               autoFocus
             />
+          )}
+          {shownError && (
+            <Text style={[styles.errorText, { color: colors.error }]}>{shownError}</Text>
+          )}
+          {presets && presets.length > 0 && (
+            <View style={styles.presets}>
+              {presets.map((preset) => (
+                <TouchableOpacity
+                  key={preset.label}
+                  style={[
+                    buttonStyles.chip,
+                    {
+                      backgroundColor: colors.background,
+                      borderColor: colors.surfaceOutline,
+                      borderWidth: StyleSheet.hairlineWidth,
+                    },
+                  ]}
+                  onPress={() => {
+                    setValue(preset.value);
+                    setTouched(true);
+                  }}
+                >
+                  <Text style={[buttonText.chip, { color: colors.text }]}>{preset.label}</Text>
+                </TouchableOpacity>
+              ))}
+            </View>
           )}
           <View style={styles.buttons}>
             <TouchableOpacity
@@ -118,8 +176,13 @@ export function InputModal({
               <Text style={[styles.buttonText, { color: colors.text }]}>{t('common.cancel')}</Text>
             </TouchableOpacity>
             <TouchableOpacity
-              style={[styles.button, { backgroundColor: colors.primary }]}
+              style={[
+                styles.button,
+                { backgroundColor: colors.primary },
+                !canConfirm && styles.buttonDisabled,
+              ]}
               onPress={handleConfirm}
+              disabled={!canConfirm}
             >
               <Text style={[styles.buttonText, { color: colors.surface }]}>
                 {t('common.confirm')}
@@ -166,6 +229,20 @@ const styles = StyleSheet.create({
     minHeight: 100,
     textAlignVertical: 'top',
   },
+  // Tighten the gap so the error message reads as attached to the field.
+  inputWithError: {
+    marginBottom: spacing.xs,
+  },
+  errorText: {
+    fontSize: 13,
+    marginBottom: spacing.md,
+  },
+  presets: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: spacing.sm,
+    marginBottom: spacing.md,
+  },
   buttons: {
     flexDirection: 'row',
     justifyContent: 'flex-end',
@@ -177,6 +254,9 @@ const styles = StyleSheet.create({
     borderRadius: borderRadius.medium,
     minWidth: 80,
     alignItems: 'center',
+  },
+  buttonDisabled: {
+    opacity: 0.4,
   },
   buttonText: {
     fontSize: 16,

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -28,6 +28,10 @@ export const CHANGELOG: ChangelogRelease[] = [
         items: [
           'Fixed being unable to type "-1" (or "-2") for a torrent\'s ratio or seeding time share limit — the numeric keyboard had no minus-sign key',
           'Fixed setting a torrent\'s ratio or seeding time limit failing with "Missing required parameters" on qBittorrent 5.1+',
+          'Fixed changing a ratio or seeding time limit silently resetting the torrent\'s share limit action and inactive seeding limit to the server-wide defaults — on servers whose global action is "Remove torrent", this could delete the torrent',
+          'Ratio, seeding time and speed limit boxes now reject invalid entries instead of quietly applying "unlimited" (or reporting "NaN"), and offer one-tap Unlimited / Use global shortcuts',
+          'The Ratio Limit and Seeding Time Limit rows now read "Global (…)" when the torrent follows the server-wide limit, instead of incorrectly showing "Unlimited"',
+          'The torrent screen now tells you when a torrent no longer exists on the server and returns to the list, instead of showing a confusing "Endpoint not found" error',
         ],
       },
     ],

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -27,6 +27,7 @@ export const CHANGELOG: ChangelogRelease[] = [
         title: 'Bugs Fixed',
         items: [
           'Fixed being unable to type "-1" (or "-2") for a torrent\'s ratio or seeding time share limit — the numeric keyboard had no minus-sign key',
+          'Fixed setting a torrent\'s ratio or seeding time limit failing with "Missing required parameters" on qBittorrent 5.1+',
         ],
       },
     ],

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -20,6 +20,18 @@ export interface ChangelogRelease {
 
 export const CHANGELOG: ChangelogRelease[] = [
   {
+    version: '3.8.32',
+    date: '2026-07-27',
+    sections: [
+      {
+        title: 'Bugs Fixed',
+        items: [
+          'Fixed being unable to type "-1" (or "-2") for a torrent\'s ratio or seeding time share limit — the numeric keyboard had no minus-sign key',
+        ],
+      },
+    ],
+  },
+  {
     version: '3.8.31',
     date: '2026-07-26',
     sections: [

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -926,7 +926,10 @@
     "sectionAssigned": "Zugewiesen",
     "sectionAddFromLibrary": "Aus Bibliothek hinzufügen",
     "sectionNewTag": "Neuer Tag",
-    "longPressToDelete": "Lange drücken, um aus qBittorrent zu löschen"
+    "longPressToDelete": "Lange drücken, um aus qBittorrent zu löschen",
+    "globalLimit": "Serverweit ({{value}})",
+    "useGlobal": "Global verwenden",
+    "torrentRemoved": "Dieser Torrent ist nicht mehr auf dem Server"
   },
   "filters": {
     "all": "Alle",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -946,7 +946,10 @@
     "sectionAssigned": "Assigned",
     "sectionAddFromLibrary": "Add from library",
     "sectionNewTag": "New tag",
-    "longPressToDelete": "Long-press to delete from qBittorrent"
+    "longPressToDelete": "Long-press to delete from qBittorrent",
+    "globalLimit": "Global ({{value}})",
+    "useGlobal": "Use global",
+    "torrentRemoved": "This torrent is no longer on the server"
   },
   "filters": {
     "all": "All",

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -926,7 +926,10 @@
     "sectionAssigned": "Asignadas",
     "sectionAddFromLibrary": "Añadir de la biblioteca",
     "sectionNewTag": "Nueva etiqueta",
-    "longPressToDelete": "Mantén pulsado para eliminar de qBittorrent"
+    "longPressToDelete": "Mantén pulsado para eliminar de qBittorrent",
+    "globalLimit": "Global del servidor ({{value}})",
+    "useGlobal": "Usar global",
+    "torrentRemoved": "Este torrent ya no está en el servidor"
   },
   "filters": {
     "all": "Todos",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -926,7 +926,10 @@
     "sectionAssigned": "Assignées",
     "sectionAddFromLibrary": "Ajouter depuis la bibliothèque",
     "sectionNewTag": "Nouvelle étiquette",
-    "longPressToDelete": "Appui long pour supprimer de qBittorrent"
+    "longPressToDelete": "Appui long pour supprimer de qBittorrent",
+    "globalLimit": "Globale du serveur ({{value}})",
+    "useGlobal": "Valeur globale",
+    "torrentRemoved": "Ce torrent n'est plus sur le serveur"
   },
   "filters": {
     "all": "Tous",

--- a/locales/ru/translation.json
+++ b/locales/ru/translation.json
@@ -946,7 +946,10 @@
     "sectionAssigned": "Назначенные",
     "sectionAddFromLibrary": "Добавить из библиотеки",
     "sectionNewTag": "Новый тег",
-    "longPressToDelete": "Удерживайте, чтобы удалить из qBittorrent"
+    "longPressToDelete": "Удерживайте, чтобы удалить из qBittorrent",
+    "globalLimit": "Глобальный ({{value}})",
+    "useGlobal": "Глобальное",
+    "torrentRemoved": "Этого торрента больше нет на сервере"
   },
   "filters": {
     "all": "Все",

--- a/locales/zh/translation.json
+++ b/locales/zh/translation.json
@@ -926,7 +926,10 @@
     "sectionAssigned": "已分配",
     "sectionAddFromLibrary": "从库中添加",
     "sectionNewTag": "新建标签",
-    "longPressToDelete": "长按可从 qBittorrent 中删除"
+    "longPressToDelete": "长按可从 qBittorrent 中删除",
+    "globalLimit": "全局限制 ({{value}})",
+    "useGlobal": "使用全局",
+    "torrentRemoved": "该种子已不在服务器上"
   },
   "filters": {
     "all": "全部",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qRemote",
-  "version": "3.8.31",
+  "version": "3.8.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qRemote",
-      "version": "3.8.31",
+      "version": "3.8.32",
       "dependencies": {
         "@expo/vector-icons": "^15.1.1",
         "@react-native-async-storage/async-storage": "2.2.0",
@@ -7080,6 +7080,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9367,9 +9368,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9389,9 +9387,6 @@
       "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -9413,9 +9408,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9435,9 +9427,6 @@
       "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qRemote",
-  "version": "3.8.31",
+  "version": "3.8.32",
   "main": "index.ts",
   "scripts": {
     "start": "expo start --dev-client",

--- a/services/api/client.ts
+++ b/services/api/client.ts
@@ -9,6 +9,24 @@ import { clogDebug, clogInfo, clogWarn, clogError } from '@/services/connectivit
 import { ApiFeatures, getApiFeatures } from '@/utils/apiVersion';
 import { basicAuthHeader } from '@/utils/basicAuth';
 
+/** An error from the API client, carrying the HTTP status when the request got a response. */
+export interface ApiError extends Error {
+  status?: number;
+}
+
+/**
+ * Build the error the interceptor throws.
+ *
+ * The message text is load-bearing — callers substring-match these strings — so
+ * this only *adds* the status code alongside it, letting callers distinguish
+ * e.g. "this torrent is gone" (404) from a generic failure without parsing prose.
+ */
+function apiError(message: string, status?: number): ApiError {
+  const err = new Error(message) as ApiError;
+  if (status !== undefined) err.status = status;
+  return err;
+}
+
 class ApiClient {
   private client: AxiosInstance;
   private currentServer: ServerConfig | null = null;
@@ -141,7 +159,7 @@ class ApiClient {
         if (status === 403) {
           this.cookies = '';
           clogError('HTTP', `403 Forbidden — ${reqUrl}`);
-          throw new Error('Authentication failed. Please check your credentials.');
+          throw apiError('Authentication failed. Please check your credentials.', status);
         }
 
         // Handle rate limiting
@@ -150,7 +168,7 @@ class ApiClient {
           const retryAfter = headers['retry-after'] ?? headers['Retry-After'];
           const waitMsg = retryAfter ? ` Please retry after ${retryAfter} seconds.` : '';
           clogWarn('HTTP', `429 Rate Limited — ${reqUrl}${waitMsg}`);
-          throw new Error(`Rate limited by server.${waitMsg}`.trim());
+          throw apiError(`Rate limited by server.${waitMsg}`.trim(), status);
         }
 
         // 409 means different things on different endpoints — queueing
@@ -163,28 +181,30 @@ class ApiClient {
           );
           if (isPriorityEndpoint) {
             clogWarn('HTTP', `409 Conflict — ${reqUrl}`);
-            throw new Error(
+            throw apiError(
               'Torrent queueing must be enabled in qBittorrent to change priorities.',
+              status,
             );
           }
           const message = error.response?.data?.toString().trim();
           clogWarn('HTTP', `409 Conflict — ${reqUrl}: ${message || '(no body)'}`);
-          throw new Error(message || 'This torrent already exists or could not be added.');
+          throw apiError(message || 'This torrent already exists or could not be added.', status);
         }
 
         // Handle 404 Not Found errors
         if (status === 404) {
           const fullUrl = `${error.config?.baseURL}${error.config?.url}`;
           clogWarn('HTTP', `404 Not Found — ${fullUrl}`);
-          throw new Error(
+          throw apiError(
             `Endpoint not found: ${fullUrl}. Please check your qBittorrent version and API compatibility.`,
+            status,
           );
         }
 
         // Handle network errors
         if (error.code === 'ECONNABORTED' || error.code === 'ERR_NETWORK') {
           clogError('HTTP', `Network error (${error.code}) — ${reqUrl}`);
-          throw new Error('Connection timeout. Please check your server connection.');
+          throw apiError('Connection timeout. Please check your server connection.', status);
         }
 
         // Handle other errors
@@ -194,7 +214,7 @@ class ApiClient {
           'HTTP',
           `${status ? 'HTTP ' + status : error.code || 'Unknown'} — ${reqUrl}: ${message}`,
         );
-        throw new Error(message);
+        throw apiError(message, status);
       },
     );
   }

--- a/services/api/torrents.ts
+++ b/services/api/torrents.ts
@@ -470,31 +470,43 @@ export const torrentsApi = {
   },
 
   /**
-   * Set torrent share limit
+   * Set torrent share limits.
+   *
+   * Newer qBittorrent (5.x / WebAPI ≥ 2.11.0) REQUIRES inactiveSeedingTimeLimit,
+   * shareLimitAction and shareLimitsMode — omitting them fails the request with
+   * "Missing required parameters". They are not "leave unchanged" parameters
+   * though: the server applies whatever it receives, and the sentinel values
+   * ('Default', -2) mean "fall back to the global setting". Sending those blindly
+   * wipes the torrent's own share-limit action, and if the global action is
+   * "Remove" the server can delete a torrent the user only meant to re-limit.
+   *
+   * So callers must pass the torrent's CURRENT values (straight off `torrents/info`)
+   * for everything they are not deliberately changing; the sentinels below are a
+   * last resort for servers that don't report the field at all.
    */
   async setTorrentShareLimits(
     hashes: string[],
-    ratioLimit?: number,
-    seedingTimeLimit?: number,
-    inactiveSeedingTimeLimit?: number,
+    limits: {
+      ratioLimit?: number;
+      seedingTimeLimit?: number;
+      inactiveSeedingTimeLimit?: number;
+      shareLimitAction?: string;
+      shareLimitsMode?: string;
+    } = {},
   ): Promise<void> {
     const params: Record<string, string | number | boolean> = {
       hashes: hashes.join('|'),
     };
-    if (ratioLimit !== undefined) {
-      params.ratioLimit = ratioLimit;
+    if (limits.ratioLimit !== undefined) {
+      params.ratioLimit = limits.ratioLimit;
     }
-    if (seedingTimeLimit !== undefined) {
-      params.seedingTimeLimit = seedingTimeLimit;
+    if (limits.seedingTimeLimit !== undefined) {
+      params.seedingTimeLimit = limits.seedingTimeLimit;
     }
-    // qBittorrent 5.1+ (WebAPI 2.11.0+) requires these three params too, or
-    // setShareLimits fails with "Missing required parameters". There's no UI
-    // for shareLimitAction/shareLimitsMode yet, so send "Default" (keeps the
-    // server's existing per-torrent/global behavior unchanged).
     if (apiClient.getApiFeatures().supportsInactiveSeedingLimit) {
-      params.inactiveSeedingTimeLimit = inactiveSeedingTimeLimit ?? -2;
-      params.shareLimitAction = 'Default';
-      params.shareLimitsMode = 'Default';
+      params.inactiveSeedingTimeLimit = limits.inactiveSeedingTimeLimit ?? -2;
+      params.shareLimitAction = limits.shareLimitAction ?? 'Default';
+      params.shareLimitsMode = limits.shareLimitsMode ?? 'Default';
     }
     await apiClient.postUrlEncoded(`/api/${API_VERSION}/torrents/setShareLimits`, params);
   },

--- a/services/api/torrents.ts
+++ b/services/api/torrents.ts
@@ -476,6 +476,7 @@ export const torrentsApi = {
     hashes: string[],
     ratioLimit?: number,
     seedingTimeLimit?: number,
+    inactiveSeedingTimeLimit?: number,
   ): Promise<void> {
     const params: Record<string, string | number | boolean> = {
       hashes: hashes.join('|'),
@@ -485,6 +486,15 @@ export const torrentsApi = {
     }
     if (seedingTimeLimit !== undefined) {
       params.seedingTimeLimit = seedingTimeLimit;
+    }
+    // qBittorrent 5.1+ (WebAPI 2.11.0+) requires these three params too, or
+    // setShareLimits fails with "Missing required parameters". There's no UI
+    // for shareLimitAction/shareLimitsMode yet, so send "Default" (keeps the
+    // server's existing per-torrent/global behavior unchanged).
+    if (apiClient.getApiFeatures().supportsInactiveSeedingLimit) {
+      params.inactiveSeedingTimeLimit = inactiveSeedingTimeLimit ?? -2;
+      params.shareLimitAction = 'Default';
+      params.shareLimitsMode = 'Default';
     }
     await apiClient.postUrlEncoded(`/api/${API_VERSION}/torrents/setShareLimits`, params);
   },

--- a/tests/rn/components/InputModal.test.tsx
+++ b/tests/rn/components/InputModal.test.tsx
@@ -11,6 +11,7 @@ jest.mock('@/context/ThemeContext', () => ({
       background: '#eee',
       surfaceOutline: '#ccc',
       primary: '#00f',
+      error: '#f00',
     },
   }),
 }));
@@ -199,5 +200,129 @@ describe('InputModal', () => {
     );
     const textInput = screen.getByPlaceholderText('p');
     expect(textInput.props.keyboardType).toBe('numeric');
+  });
+
+  describe('validation', () => {
+    const invalidUnlessNumber = (v: string) => (/^\d*$/.test(v) ? null : 'not a number');
+
+    it('does not show an error before the user has typed anything', async () => {
+      await render(
+        <InputModal
+          visible
+          title="Limit"
+          placeholder="p"
+          defaultValue="oops"
+          onCancel={jest.fn()}
+          onConfirm={jest.fn()}
+          allowEmpty
+          validate={invalidUnlessNumber}
+        />,
+      );
+      expect(screen.queryByText('not a number')).toBeNull();
+    });
+
+    it('shows the error once the value has been edited', async () => {
+      await render(
+        <InputModal
+          visible
+          title="Limit"
+          placeholder="p"
+          onCancel={jest.fn()}
+          onConfirm={jest.fn()}
+          allowEmpty
+          validate={invalidUnlessNumber}
+        />,
+      );
+      await fireEvent.changeText(screen.getByPlaceholderText('p'), 'abc');
+      expect(screen.getByText('not a number')).toBeTruthy();
+    });
+
+    it('blocks confirm while the value is invalid', async () => {
+      const onConfirm = jest.fn();
+      await render(
+        <InputModal
+          visible
+          title="Limit"
+          placeholder="p"
+          onCancel={jest.fn()}
+          onConfirm={onConfirm}
+          allowEmpty
+          validate={invalidUnlessNumber}
+        />,
+      );
+      await fireEvent.changeText(screen.getByPlaceholderText('p'), 'abc');
+      await fireEvent.press(screen.getByText('common.confirm'));
+      expect(onConfirm).not.toHaveBeenCalled();
+    });
+
+    it('confirms once the value becomes valid', async () => {
+      const onConfirm = jest.fn();
+      await render(
+        <InputModal
+          visible
+          title="Limit"
+          placeholder="p"
+          onCancel={jest.fn()}
+          onConfirm={onConfirm}
+          allowEmpty
+          validate={invalidUnlessNumber}
+        />,
+      );
+      await fireEvent.changeText(screen.getByPlaceholderText('p'), 'abc');
+      await fireEvent.changeText(screen.getByPlaceholderText('p'), '42');
+      expect(screen.queryByText('not a number')).toBeNull();
+      await fireEvent.press(screen.getByText('common.confirm'));
+      expect(onConfirm).toHaveBeenCalledWith('42');
+    });
+
+    it('renders no error row when no validate prop is given', async () => {
+      await render(
+        <InputModal
+          visible
+          title="Rename"
+          placeholder="p"
+          onCancel={jest.fn()}
+          onConfirm={jest.fn()}
+        />,
+      );
+      await fireEvent.changeText(screen.getByPlaceholderText('p'), 'anything');
+      expect(screen.queryByText('not a number')).toBeNull();
+    });
+  });
+
+  describe('presets', () => {
+    it('fills the input when a preset chip is tapped, without confirming', async () => {
+      const onConfirm = jest.fn();
+      await render(
+        <InputModal
+          visible
+          title="Limit"
+          placeholder="p"
+          onCancel={jest.fn()}
+          onConfirm={onConfirm}
+          allowEmpty
+          presets={[
+            { label: 'Unlimited', value: '-1' },
+            { label: 'Use global', value: '-2' },
+          ]}
+        />,
+      );
+      await fireEvent.press(screen.getByText('Use global'));
+      expect(screen.getByPlaceholderText('p').props.value).toBe('-2');
+      expect(onConfirm).not.toHaveBeenCalled();
+    });
+
+    it('renders no chips when presets are omitted', async () => {
+      await render(
+        <InputModal
+          visible
+          title="Rename"
+          placeholder="p"
+          onCancel={jest.fn()}
+          onConfirm={jest.fn()}
+        />,
+      );
+      expect(screen.queryByText('Unlimited')).toBeNull();
+    });
   });
 });

--- a/tests/services/client.test.ts
+++ b/tests/services/client.test.ts
@@ -313,6 +313,22 @@ describe('apiClient', () => {
       expect(() => capturedResponseInterceptorError!(err)).toThrow(/Endpoint not found/);
     });
 
+    // The message text stays the callers' contract, but the status lets a caller
+    // tell "this torrent is gone" from "this endpoint doesn't exist" without
+    // parsing prose. The torrent detail screen relies on this.
+    it.each([[403], [404], [409], [429]])('attaches HTTP %i to the thrown error', (status) => {
+      const err = makeErr({
+        config: { baseURL: 'http://example.com', url: '/api/v2/torrents/add' },
+        response: { status },
+      });
+      try {
+        capturedResponseInterceptorError!(err);
+        throw new Error('expected the interceptor to throw');
+      } catch (thrown: unknown) {
+        expect((thrown as { status?: number }).status).toBe(status);
+      }
+    });
+
     it('normalizes ECONNABORTED to connection timeout error', () => {
       const err = makeErr({ code: 'ECONNABORTED' });
       expect(() => capturedResponseInterceptorError!(err)).toThrow(

--- a/tests/services/torrents.test.ts
+++ b/tests/services/torrents.test.ts
@@ -409,6 +409,30 @@ describe('torrentsApi', () => {
         seedingTimeLimit: 60,
       });
     });
+
+    it('includes inactiveSeedingTimeLimit/shareLimitAction/shareLimitsMode on 5.x (required by qBittorrent 5.1+)', async () => {
+      mockGetApiFeatures.mockReturnValue({ supportsInactiveSeedingLimit: true });
+      mockPost.mockResolvedValueOnce(undefined);
+      await torrentsApi.setTorrentShareLimits(['h1'], 2, 60);
+      expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/setShareLimits', {
+        hashes: 'h1',
+        ratioLimit: 2,
+        seedingTimeLimit: 60,
+        inactiveSeedingTimeLimit: -2,
+        shareLimitAction: 'Default',
+        shareLimitsMode: 'Default',
+      });
+    });
+
+    it('uses provided inactiveSeedingTimeLimit on 5.x instead of the -2 default', async () => {
+      mockGetApiFeatures.mockReturnValue({ supportsInactiveSeedingLimit: true });
+      mockPost.mockResolvedValueOnce(undefined);
+      await torrentsApi.setTorrentShareLimits(['h1'], 2, 60, 30);
+      expect(mockPost).toHaveBeenCalledWith(
+        '/api/v2/torrents/setShareLimits',
+        expect.objectContaining({ inactiveSeedingTimeLimit: 30 }),
+      );
+    });
   });
 
   describe('getTorrentUploadLimit', () => {

--- a/tests/services/torrents.test.ts
+++ b/tests/services/torrents.test.ts
@@ -402,7 +402,7 @@ describe('torrentsApi', () => {
     });
     it('sends both limits when provided', async () => {
       mockPost.mockResolvedValueOnce(undefined);
-      await torrentsApi.setTorrentShareLimits(['h1'], 2, 60);
+      await torrentsApi.setTorrentShareLimits(['h1'], { ratioLimit: 2, seedingTimeLimit: 60 });
       expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/setShareLimits', {
         hashes: 'h1',
         ratioLimit: 2,
@@ -413,7 +413,7 @@ describe('torrentsApi', () => {
     it('includes inactiveSeedingTimeLimit/shareLimitAction/shareLimitsMode on 5.x (required by qBittorrent 5.1+)', async () => {
       mockGetApiFeatures.mockReturnValue({ supportsInactiveSeedingLimit: true });
       mockPost.mockResolvedValueOnce(undefined);
-      await torrentsApi.setTorrentShareLimits(['h1'], 2, 60);
+      await torrentsApi.setTorrentShareLimits(['h1'], { ratioLimit: 2, seedingTimeLimit: 60 });
       expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/setShareLimits', {
         hashes: 'h1',
         ratioLimit: 2,
@@ -424,10 +424,37 @@ describe('torrentsApi', () => {
       });
     });
 
+    // Regression guard: 'Default' means "use the global setting", not "leave
+    // unchanged". Hardcoding it wiped the torrent's own share-limit action, and
+    // with a global action of "Remove torrent" the server deleted the torrent.
+    it('round-trips the current share limit action/mode instead of resetting them to Default', async () => {
+      mockGetApiFeatures.mockReturnValue({ supportsInactiveSeedingLimit: true });
+      mockPost.mockResolvedValueOnce(undefined);
+      await torrentsApi.setTorrentShareLimits(['h1'], {
+        ratioLimit: 2,
+        seedingTimeLimit: 60,
+        inactiveSeedingTimeLimit: 1440,
+        shareLimitAction: 'Remove',
+        shareLimitsMode: 'MatchAll',
+      });
+      expect(mockPost).toHaveBeenCalledWith('/api/v2/torrents/setShareLimits', {
+        hashes: 'h1',
+        ratioLimit: 2,
+        seedingTimeLimit: 60,
+        inactiveSeedingTimeLimit: 1440,
+        shareLimitAction: 'Remove',
+        shareLimitsMode: 'MatchAll',
+      });
+    });
+
     it('uses provided inactiveSeedingTimeLimit on 5.x instead of the -2 default', async () => {
       mockGetApiFeatures.mockReturnValue({ supportsInactiveSeedingLimit: true });
       mockPost.mockResolvedValueOnce(undefined);
-      await torrentsApi.setTorrentShareLimits(['h1'], 2, 60, 30);
+      await torrentsApi.setTorrentShareLimits(['h1'], {
+        ratioLimit: 2,
+        seedingTimeLimit: 60,
+        inactiveSeedingTimeLimit: 30,
+      });
       expect(mockPost).toHaveBeenCalledWith(
         '/api/v2/torrents/setShareLimits',
         expect.objectContaining({ inactiveSeedingTimeLimit: 30 }),

--- a/tests/utils/limit-input.test.ts
+++ b/tests/utils/limit-input.test.ts
@@ -1,0 +1,128 @@
+import {
+  describeShareLimit,
+  normalizeNumericInput,
+  parseShareLimitInput,
+  parseSpeedLimitInput,
+  SHARE_LIMIT_GLOBAL,
+  SHARE_LIMIT_UNLIMITED,
+} from '@/utils/limit-input';
+
+describe('normalizeNumericInput', () => {
+  it('trims surrounding whitespace', () => {
+    expect(normalizeNumericInput('  2.5  ')).toBe('2.5');
+  });
+
+  it('accepts the decimal comma used by the es/fr/de/ru keyboards', () => {
+    expect(normalizeNumericInput('1,5')).toBe('1.5');
+  });
+
+  it.each([
+    ['−1', '-1'], // minus sign
+    ['–1', '-1'], // en dash
+    ['—1', '-1'], // em dash
+  ])('rewrites %s to an ASCII hyphen', (input, expected) => {
+    expect(normalizeNumericInput(input)).toBe(expected);
+  });
+});
+
+describe('parseShareLimitInput', () => {
+  it('treats an empty value as unlimited', () => {
+    expect(parseShareLimitInput('')).toBe(SHARE_LIMIT_UNLIMITED);
+    expect(parseShareLimitInput('   ')).toBe(SHARE_LIMIT_UNLIMITED);
+  });
+
+  it.each([
+    ['0', 0],
+    ['2', 2],
+    ['2.5', 2.5],
+    ['.5', 0.5],
+    [' 2 ', 2],
+    ['-1', SHARE_LIMIT_UNLIMITED],
+    ['-2', SHARE_LIMIT_GLOBAL],
+  ])('parses %s', (input, expected) => {
+    expect(parseShareLimitInput(input)).toBe(expected);
+  });
+
+  it('accepts the sentinels typed with a Unicode minus or decimal comma', () => {
+    expect(parseShareLimitInput('−1')).toBe(SHARE_LIMIT_UNLIMITED);
+    expect(parseShareLimitInput('1,5')).toBe(1.5);
+  });
+
+  // The whole point of not using parseFloat: it returns 1.2 for '1.2.3' and NaN
+  // for 'abc', and NaN then read as "unlimited" downstream while the success
+  // toast printed "NaN".
+  it.each([['abc'], ['1.2.3'], ['1e5'], ['--1'], ['1 2'], ['$5'], ['-'], ['.']])(
+    'rejects %s',
+    (input) => {
+      expect(parseShareLimitInput(input)).toBeNull();
+    },
+  );
+
+  it('rejects negatives that are not one of the two sentinels', () => {
+    expect(parseShareLimitInput('-3')).toBeNull();
+    expect(parseShareLimitInput('-0.5')).toBeNull();
+  });
+
+  describe('integer mode (seeding time in minutes)', () => {
+    it('accepts whole numbers and the sentinels', () => {
+      expect(parseShareLimitInput('60', { integer: true })).toBe(60);
+      expect(parseShareLimitInput('-2', { integer: true })).toBe(SHARE_LIMIT_GLOBAL);
+    });
+
+    it('rejects decimals', () => {
+      expect(parseShareLimitInput('60.5', { integer: true })).toBeNull();
+    });
+  });
+});
+
+describe('parseSpeedLimitInput', () => {
+  it('treats an empty value as 0, which qBittorrent reads as unlimited', () => {
+    expect(parseSpeedLimitInput('')).toBe(0);
+  });
+
+  it('parses non-negative numbers', () => {
+    expect(parseSpeedLimitInput('0')).toBe(0);
+    expect(parseSpeedLimitInput('1024')).toBe(1024);
+    expect(parseSpeedLimitInput('1,5')).toBe(1.5);
+  });
+
+  it('rejects junk instead of silently coercing it to 0', () => {
+    expect(parseSpeedLimitInput('abc')).toBeNull();
+    expect(parseSpeedLimitInput('1.2.3')).toBeNull();
+  });
+
+  it('rejects negatives — speed limits have no sentinel values', () => {
+    expect(parseSpeedLimitInput('-1')).toBeNull();
+  });
+});
+
+describe('describeShareLimit', () => {
+  it('reports an explicit per-torrent limit', () => {
+    expect(describeShareLimit(2, 2)).toEqual({ kind: 'value', value: 2 });
+  });
+
+  it('reports no limit', () => {
+    expect(describeShareLimit(SHARE_LIMIT_UNLIMITED, SHARE_LIMIT_UNLIMITED)).toEqual({
+      kind: 'unlimited',
+    });
+  });
+
+  // The case that used to render as a bare "Unlimited" while the adjacent
+  // Max Ratio row showed the real number.
+  it('resolves the -2 sentinel against the effective limit', () => {
+    expect(describeShareLimit(SHARE_LIMIT_GLOBAL, 1.5)).toEqual({
+      kind: 'global',
+      effective: 1.5,
+    });
+  });
+
+  it('reports unlimited when the global limit is itself unlimited', () => {
+    expect(describeShareLimit(SHARE_LIMIT_GLOBAL, -1)).toEqual({ kind: 'global', effective: null });
+  });
+
+  it('falls back to the effective value when the server omits the per-torrent field', () => {
+    expect(describeShareLimit(undefined, 1.5)).toEqual({ kind: 'value', value: 1.5 });
+    expect(describeShareLimit(undefined, -1)).toEqual({ kind: 'unlimited' });
+    expect(describeShareLimit(null, null)).toEqual({ kind: 'unlimited' });
+  });
+});

--- a/types/api.ts
+++ b/types/api.ts
@@ -162,9 +162,17 @@ export interface TorrentInfo {
   f_l_piece_prio: boolean;
   force_start: boolean;
   hash: string;
+  /**
+   * Per-torrent inactive-seeding limit in minutes (-2 = use global, -1 = no
+   * limit). Reported from qBittorrent 5.0 / WebAPI 2.11.0 — absent on older
+   * servers. Must be echoed back on setShareLimits, see `share_limit_action`.
+   */
+  inactive_seeding_time_limit?: number;
   last_activity: number;
   magnet_uri: string;
+  /** Effective ratio limit, with a `-2` ratio_limit already resolved to the global value. */
   max_ratio: number;
+  /** Effective seeding time limit (minutes), with `-2` already resolved to the global value. */
   max_seeding_time: number;
   name: string;
   num_complete: number;
@@ -176,12 +184,25 @@ export interface TorrentInfo {
   priority: number;
   progress: number;
   ratio: number;
+  /** Per-torrent ratio limit: -2 = use global limit, -1 = no limit. Compare `max_ratio` (effective). */
   ratio_limit?: number;
   save_path: string;
   seeding_time: number;
+  /** Per-torrent seeding limit (minutes): -2 = use global, -1 = no limit. Compare `max_seeding_time`. */
   seeding_time_limit?: number;
   seen_complete: number;
   seq_dl: boolean;
+  /**
+   * What qBittorrent does when a share limit is reached, e.g. 'Default' (use the
+   * global setting), 'Stop', 'Remove', 'RemoveWithContent', 'EnableSuperSeeding'.
+   * Reported from WebAPI 2.10.4. `setShareLimits` REQUIRES this param on newer
+   * servers and applies whatever is sent, so it must be round-tripped rather
+   * than defaulted — sending 'Default' silently resets the torrent to the global
+   * action (which may be "Remove", deleting the torrent).
+   */
+  share_limit_action?: string;
+  /** Whether all or any share limit must be met, e.g. 'Default' | 'MatchAny' | 'MatchAll' (WebAPI 2.16.0+). */
+  share_limits_mode?: string;
   size: number;
   state: TorrentState;
   super_seeding: boolean;

--- a/utils/error.ts
+++ b/utils/error.ts
@@ -8,3 +8,16 @@ export function getErrorMessage(error: unknown): string {
 export function isAxiosError(error: unknown): error is AxiosError {
   return error instanceof AxiosError || (error instanceof Error && 'isAxiosError' in error);
 }
+
+/**
+ * HTTP status attached by the API client's error normalizer, when the request
+ * got a response. Lets callers branch on the status instead of substring-matching
+ * the human-readable message.
+ */
+export function getErrorStatus(error: unknown): number | undefined {
+  if (error instanceof Error && 'status' in error) {
+    const status = (error as { status?: unknown }).status;
+    return typeof status === 'number' ? status : undefined;
+  }
+  return undefined;
+}

--- a/utils/limit-input.ts
+++ b/utils/limit-input.ts
@@ -1,0 +1,111 @@
+/**
+ * limit-input.ts — parsing and display logic for the numeric limit fields
+ * (share ratio, seeding time, speed) the user types on the torrent detail screen.
+ *
+ * qBittorrent uses two sentinel values in every share-limit field (ratio,
+ * seeding time, inactive seeding time):
+ *   -2 → follow the global limit
+ *   -1 → no limit
+ * Any other negative number is meaningless, so it is rejected on input.
+ *
+ * `torrents/info` reports each share limit twice: the torrent's OWN setting
+ * (`ratio_limit`) and the EFFECTIVE limit with -2 already resolved against the
+ * global setting (`max_ratio`). Those agree when an explicit per-torrent limit
+ * is set and diverge when the torrent follows the global limit — which is why
+ * showing the raw own-value alone reads "Unlimited" for a torrent that is in
+ * fact capped by the global limit.
+ */
+
+/** Sentinel: follow the global (server-wide) limit. */
+export const SHARE_LIMIT_GLOBAL = -2;
+/** Sentinel: no limit at all. */
+export const SHARE_LIMIT_UNLIMITED = -1;
+
+/**
+ * Smooth over what iOS keyboards actually emit before parsing.
+ *
+ * The numbers-and-punctuation keyboard offers "," as the decimal separator in
+ * the es/fr/de/ru locales, and some keyboards produce a Unicode minus (U+2212)
+ * or an en/em dash rather than ASCII "-". Without this, a strict parse would
+ * reject input that looks perfectly valid to the person typing it.
+ */
+export function normalizeNumericInput(raw: string): string {
+  return raw.trim().replace(/[−–—]/g, '-').replace(',', '.');
+}
+
+/**
+ * Parse a user-entered share limit. Returns `null` when the input is not a
+ * usable value, so callers can reject it instead of silently coercing.
+ *
+ * Deliberately stricter than `parseFloat`, which happily returns 1.2 for
+ * "1.2.3" and NaN for "abc" — and NaN then reads as "unlimited" downstream.
+ *
+ * An empty string is treated as "no limit" (-1), matching the placeholder text.
+ */
+export function parseShareLimitInput(
+  raw: string,
+  options: { integer?: boolean } = {},
+): number | null {
+  const normalized = normalizeNumericInput(raw);
+  if (normalized === '') return SHARE_LIMIT_UNLIMITED;
+
+  const pattern = options.integer ? /^-?\d+$/ : /^-?(?:\d+(?:\.\d+)?|\.\d+)$/;
+  if (!pattern.test(normalized)) return null;
+
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed)) return null;
+
+  // Only the two documented sentinels are valid negatives.
+  if (parsed < 0 && parsed !== SHARE_LIMIT_GLOBAL && parsed !== SHARE_LIMIT_UNLIMITED) {
+    return null;
+  }
+  return parsed;
+}
+
+/**
+ * Parse a speed limit. Unit-agnostic — the caller decides whether it's bytes/s
+ * or KiB/s. Empty means 0, which qBittorrent treats as unlimited. Negatives are
+ * rejected: unlike share limits, speed limits have no sentinel values.
+ */
+export function parseSpeedLimitInput(raw: string): number | null {
+  const normalized = normalizeNumericInput(raw);
+  if (normalized === '') return 0;
+  if (!/^\d+(?:\.\d+)?$/.test(normalized)) return null;
+
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export type ShareLimitDisplay =
+  /** No limit applies. */
+  | { kind: 'unlimited' }
+  /** Following the global limit; `effective` is the resolved value, or null when the global limit is itself unlimited. */
+  | { kind: 'global'; effective: number | null }
+  /** An explicit per-torrent limit. */
+  | { kind: 'value'; value: number };
+
+/**
+ * Work out what a share-limit row should actually say.
+ *
+ * @param own       the torrent's own setting (`ratio_limit` / `seeding_time_limit`)
+ * @param effective the resolved limit (`max_ratio` / `max_seeding_time`)
+ */
+export function describeShareLimit(
+  own: number | null | undefined,
+  effective: number | null | undefined,
+): ShareLimitDisplay {
+  const resolved = effective != null && effective >= 0 ? effective : null;
+
+  // Servers older than WebAPI 2.8.0 don't report the per-torrent field at all;
+  // the effective value is the only thing we know.
+  if (own == null) {
+    return resolved == null ? { kind: 'unlimited' } : { kind: 'value', value: resolved };
+  }
+  if (own === SHARE_LIMIT_GLOBAL) {
+    return { kind: 'global', effective: resolved };
+  }
+  if (own < 0) {
+    return { kind: 'unlimited' };
+  }
+  return { kind: 'value', value: own };
+}


### PR DESCRIPTION
The ratio limit and seeding time limit inputs used a numeric-only iOS
keyboard, which has no minus-sign key, so users could never type -1
(no limit) or -2 (use global limit) by hand. Switch both inputs to the
numbers-and-punctuation keyboard type, which includes "-".

Fixes #163.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018eJbJX8jRTAho8MD6fmaME