### PR TITLE
Fix flaky ActionMenu timer test

### DIFF
--- a/tests/rn/components/ActionMenu.test.tsx
+++ b/tests/rn/components/ActionMenu.test.tsx
@@ -29,6 +29,15 @@ describe('ActionMenu', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    // Tests that opt into fake timers must not leave them installed on
+    // failure — an assertion throwing partway through a test body would
+    // otherwise skip an inline `jest.useRealTimers()` cleanup at the end of
+    // that test, leaking fake timers into every later test in this worker
+    // process (surfacing as unrelated timer-based tests misbehaving, or the
+    // worker failing to exit gracefully). afterEach always runs, so put
+    // cleanup here instead of at the end of the test body.
+    jest.clearAllTimers();
+    jest.useRealTimers();
     Object.assign(mockInsets, { top: 0, bottom: 0, left: 0, right: 0 });
   });
 
@@ -66,7 +75,6 @@ describe('ActionMenu', () => {
       jest.advanceTimersByTime(150);
     });
     expect(items[0].onPress).toHaveBeenCalledTimes(1);
-    jest.useRealTimers();
   });
 
   it('applies destructive styling path for destructive items without crashing', async () => {
@@ -200,7 +208,6 @@ describe('ActionMenu', () => {
         jest.advanceTimersByTime(150);
       });
       expect(items[0].onPress).toHaveBeenCalledTimes(1);
-      jest.useRealTimers();
     });
   });
 });


### PR DESCRIPTION
## Summary
The CI "Test coverage" job was intermittently failing on `ActionMenu.test.tsx`'s "closes then fires the item action after the delay" test. Root cause: both timer-dependent tests called `jest.useRealTimers()` as the last line of the test body. If an earlier `expect()` in that same test threw, that cleanup line never ran (Jest aborts the test body on the first failed assertion) — leaving fake timers installed for every subsequent test in the same worker process. That's self-perpetuating: once it fails once for any reason, it contaminates everything after it, which matches the "worker process failed to exit gracefully... active timers" warning seen in the CI logs.

Fix: moved the timer cleanup into `afterEach`, which always runs regardless of test outcome, instead of relying on an inline cleanup call that a failure can skip.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` — 0 errors
- [x] `npm test` run 5 times consecutively, all green (963/963 each time) — previously this would intermittently fail on the ActionMenu test in the full-suite run