### PR TITLE
Add grace period before showing transient connection errors

### DIFF
--- a/app/(tabs)/(torrents)/index.tsx
+++ b/app/(tabs)/(torrents)/index.tsx
@@ -56,6 +56,7 @@ import { buttonStyles, buttonText } from '@/constants/buttons';
 import { typography } from '@/constants/typography';
 import { QuickConnectPanel } from '@/components/QuickConnectPanel';
 import { useTorrentActions } from '@/hooks/useTorrentActions';
+import { useGracefulError } from '@/hooks/useGracefulError';
 import { getErrorMessage } from '@/utils/error';
 import { extractMagnetLink } from '@/utils/magnet';
 import { getAddTorrentDialogueVariant } from '@/utils/add-torrent-dialogue';
@@ -78,6 +79,7 @@ export default function TorrentsScreen() {
     isRecoveringFromBackground,
     initialLoadComplete,
   } = useTorrents();
+  const { graceError, isPendingError } = useGracefulError(error);
   const { isConnected, isLoading: serverIsLoading, connectToServer } = useServer();
   const { colors, isDark } = useTheme();
   const params = useLocalSearchParams<{
@@ -1084,8 +1086,14 @@ export default function TorrentsScreen() {
     );
   }
 
-  // Show skeleton list during initial app launch (server connecting or first data fetch)
-  if (!initialLoadComplete && (serverIsLoading || !isConnected || isLoading)) {
+  // Show skeleton list during initial app launch (server connecting or first
+  // data fetch), during background recovery, or while a fresh error is still
+  // within its grace window — most poll failures self-heal within a couple
+  // of seconds and shouldn't flash a hard error.
+  if (
+    (!initialLoadComplete && (serverIsLoading || !isConnected || isLoading)) ||
+    (initialLoadComplete && (isRecoveringFromBackground || isPendingError))
+  ) {
     return (
       <>
         <FocusAwareStatusBar barStyle={isDark ? 'light-content' : 'dark-content'} />
@@ -1100,8 +1108,9 @@ export default function TorrentsScreen() {
     );
   }
 
-  // Only show persistent errors (not during background recovery or initial connection)
-  if (error && !isRecoveringFromBackground && initialLoadComplete) {
+  // Only show persistent errors (not during background recovery, initial
+  // connection, or a fresh error still within its grace window)
+  if (graceError && initialLoadComplete) {
     return (
       <>
         <FocusAwareStatusBar barStyle={isDark ? 'light-content' : 'dark-content'} />
@@ -1110,7 +1119,7 @@ export default function TorrentsScreen() {
           icon="alert-circle-outline"
           iconColor={colors.error}
           title={t('screens.torrents.somethingWentWrong')}
-          subtitle={error}
+          subtitle={graceError}
           actionLabel={t('common.retry')}
           onAction={refresh}
         />

--- a/app/(tabs)/transfer.tsx
+++ b/app/(tabs)/transfer.tsx
@@ -42,6 +42,7 @@ import { InputModal } from '@/components/InputModal';
 import { OptionPicker, OptionPickerItem } from '@/components/OptionPicker';
 import { getErrorMessage } from '@/utils/error';
 import { haptics } from '@/utils/haptics';
+import { useGracefulError } from '@/hooks/useGracefulError';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const GRAPH_HORIZONTAL_PADDING = spacing.lg * 2;
@@ -74,6 +75,7 @@ export default function TransferScreen() {
     initialLoadComplete,
   } = useTorrents();
   const isRecoveringFromBackground = transferRecovering || torrentRecovering;
+  const { graceError, isPendingError } = useGracefulError(error);
   const { colors, isDark } = useTheme();
   const { showToast } = useToast();
   const router = useRouter();
@@ -419,7 +421,14 @@ export default function TransferScreen() {
     );
   }
 
-  if (!initialLoadComplete && (serverIsLoading || !isConnected || isLoading)) {
+  // Show the loading spinner during initial launch, during background
+  // recovery, or while a fresh error is still within its grace window —
+  // most poll failures self-heal within a couple of seconds and shouldn't
+  // flash a hard error.
+  if (
+    (!initialLoadComplete && (serverIsLoading || !isConnected || isLoading)) ||
+    (initialLoadComplete && (isRecoveringFromBackground || isPendingError))
+  ) {
     return (
       <View style={[styles.center, { backgroundColor: colors.background }]}>
         <FocusAwareStatusBar barStyle={isDark ? 'light-content' : 'dark-content'} />
@@ -431,12 +440,12 @@ export default function TransferScreen() {
     );
   }
 
-  if (error && !isRecoveringFromBackground && initialLoadComplete) {
+  if (graceError && initialLoadComplete) {
     return (
       <View style={[styles.center, { backgroundColor: colors.background }]}>
         <FocusAwareStatusBar barStyle={isDark ? 'light-content' : 'dark-content'} />
         <Ionicons name="alert-circle-outline" size={56} color={colors.error} />
-        <Text style={[styles.errorTitle, { color: colors.error }]}>{error}</Text>
+        <Text style={[styles.errorTitle, { color: colors.error }]}>{graceError}</Text>
         <TouchableOpacity
           style={[styles.retryButton, { backgroundColor: colors.primary }]}
           onPress={refresh}

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -20,6 +20,18 @@ export interface ChangelogRelease {
 
 export const CHANGELOG: ChangelogRelease[] = [
   {
+    version: '3.8.35',
+    date: '2026-07-30',
+    sections: [
+      {
+        title: 'Bugs Fixed',
+        items: [
+          'Fixed the torrent list and Transfer tab occasionally flashing a connection error for a moment when opening the app or returning from background',
+        ],
+      },
+    ],
+  },
+  {
     version: '3.8.34',
     date: '2026-07-27',
     sections: [

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -20,18 +20,6 @@ export interface ChangelogRelease {
 
 export const CHANGELOG: ChangelogRelease[] = [
   {
-    version: '3.8.35',
-    date: '2026-07-30',
-    sections: [
-      {
-        title: 'Bugs Fixed',
-        items: [
-          'Fixed the torrent list and Transfer tab occasionally flashing a connection error for a moment when opening the app or returning from background',
-        ],
-      },
-    ],
-  },
-  {
     version: '3.8.34',
     date: '2026-07-27',
     sections: [

--- a/hooks/useGracefulError.ts
+++ b/hooks/useGracefulError.ts
@@ -1,0 +1,43 @@
+/**
+ * useGracefulError.ts — delays surfacing a transient error to the UI.
+ *
+ * A poll that fails once right after opening/resuming the app usually
+ * self-heals within a couple of seconds (the next poll, or a reactive
+ * reconnect) — showing the full error UI immediately causes a jarring
+ * flash. `graceError` only becomes non-null once `error` has been
+ * continuously truthy for `graceMs`; it clears instantly the moment `error`
+ * clears.
+ */
+import { useEffect, useState } from 'react';
+
+const DEFAULT_GRACE_MS = 2500;
+
+export function useGracefulError(
+  error: string | null,
+  graceMs: number = DEFAULT_GRACE_MS,
+): { graceError: string | null; isPendingError: boolean } {
+  const [confirmedError, setConfirmedError] = useState<string | null>(null);
+  const hasError = error !== null;
+
+  useEffect(() => {
+    if (!hasError) return undefined;
+    const timer = setTimeout(() => setConfirmedError(error), graceMs);
+    return () => {
+      clearTimeout(timer);
+      // Forget a stale confirmed error from a prior streak so a new error
+      // arriving right after the old one cleared goes through its own
+      // grace period instead of appearing to fire instantly.
+      setConfirmedError(null);
+    };
+    // Keyed on presence, not the exact message, so text churn across
+    // repeated failures during a sustained outage doesn't keep resetting
+    // the countdown.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [hasError, graceMs]);
+
+  // Clear instantly the moment the underlying error clears — derived at
+  // render time rather than via a second effect.
+  const graceError = hasError ? confirmedError : null;
+
+  return { graceError, isPendingError: hasError && graceError === null };
+}

--- a/tests/rn/hooks/useGracefulError.test.ts
+++ b/tests/rn/hooks/useGracefulError.test.ts
@@ -1,0 +1,108 @@
+import { renderHook, act } from '@testing-library/react-native';
+import { useGracefulError } from '@/hooks/useGracefulError';
+
+describe('useGracefulError', () => {
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('reports no error and no pending state when there is no error', async () => {
+    const { result } = await renderHook(
+      ({ error }: { error: string | null }) => useGracefulError(error),
+      { initialProps: { error: null as string | null } },
+    );
+    expect(result.current.graceError).toBeNull();
+    expect(result.current.isPendingError).toBe(false);
+  });
+
+  it('withholds the error until the grace period elapses', async () => {
+    jest.useFakeTimers();
+    const { result, rerender } = await renderHook(
+      ({ error }: { error: string | null }) => useGracefulError(error, 2500),
+      { initialProps: { error: null as string | null } },
+    );
+
+    await rerender({ error: 'Network Error' });
+    expect(result.current.graceError).toBeNull();
+    expect(result.current.isPendingError).toBe(true);
+
+    await act(async () => {
+      jest.advanceTimersByTime(2400);
+    });
+    expect(result.current.graceError).toBeNull();
+    expect(result.current.isPendingError).toBe(true);
+
+    await act(async () => {
+      jest.advanceTimersByTime(200);
+    });
+    expect(result.current.graceError).toBe('Network Error');
+    expect(result.current.isPendingError).toBe(false);
+  });
+
+  it('clears without ever surfacing the error if it resolves before the grace period', async () => {
+    jest.useFakeTimers();
+    const { result, rerender } = await renderHook(
+      ({ error }: { error: string | null }) => useGracefulError(error, 2500),
+      { initialProps: { error: 'Network Error' as string | null } },
+    );
+    expect(result.current.isPendingError).toBe(true);
+
+    await act(async () => {
+      jest.advanceTimersByTime(1000);
+    });
+    await rerender({ error: null });
+
+    expect(result.current.graceError).toBeNull();
+    expect(result.current.isPendingError).toBe(false);
+
+    await act(async () => {
+      jest.advanceTimersByTime(5000);
+    });
+    expect(result.current.graceError).toBeNull();
+  });
+
+  it('restarts the grace window for a new error after the previous one cleared', async () => {
+    jest.useFakeTimers();
+    const { result, rerender } = await renderHook(
+      ({ error }: { error: string | null }) => useGracefulError(error, 2500),
+      { initialProps: { error: 'Authentication failed' as string | null } },
+    );
+
+    await act(async () => {
+      jest.advanceTimersByTime(2500);
+    });
+    expect(result.current.graceError).toBe('Authentication failed');
+
+    await rerender({ error: null });
+    expect(result.current.graceError).toBeNull();
+
+    await rerender({ error: 'Connection timeout' });
+    expect(result.current.graceError).toBeNull();
+    expect(result.current.isPendingError).toBe(true);
+
+    await act(async () => {
+      jest.advanceTimersByTime(2500);
+    });
+    expect(result.current.graceError).toBe('Connection timeout');
+  });
+
+  it('uses the default grace period when none is provided', async () => {
+    jest.useFakeTimers();
+    const { result, rerender } = await renderHook(
+      ({ error }: { error: string | null }) => useGracefulError(error),
+      { initialProps: { error: null as string | null } },
+    );
+    await rerender({ error: 'Network Error' });
+
+    await act(async () => {
+      jest.advanceTimersByTime(2499);
+    });
+    expect(result.current.graceError).toBeNull();
+
+    await act(async () => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(result.current.graceError).toBe('Network Error');
+  });
+});


### PR DESCRIPTION
The Torrents list and Transfer tab showed a hard "Something Went Wrong"
error the instant a poll failed, even for brief session hiccups right
after opening or resuming the app that self-heal within a second or two
via the next poll or a reactive reconnect. Add useGracefulError, which
withholds the error for ~2.5s (keeping the loading skeleton/spinner
visible instead) and only surfaces it if it hasn't cleared by then.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013FPX25AnLTAVDuCFzXMmhR