### PR TITLE
Add breathing room around torrent list cards

### DIFF
--- a/app/(tabs)/(torrents)/index.tsx
+++ b/app/(tabs)/(torrents)/index.tsx
@@ -2290,12 +2290,12 @@ const styles = StyleSheet.create({
   },
   listContent: {
     paddingTop: 100,
-    paddingHorizontal: 2,
+    paddingHorizontal: spacing.md,
     borderRadius: borderRadius.large,
   },
   skeletonList: {
     paddingTop: 100,
-    paddingHorizontal: 2,
+    paddingHorizontal: spacing.md,
   },
   selectionHeader: {
     flexDirection: 'row',

--- a/components/TorrentCard.tsx
+++ b/components/TorrentCard.tsx
@@ -520,14 +520,14 @@ const styles = StyleSheet.create({
   card: {
     borderRadius: borderRadius.medium,
     borderLeftWidth: 1.5,
-    marginVertical: 2,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.sm - 2,
+    marginVertical: spacing.xs,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
     ...shadows.card,
   },
   cardDetailed: {
     borderRadius: borderRadius.large,
-    marginVertical: 2,
+    marginVertical: spacing.xs,
     paddingHorizontal: spacing.md,
     paddingVertical: spacing.md,
   },


### PR DESCRIPTION
## Summary
- Fixes #187 — torrent rows had almost no padding (`paddingHorizontal: 2`), making the list feel cluttered edge-to-edge.
- Bumped the torrents list `paddingHorizontal` from `2` to `spacing.md` (12) so cards sit inset from the screen edges (swipe actions have fixed widths, so this doesn't affect swipe-to-pause/delete).
- Bumped `TorrentCard`'s `card`/`cardDetailed` internal padding and vertical margin between rows to the standard spacing scale for a less cramped look.

## Test plan
- Pure spacing/layout numeric change; no logic touched. `node_modules` wasn't present in this environment so `tsc`/`jest` weren't run — screenshots will be reviewed separately per the issue author's request.


---
_Generated by [Claude Code](https://claude.ai/code/session_018ebTjLuBgRuAAMsLMwiyf4)_