### PR TITLE
Cold-launch Open In: try both URL sources + add diagnostics

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -26,7 +26,11 @@ import { logStorage } from '@/services/log-storage';
 import { storageService } from '@/services/storage';
 import { apiClient } from '@/services/api/client';
 import { setHapticsEnabled } from '@/utils/haptics';
-import { setDebugMode as setConnectivityDebugMode } from '@/services/connectivity-log';
+import {
+  setDebugMode as setConnectivityDebugMode,
+  clogInfo,
+  clogWarn,
+} from '@/services/connectivity-log';
 import { extractMagnetLink } from '@/utils/magnet';
 import { extractTorrentFile, IncomingTorrentFile } from '@/utils/torrent-file';
 import { persistIncomingTorrentFile } from '@/services/incoming-file';
@@ -188,8 +192,15 @@ function StackNavigator() {
       // Copy into app-owned cache immediately, before waiting on navigation
       // readiness — see persistIncomingTorrentFile for why the source URI
       // can't be trusted to survive that wait.
+      // Logged so a failing "Open In" can be diagnosed from the Logs tab
+      // instead of guessing: if the URI is already under the app's own
+      // cache/incoming-torrents/ the native copy ran, and anything else means
+      // JS got the raw security-scoped URL straight from iOS.
+      clogInfo('LINK', `Incoming .torrent URI: ${rawTorrentFile.uri}`);
+
       const torrentFile = await persistIncomingTorrentFile(rawTorrentFile);
       if (!torrentFile) {
+        clogWarn('LINK', `Could not read incoming .torrent: ${rawTorrentFile.uri}`);
         showToast(t('errors.couldNotReadTorrentFile'), 'error');
         return;
       }
@@ -207,14 +218,30 @@ function StackNavigator() {
 
     if (!initialUrlCheckedRef.current) {
       initialUrlCheckedRef.current = true;
-      // RN core's Linking.getInitialURL() depends on bridge.launchOptions,
-      // which our AppDelegate patch (withNativeTorrentFileCopy) can't reliably
-      // rewrite under the New Architecture. expo-linking's getLinkingURL() is
-      // a separate, synchronous mechanism backed by a native registry that
-      // IS populated with our already-copied URL (both go through the same
-      // native open-URL callback dispatch), so use that for the cold-launch
-      // check instead.
-      void dispatchDeepLink(ExpoLinking.getLinkingURL());
+
+      // Two independent sources for the cold-launch URL, because neither is
+      // reliable alone on iOS here:
+      //  - expo-linking's getLinkingURL() reads a native registry populated
+      //    by the "open url" AppDelegate callback (the one our
+      //    withNativeTorrentFileCopy patch rewrites to an app-owned copy).
+      //  - RN core's Linking.getInitialURL() reads bridge.launchOptions,
+      //    which the New Architecture may not populate.
+      // Try both: dispatchDeepLink de-dupes by URL, so whichever arrives
+      // first wins and the other is a no-op. Do NOT reduce this to one
+      // source without testing a real cold launch — cold-launch "Open In"
+      // has regressed repeatedly on exactly this code path.
+      const expoUrl = ExpoLinking.getLinkingURL();
+      clogInfo('LINK', `Cold-launch expo-linking URL: ${expoUrl ?? '(none)'}`);
+      void dispatchDeepLink(expoUrl);
+
+      Linking.getInitialURL()
+        .then((rnUrl) => {
+          clogInfo('LINK', `Cold-launch RN URL: ${rnUrl ?? '(none)'}`);
+          return dispatchDeepLink(rnUrl);
+        })
+        .catch(() => {
+          // No initial URL — safe to ignore.
+        });
     }
 
     if (pendingDeepLinkRef.current) {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,4 +1,5 @@
 import '@/i18n';
+import * as ExpoLinking from 'expo-linking';
 import { ErrorBoundaryProps, Stack, useRootNavigationState, useRouter } from 'expo-router';
 import {
   Dimensions,
@@ -206,11 +207,14 @@ function StackNavigator() {
 
     if (!initialUrlCheckedRef.current) {
       initialUrlCheckedRef.current = true;
-      Linking.getInitialURL()
-        .then((url) => dispatchDeepLink(url))
-        .catch(() => {
-          // No initial URL — safe to ignore.
-        });
+      // RN core's Linking.getInitialURL() depends on bridge.launchOptions,
+      // which our AppDelegate patch (withNativeTorrentFileCopy) can't reliably
+      // rewrite under the New Architecture. expo-linking's getLinkingURL() is
+      // a separate, synchronous mechanism backed by a native registry that
+      // IS populated with our already-copied URL (both go through the same
+      // native open-URL callback dispatch), so use that for the cold-launch
+      // check instead.
+      void dispatchDeepLink(ExpoLinking.getLinkingURL());
     }
 
     if (pendingDeepLinkRef.current) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qRemote",
   "version": "3.8.34",
-  "easBuild": true, 
+  "easBuild": true,
   "main": "index.ts",
   "scripts": {
     "start": "expo start --dev-client",


### PR DESCRIPTION
## Summary
Follow-up to #171, which fixed warm-launch "Open In" but left cold launch failing with "Couldn't read the .torrent file".

**This PR is deliberately diagnostic rather than a confident fix.** Cold-launch "Open In" has now been misdiagnosed several times from source-reading alone, so this focuses on not regressing and on producing evidence.

Two changes:

1. **Query both cold-launch URL sources instead of swapping one for the other.** RN core's `Linking.getInitialURL()` reads `bridge.launchOptions` (may not be populated under the New Architecture); `expo-linking`'s `getLinkingURL()` reads a native registry populated by the "open url" AppDelegate callback that #171's plugin rewrites. An earlier revision of this branch *replaced* the former with the latter — that was a regression risk, because if the "open url" callback is what isn't firing on cold launch (the leading theory), the registry is empty and you'd get no deep link at all rather than a failing one. `dispatchDeepLink` already de-dupes by URL, so querying both is safe.

2. **Log the incoming .torrent URI + any read failure to the connectivity log** (visible in the Logs tab). This is the actual point: a URI under the app's own `cache/incoming-torrents/` proves the native copy ran, and anything else proves JS received the raw security-scoped URL from iOS. That single line distinguishes the remaining hypotheses without another round of guessing.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 963 passing
- [x] `npm run lint` — 0 errors
- [ ] On a fresh build: force-quit, open a .torrent via Files "Open In", then check Settings → Advanced → Logs for the `LINK` entries — specifically whether `Incoming .torrent URI` points into the app cache, and which of the two cold-launch sources produced a URL.