### PR TITLE
Fix "Completed" filter and status label for finished torrents

### DIFF
--- a/app/(tabs)/(torrents)/index.tsx
+++ b/app/(tabs)/(torrents)/index.tsx
@@ -58,7 +58,7 @@ import { useTorrentActions } from '@/hooks/useTorrentActions';
 import { getErrorMessage } from '@/utils/error';
 import { extractMagnetLink } from '@/utils/magnet';
 import { getAddTorrentDialogueVariant } from '@/utils/add-torrent-dialogue';
-import { isCompletedState } from '@/utils/torrent-state';
+import { isTorrentCompleted } from '@/utils/torrent-state';
 import { OptionPicker, OptionPickerItem } from '@/components/OptionPicker';
 import { MultiSelectPicker, MultiSelectPickerItem } from '@/components/MultiSelectPicker';
 import { torrentHasAnyTag, UNTAGGED_FILTER } from '@/utils/tags';
@@ -411,7 +411,7 @@ export default function TorrentsScreen() {
           case 'uploading':
             return torrent.state === 'uploading';
           case 'completed':
-            return isCompletedState(torrent.state);
+            return isTorrentCompleted(torrent.state, torrent.progress);
           case 'paused':
             return (
               torrent.state === 'pausedDL' ||

--- a/app/(tabs)/(torrents)/index.tsx
+++ b/app/(tabs)/(torrents)/index.tsx
@@ -58,6 +58,7 @@ import { useTorrentActions } from '@/hooks/useTorrentActions';
 import { getErrorMessage } from '@/utils/error';
 import { extractMagnetLink } from '@/utils/magnet';
 import { getAddTorrentDialogueVariant } from '@/utils/add-torrent-dialogue';
+import { isCompletedState } from '@/utils/torrent-state';
 import { OptionPicker, OptionPickerItem } from '@/components/OptionPicker';
 import { MultiSelectPicker, MultiSelectPickerItem } from '@/components/MultiSelectPicker';
 import { torrentHasAnyTag, UNTAGGED_FILTER } from '@/utils/tags';
@@ -410,7 +411,7 @@ export default function TorrentsScreen() {
           case 'uploading':
             return torrent.state === 'uploading';
           case 'completed':
-            return torrent.state === 'uploading' && torrent.progress === 1;
+            return isCompletedState(torrent.state);
           case 'paused':
             return (
               torrent.state === 'pausedDL' ||

--- a/app/(tabs)/(torrents)/torrent/[hash].tsx
+++ b/app/(tabs)/(torrents)/torrent/[hash].tsx
@@ -1045,8 +1045,15 @@ export default function TorrentDetail() {
 
   if (optimisticPaused !== null) {
     if (optimisticPaused) {
-      stateColor = colors.statePaused;
-      stateLabel = t('torrentDetail.paused');
+      if (torrent.progress >= 1) {
+        // Pausing/stopping a finished torrent — qBittorrent's own WebUI
+        // calls this "Completed", not "Paused".
+        stateColor = colors.stateSeeding;
+        stateLabel = t('torrentDetail.completed');
+      } else {
+        stateColor = colors.statePaused;
+        stateLabel = t('torrentDetail.paused');
+      }
     } else {
       if (torrent.progress >= 1) {
         stateColor = colors.stateSeeding;

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -27,7 +27,7 @@ export const CHANGELOG: ChangelogRelease[] = [
         title: 'Bugs Fixed',
         items: [
           'Fixed torrents that finished downloading (including ones stopped/paused, checking, or queued while at 100%) never showing up under the "Completed" filter — it now matches qBittorrent\'s own definition of complete instead of requiring the exact "uploading" state, and also falls back to 100% progress for torrents qBittorrent leaves reporting a "stopped downloading" state despite having nothing left to download',
-          'Fixed a torrent that\'s stopped/paused after finishing showing the status "Paused" — it now says "Completed", matching qBittorrent\'s own WebUI',
+          'Fixed a torrent that\'s stopped/paused after finishing showing the status "Paused" — it now says "Completed", matching qBittorrent\'s own WebUI. This also applies immediately when you tap Pause on a finished torrent, instead of showing "Paused" until the next refresh',
         ],
       },
     ],

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -27,6 +27,7 @@ export const CHANGELOG: ChangelogRelease[] = [
         title: 'Bugs Fixed',
         items: [
           'Fixed torrents that finished downloading (including ones stopped/paused, checking, or queued while at 100%) never showing up under the "Completed" filter — it now matches qBittorrent\'s own definition of complete instead of requiring the exact "uploading" state, and also falls back to 100% progress for torrents qBittorrent leaves reporting a "stopped downloading" state despite having nothing left to download',
+          'Fixed a torrent that\'s stopped/paused after finishing showing the status "Paused" — it now says "Completed", matching qBittorrent\'s own WebUI',
         ],
       },
     ],

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -20,6 +20,18 @@ export interface ChangelogRelease {
 
 export const CHANGELOG: ChangelogRelease[] = [
   {
+    version: '3.8.33',
+    date: '2026-07-27',
+    sections: [
+      {
+        title: 'Bugs Fixed',
+        items: [
+          'Fixed torrents that finished downloading (including after a manual or automatic recheck) never showing up under the "Completed" filter — it now matches qBittorrent\'s own definition of complete instead of requiring the exact "uploading" state',
+        ],
+      },
+    ],
+  },
+  {
     version: '3.8.32',
     date: '2026-07-27',
     sections: [

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -26,7 +26,7 @@ export const CHANGELOG: ChangelogRelease[] = [
       {
         title: 'Bugs Fixed',
         items: [
-          'Fixed torrents that finished downloading (including after a manual or automatic recheck) never showing up under the "Completed" filter — it now matches qBittorrent\'s own definition of complete instead of requiring the exact "uploading" state',
+          'Fixed torrents that finished downloading (including ones stopped/paused, checking, or queued while at 100%) never showing up under the "Completed" filter — it now matches qBittorrent\'s own definition of complete instead of requiring the exact "uploading" state, and also falls back to 100% progress for torrents qBittorrent leaves reporting a "stopped downloading" state despite having nothing left to download',
         ],
       },
     ],

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -787,6 +787,7 @@
     "paused": "Pausiert",
     "seeding": "Seeding",
     "downloading": "Wird heruntergeladen",
+    "completed": "Abgeschlossen",
     "torrentNotFound": "Torrent nicht gefunden",
     "failedToLoadTorrent": "Torrent-Details konnten nicht geladen werden",
     "failedToUpdateTorrent": "Torrent konnte nicht aktualisiert werden",

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -1125,6 +1125,7 @@
     "forcedUp": "Forced UP",
     "paused": "Paused",
     "stopped": "Stopped",
+    "completed": "Abgeschlossen",
     "error": "Error",
     "missingFiles": "Missing Files",
     "checking": "Checking",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -39,6 +39,7 @@
     "forcedUp": "Forced UP",
     "paused": "Paused",
     "stopped": "Stopped",
+    "completed": "Completed",
     "error": "Error",
     "missingFiles": "Missing Files",
     "checking": "Checking",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -808,6 +808,7 @@
     "paused": "Paused",
     "seeding": "Seeding",
     "downloading": "Downloading",
+    "completed": "Completed",
     "torrentNotFound": "Torrent not found",
     "failedToLoadTorrent": "Failed to load torrent details",
     "failedToUpdateTorrent": "Failed to update torrent",

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -1125,6 +1125,7 @@
     "forcedUp": "Forced UP",
     "paused": "Paused",
     "stopped": "Stopped",
+    "completed": "Completado",
     "error": "Error",
     "missingFiles": "Missing Files",
     "checking": "Checking",

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -787,6 +787,7 @@
     "paused": "Pausado",
     "seeding": "Sembrando",
     "downloading": "Descargando",
+    "completed": "Completado",
     "torrentNotFound": "Torrent no encontrado",
     "failedToLoadTorrent": "Error al cargar los detalles del torrent",
     "failedToUpdateTorrent": "Error al actualizar el torrent",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -1125,6 +1125,7 @@
     "forcedUp": "Forced UP",
     "paused": "Paused",
     "stopped": "Stopped",
+    "completed": "Terminé",
     "error": "Error",
     "missingFiles": "Missing Files",
     "checking": "Checking",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -787,6 +787,7 @@
     "paused": "En pause",
     "seeding": "En partage",
     "downloading": "En téléchargement",
+    "completed": "Terminé",
     "torrentNotFound": "Torrent introuvable",
     "failedToLoadTorrent": "Échec du chargement des détails du torrent",
     "failedToUpdateTorrent": "Échec de la mise à jour du torrent",

--- a/locales/ru/translation.json
+++ b/locales/ru/translation.json
@@ -808,6 +808,7 @@
     "paused": "Пауза",
     "seeding": "Раздача",
     "downloading": "Загрузка",
+    "completed": "Завершено",
     "torrentNotFound": "Торрент не найден",
     "failedToLoadTorrent": "Не удалось загрузить сведения о торренте",
     "failedToUpdateTorrent": "Не удалось обновить торрент",

--- a/locales/ru/translation.json
+++ b/locales/ru/translation.json
@@ -39,6 +39,7 @@
     "forcedUp": "Принуд. отдача",
     "paused": "Пауза",
     "stopped": "Остановлено",
+    "completed": "Завершено",
     "error": "Ошибка",
     "missingFiles": "Нет файлов",
     "checking": "Проверка",

--- a/locales/zh/translation.json
+++ b/locales/zh/translation.json
@@ -1125,6 +1125,7 @@
     "forcedUp": "Forced UP",
     "paused": "Paused",
     "stopped": "Stopped",
+    "completed": "已完成",
     "error": "Error",
     "missingFiles": "Missing Files",
     "checking": "Checking",

--- a/locales/zh/translation.json
+++ b/locales/zh/translation.json
@@ -787,6 +787,7 @@
     "paused": "已暂停",
     "seeding": "做种中",
     "downloading": "下载中",
+    "completed": "已完成",
     "torrentNotFound": "未找到种子",
     "failedToLoadTorrent": "加载种子详情失败",
     "failedToUpdateTorrent": "更新种子失败",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qRemote",
-  "version": "3.8.32",
+  "version": "3.8.33",
   "main": "index.ts",
   "scripts": {
     "start": "expo start --dev-client",

--- a/tests/rn/components/TorrentCard.test.tsx
+++ b/tests/rn/components/TorrentCard.test.tsx
@@ -106,6 +106,18 @@ describe('TorrentCard state badge', () => {
     expect(StyleSheet.flatten(badge?.props.style)).toMatchObject({ overflow: 'hidden' });
   });
 
+  it('shows "states.completed" (not "states.paused") for a torrent stopped after finishing, matching qBittorrent\'s own WebUI', async () => {
+    await render(
+      <TorrentCard
+        torrent={{ ...baseTorrent, state: 'stoppedUP', progress: 1, dlspeed: 0, upspeed: 0 } as TorrentInfo}
+        onPress={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText('states.completed')).toBeTruthy();
+    expect(screen.queryByText('states.paused')).toBeNull();
+  });
+
   it('does not render the old state dot', async () => {
     await render(<TorrentCard torrent={baseTorrent} onPress={jest.fn()} />);
 

--- a/tests/utils/torrent-state.test.ts
+++ b/tests/utils/torrent-state.test.ts
@@ -1,4 +1,4 @@
-import { getStateColor, getStateLabel, hasEta } from '@/utils/torrent-state';
+import { getStateColor, getStateLabel, hasEta, isCompletedState } from '@/utils/torrent-state';
 
 const mockColors = {
   stateUploadAndDownload: '#upload-and-download',
@@ -249,5 +249,34 @@ describe('hasEta', () => {
 
   it('returns false when eta is 0', () => {
     expect(hasEta(0, 0.5)).toBe(false);
+  });
+});
+
+describe('isCompletedState', () => {
+  it.each(['uploading', 'stalledUP', 'checkingUP', 'pausedUP', 'stoppedUP', 'queuedUP', 'forcedUP'])(
+    '%s → true (matches qBittorrent isCompleted())',
+    (state) => {
+      expect(isCompletedState(state)).toBe(true);
+    },
+  );
+
+  it.each([
+    'downloading',
+    'forcedDL',
+    'metaDL',
+    'forcedMetaDL',
+    'pausedDL',
+    'stoppedDL',
+    'queuedDL',
+    'stalledDL',
+    'checkingDL',
+    'checkingResumeData',
+    'error',
+    'missingFiles',
+    'allocating',
+    'moving',
+    'unknown',
+  ])('%s → false', (state) => {
+    expect(isCompletedState(state)).toBe(false);
   });
 });

--- a/tests/utils/torrent-state.test.ts
+++ b/tests/utils/torrent-state.test.ts
@@ -1,4 +1,10 @@
-import { getStateColor, getStateLabel, hasEta, isCompletedState } from '@/utils/torrent-state';
+import {
+  getStateColor,
+  getStateLabel,
+  hasEta,
+  isCompletedState,
+  isTorrentCompleted,
+} from '@/utils/torrent-state';
 
 const mockColors = {
   stateUploadAndDownload: '#upload-and-download',
@@ -278,5 +284,21 @@ describe('isCompletedState', () => {
     'unknown',
   ])('%s → false', (state) => {
     expect(isCompletedState(state)).toBe(false);
+  });
+});
+
+describe('isTorrentCompleted', () => {
+  it('returns true for upload-side states regardless of progress', () => {
+    expect(isTorrentCompleted('stalledUP', 1)).toBe(true);
+  });
+
+  it('returns true when progress is 100% even on a download-side state (qBittorrent leaves stopped-while-finished torrents on stoppedDL/pausedDL)', () => {
+    expect(isTorrentCompleted('stoppedDL', 1)).toBe(true);
+    expect(isTorrentCompleted('pausedDL', 1)).toBe(true);
+  });
+
+  it('returns false for a download-side state below 100% progress', () => {
+    expect(isTorrentCompleted('stoppedDL', 0.5)).toBe(false);
+    expect(isTorrentCompleted('downloading', 0.99)).toBe(false);
   });
 });

--- a/tests/utils/torrent-state.test.ts
+++ b/tests/utils/torrent-state.test.ts
@@ -70,16 +70,24 @@ describe('getStateColor', () => {
       expect(getStateColor('pausedDL', 0.5, 0, 0, mockColors)).toBe('#paused');
     });
 
-    it('pausedUP → statePaused', () => {
-      expect(getStateColor('pausedUP', 1, 0, 0, mockColors)).toBe('#paused');
+    it('pausedUP (finished-then-stopped) → stateSeeding', () => {
+      expect(getStateColor('pausedUP', 1, 0, 0, mockColors)).toBe('#seeding');
     });
 
     it('stoppedDL → statePaused', () => {
       expect(getStateColor('stoppedDL', 0.5, 0, 0, mockColors)).toBe('#paused');
     });
 
-    it('stoppedUP → statePaused', () => {
-      expect(getStateColor('stoppedUP', 1, 0, 0, mockColors)).toBe('#paused');
+    it('stoppedUP (finished-then-stopped) → stateSeeding', () => {
+      expect(getStateColor('stoppedUP', 1, 0, 0, mockColors)).toBe('#seeding');
+    });
+
+    it('stoppedDL at 100% progress (qBittorrent state-machine gap) → stateSeeding', () => {
+      expect(getStateColor('stoppedDL', 1, 0, 0, mockColors)).toBe('#seeding');
+    });
+
+    it('pausedDL at 100% progress (qBittorrent state-machine gap) → stateSeeding', () => {
+      expect(getStateColor('pausedDL', 1, 0, 0, mockColors)).toBe('#seeding');
     });
 
     it('error → stateError', () => {
@@ -182,16 +190,24 @@ describe('getStateLabel', () => {
       expect(getStateLabel('pausedDL', 0.5, 0, 0)).toBe('Paused');
     });
 
-    it('pausedUP → "Paused"', () => {
-      expect(getStateLabel('pausedUP', 1, 0, 0)).toBe('Paused');
+    it('pausedUP (finished-then-stopped) → "Completed", matching qBittorrent\'s own WebUI', () => {
+      expect(getStateLabel('pausedUP', 1, 0, 0)).toBe('Completed');
     });
 
     it('stoppedDL → "Stopped"', () => {
       expect(getStateLabel('stoppedDL', 0.5, 0, 0)).toBe('Stopped');
     });
 
-    it('stoppedUP → "Paused"', () => {
-      expect(getStateLabel('stoppedUP', 1, 0, 0)).toBe('Paused');
+    it('stoppedUP (finished-then-stopped) → "Completed", matching qBittorrent\'s own WebUI', () => {
+      expect(getStateLabel('stoppedUP', 1, 0, 0)).toBe('Completed');
+    });
+
+    it('stoppedDL at 100% progress (qBittorrent state-machine gap) → "Completed"', () => {
+      expect(getStateLabel('stoppedDL', 1, 0, 0)).toBe('Completed');
+    });
+
+    it('pausedDL at 100% progress (qBittorrent state-machine gap) → "Completed"', () => {
+      expect(getStateLabel('pausedDL', 1, 0, 0)).toBe('Completed');
     });
 
     it('error → "Error"', () => {

--- a/utils/torrent-state.ts
+++ b/utils/torrent-state.ts
@@ -86,9 +86,14 @@ export function isTorrentComplete(progress: number): boolean {
  * `qbittorrent-api` Python client's `TorrentState.is_complete`): a torrent is
  * "completed" once it has finished downloading and moved to an upload/seed-side
  * state, regardless of whether it's actively seeding, paused/stopped, queued,
- * checking, or stalled while in that state. Progress alone is not a reliable
- * signal here — e.g. a re-check of a finished torrent reports `checkingUP`
- * while briefly re-verifying, and `progress` can even dip below 1 mid-check.
+ * checking, or stalled while in that state.
+ *
+ * This alone is NOT sufficient to detect completion, though: qBittorrent's own
+ * state machine has a known gap where a torrent that finishes downloading while
+ * stopped (e.g. added pre-stopped over existing 100%-complete data, or stopped
+ * mid-check) can be left reporting `stoppedDL`/`pausedDL` — the "downloading"
+ * side — indefinitely, even though it never has anything left to download (see
+ * `isTorrentCompleted`, which combines this with a `progress` fallback).
  */
 export function isCompletedState(state: string): boolean {
   switch (state) {
@@ -103,6 +108,19 @@ export function isCompletedState(state: string): boolean {
     default:
       return false;
   }
+}
+
+/**
+ * The authoritative "is this torrent done" check: true if `state` is on the
+ * upload/seed side (see `isCompletedState`) OR `progress` has reached 100%.
+ * The progress fallback exists because qBittorrent doesn't always flip a
+ * torrent's state to the upload side when it finishes while stopped/paused —
+ * it can stay on `stoppedDL`/`pausedDL` with nothing left to download. Prefer
+ * this over `isCompletedState` alone whenever `progress` is available (e.g.
+ * the "Completed" filter) to avoid missing those torrents.
+ */
+export function isTorrentCompleted(state: string, progress: number): boolean {
+  return isCompletedState(state) || isTorrentComplete(progress);
 }
 
 /**

--- a/utils/torrent-state.ts
+++ b/utils/torrent-state.ts
@@ -36,6 +36,13 @@ export function getStateColor(
 
   if (state === 'stalledUP' && progress >= 1) return colors.stateSeeding;
 
+  // qBittorrent can leave a torrent reporting a download-side stopped state
+  // (stoppedDL/pausedDL) even once it has nothing left to download — treat
+  // it the same as stoppedUP/pausedUP (see isTorrentCompleted).
+  if ((state === 'stoppedDL' || state === 'pausedDL') && progress >= 1) {
+    return colors.stateSeeding;
+  }
+
   switch (state) {
     case 'downloading':
     case 'forcedDL':
@@ -47,10 +54,13 @@ export function getStateColor(
     case 'forcedUP':
       return colors.stateUploadOnly;
     case 'pausedDL':
-    case 'pausedUP':
     case 'stoppedDL':
-    case 'stoppedUP':
       return colors.statePaused;
+    case 'pausedUP':
+    case 'stoppedUP':
+      // Stopped/paused after finishing — qBittorrent's own WebUI calls this
+      // "Completed", not "Paused"; use the same positive color as seeding.
+      return colors.stateSeeding;
     case 'error':
     case 'missingFiles':
     case 'stalledDL':
@@ -149,6 +159,13 @@ export function getStateLabel(
 
   if (state === 'stalledUP' && progress >= 1) return s('seeding', 'Seeding');
 
+  // qBittorrent can leave a torrent reporting a download-side stopped state
+  // (stoppedDL/pausedDL) even once it has nothing left to download — treat
+  // it the same as stoppedUP/pausedUP (see isTorrentCompleted).
+  if ((state === 'stoppedDL' || state === 'pausedDL') && progress >= 1) {
+    return s('completed', 'Completed');
+  }
+
   switch (state) {
     case 'downloading':
       return s('downloading', 'Downloading');
@@ -163,12 +180,15 @@ export function getStateLabel(
     case 'forcedUP':
       return s('forcedUp', 'Forced UP');
     case 'pausedDL':
-    case 'pausedUP':
       return s('paused', 'Paused');
     case 'stoppedDL':
       return s('stopped', 'Stopped');
+    case 'pausedUP':
     case 'stoppedUP':
-      return s('paused', 'Paused');
+      // Stopped/paused after finishing — qBittorrent's own WebUI calls this
+      // "Completed", not "Paused" (confirmed against its dynamicTable.js,
+      // true both for the legacy pausedUP and current stoppedUP naming).
+      return s('completed', 'Completed');
     case 'error':
       return s('error', 'Error');
     case 'missingFiles':

--- a/utils/torrent-state.ts
+++ b/utils/torrent-state.ts
@@ -82,6 +82,30 @@ export function isTorrentComplete(progress: number): boolean {
 }
 
 /**
+ * Mirrors qBittorrent's own `TorrentImpl::isCompleted()` (and the
+ * `qbittorrent-api` Python client's `TorrentState.is_complete`): a torrent is
+ * "completed" once it has finished downloading and moved to an upload/seed-side
+ * state, regardless of whether it's actively seeding, paused/stopped, queued,
+ * checking, or stalled while in that state. Progress alone is not a reliable
+ * signal here — e.g. a re-check of a finished torrent reports `checkingUP`
+ * while briefly re-verifying, and `progress` can even dip below 1 mid-check.
+ */
+export function isCompletedState(state: string): boolean {
+  switch (state) {
+    case 'uploading':
+    case 'stalledUP':
+    case 'checkingUP':
+    case 'pausedUP':
+    case 'stoppedUP':
+    case 'queuedUP':
+    case 'forcedUP':
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
  * ETA is only meaningful while a torrent is still downloading.
  * `8640000` is qBittorrent's sentinel for an infinite/unknown ETA.
  */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #165.

## The actual bug

qRemote's status label mapped a torrent that finished downloading and was then paused/stopped (`stoppedUP`, and the legacy `pausedUP` alias) to **"Paused"**. qBittorrent's own WebUI (`dynamicTable.js`) has always labeled that exact state **"Completed"** — confirmed against both the current `master` and old `release-4.6.0` source. So after finishing a download and clicking Pause, qRemote said "Paused" where the official WebUI says "Completed" — the actual bug a user hit.

## Root causes found (in order of investigation)

1. **Filter used the wrong predicate.** The "Completed" filter chip only matched `state === 'uploading' && progress === 1`, excluding all other finished-but-idle states (`stalledUP`, `checkingUP`, `queuedUP`, `forcedUP`, `stoppedUP`/`pausedUP`).
2. **qBittorrent's own state-machine gap.** A torrent that finishes downloading while stopped can be left reporting `stoppedDL`/`pausedDL` (download side) indefinitely, with 100% progress and nothing left to download.
3. **The real reported bug: wrong status label.** Independent of the filter, `getStateLabel`/`getStateColor` mapped `stoppedUP`/`pausedUP` to "Paused"/grey instead of "Completed"/seeding-green — what the user saw directly on the card/detail screen after pausing a finished torrent.
4. **Optimistic UI made it worse.** The torrent detail screen shows an optimistic "Paused" label for a few seconds right after tapping Pause (while polling to confirm), unconditionally, even for a torrent that's already 100% downloaded.

## Fix

`utils/torrent-state.ts`:
- `isCompletedState(state)` — mirrors qBittorrent's `TorrentImpl::isCompleted()` (`uploading`, `stalledUP`, `checkingUP`, `pausedUP`, `stoppedUP`, `queuedUP`, `forcedUP`).
- `isTorrentCompleted(state, progress)` — ORs the above with `progress >= 1`, covering the `stoppedDL`/`pausedDL`-at-100% gap. Used by the "Completed" filter in `app/(tabs)/(torrents)/index.tsx`.
- `getStateLabel`/`getStateColor` — `stoppedUP`/`pausedUP` now return "Completed" / `stateSeeding` (not "Paused" / `statePaused`), matching qBittorrent's WebUI exactly, with the same progress fallback for `stoppedDL`/`pausedDL` at 100%.

`app/(tabs)/(torrents)/torrent/[hash].tsx`:
- The optimistic-pause branch now shows "Completed" (not "Paused") immediately when pausing a torrent that's already at 100% progress, mirroring the existing progress check already used in the optimistic-resume branch.

Added `states.completed` / `torrentDetail.completed` i18n keys across all 6 locales, unit tests for every new function/branch in `tests/utils/torrent-state.test.ts`, and a `TorrentCard` render test proving the actual rendered label. Plus a changelog entry.

## Testing

- `npx tsc --noEmit` — clean.
- `npm test` — 952/952 passing, including a new `TorrentCard` test that renders a `stoppedUP` torrent and asserts the visible text is "Completed" (not "Paused"), and the i18n parity test across all 6 locales.
- `npm run lint` — 0 errors (pre-existing warning baseline only).

No device/simulator or live qBittorrent server is available in this environment; verified via the unit/component tests above (including an actual component render + text assertion) plus direct comparison against qBittorrent's own WebUI source (`dynamicTable.js`) and C++ state machine (`torrentimpl.cpp`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fa337-7782-7277-bc8c-2cc1ee7b39f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fa337-7782-7277-bc8c-2cc1ee7b39f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

