### PR TITLE
Add breathing room around torrent list cards (#187)

### DIFF
--- a/app/(tabs)/(torrents)/index.tsx
+++ b/app/(tabs)/(torrents)/index.tsx
@@ -2290,12 +2290,12 @@ const styles = StyleSheet.create({
   },
   listContent: {
     paddingTop: 100,
-    paddingHorizontal: 2,
+    paddingHorizontal: spacing.md,
     borderRadius: borderRadius.large,
   },
   skeletonList: {
     paddingTop: 100,
-    paddingHorizontal: 2,
+    paddingHorizontal: spacing.md,
   },
   selectionHeader: {
     flexDirection: 'row',

--- a/components/TorrentCard.tsx
+++ b/components/TorrentCard.tsx
@@ -520,14 +520,14 @@ const styles = StyleSheet.create({
   card: {
     borderRadius: borderRadius.medium,
     borderLeftWidth: 1.5,
-    marginVertical: 2,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.sm - 2,
+    marginVertical: spacing.xs,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
     ...shadows.card,
   },
   cardDetailed: {
     borderRadius: borderRadius.large,
-    marginVertical: 2,
+    marginVertical: spacing.xs,
     paddingHorizontal: spacing.md,
     paddingVertical: spacing.md,
   },


### PR DESCRIPTION
List content and card padding were nearly zero (2px), making rows feel
cluttered and edge-to-edge. Bump list horizontal padding and card
padding/margins to the standard spacing scale.