### PR TITLE
Fix torrent card layout breaking with many tags

### DIFF
--- a/components/TorrentCard.tsx
+++ b/components/TorrentCard.tsx
@@ -402,7 +402,7 @@ function TorrentCardInner({
           onPauseResume && { paddingRight: (compact ? 24 : 28) + spacing.sm },
         ]}
       >
-        <Text style={[styles.sizeText, { color: colors.textSecondary }]}>
+        <Text style={[styles.sizeText, { color: colors.textSecondary }]} numberOfLines={1}>
           {formatSize(downloaded)} / {formatSize(totalSize)}
         </Text>
         {(torrent.category || tagList.length > 0) && (
@@ -573,20 +573,24 @@ const styles = StyleSheet.create({
   },
   stickerRow: {
     flexDirection: 'row',
+    flexWrap: 'wrap',
     alignItems: 'center',
     gap: 4,
     marginLeft: spacing.xs,
-    flexShrink: 0,
+    flexShrink: 1,
+    maxWidth: '100%',
   },
   sticker: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 4,
     maxWidth: 100,
+    overflow: 'hidden',
   },
   stickerText: {
     fontSize: 12,
     fontWeight: '600',
+    flexShrink: 1,
   },
   progressRow: {
     flexDirection: 'row',
@@ -611,8 +615,10 @@ const styles = StyleSheet.create({
   },
   sizeRow: {
     flexDirection: 'row',
+    flexWrap: 'wrap',
     alignItems: 'center',
     justifyContent: 'space-between',
+    rowGap: 4,
   },
   sizeText: {
     fontSize: 12,

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -20,6 +20,18 @@ export interface ChangelogRelease {
 
 export const CHANGELOG: ChangelogRelease[] = [
   {
+    version: '3.8.35',
+    date: '2026-07-28',
+    sections: [
+      {
+        title: 'Bugs Fixed',
+        items: [
+          'Fixed torrent cards with many tags squishing the downloaded/total size into unreadable text and letting long tag names overlap each other',
+        ],
+      },
+    ],
+  },
+  {
     version: '3.8.34',
     date: '2026-07-27',
     sections: [
@@ -34,7 +46,7 @@ export const CHANGELOG: ChangelogRelease[] = [
         title: 'Bugs Fixed',
         items: [
           'Fixed a false "couldn\'t read torrent file" error that could briefly flash when opening a .torrent file from a cold launch',
-		  'Fixed Transfer tab speed numbers getting cut off at higher speeds',
+          'Fixed Transfer tab speed numbers getting cut off at higher speeds',
           'Fixed per-torrent speed limits sometimes applying the wrong units',
           'Fixed torrent cards showing "unlimited" for a ratio limit that actually follows the global limit',
           'Fixed the folder-path autocomplete list clipping suggestions instead of scrolling to them',

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -20,18 +20,6 @@ export interface ChangelogRelease {
 
 export const CHANGELOG: ChangelogRelease[] = [
   {
-    version: '3.8.35',
-    date: '2026-07-28',
-    sections: [
-      {
-        title: 'Bugs Fixed',
-        items: [
-          'Fixed torrent cards with many tags squishing the downloaded/total size into unreadable text and letting long tag names overlap each other',
-        ],
-      },
-    ],
-  },
-  {
     version: '3.8.34',
     date: '2026-07-27',
     sections: [


### PR DESCRIPTION
## Summary
- Fixes #177 — torrent cards with several tags squished the downloaded/total size text into unreadable single characters, since the size/sticker row didn't wrap.
- The sticker row and its parent now wrap: tags stay right-aligned next to the size text when they fit, and fall to their own left-aligned row(s) when they don't.
- Also fixes a related overlap bug found while testing: long tag names had no `flexShrink` on their text, so `numberOfLines={1}` never got a chance to truncate — the text rendered past the chip's width cap and bled into the next chip. Added `flexShrink` plus `overflow: hidden` as a clip safety net.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 963 passed
- [x] `npm run lint` — 0 errors (pre-existing warning baseline unchanged)
- [x] Verified on-device (screenshot in issue thread) that long/garbage tag names no longer overlap and wrap onto their own row correctly