### PR TITLE
Fix path autocomplete not triggering on Windows drives other than C:

### DIFF
--- a/components/PathAutocompleteInput.tsx
+++ b/components/PathAutocompleteInput.tsx
@@ -24,6 +24,14 @@ const SUGGESTION_LIMIT = 8;
 const DEBOUNCE_MS = 250;
 /** Delay clearing suggestions on blur so a tap on a row can register first. */
 const BLUR_CLEAR_MS = 150;
+/**
+ * On a Windows qBittorrent host, getDirectoryContent('/', ...) resolves to the
+ * root of whatever drive qBittorrent happens to be running on (typically C:) —
+ * there's no API to enumerate other drives. But the endpoint does accept a
+ * drive-letter path like "D:/" directly, so once a user types one, suggestions
+ * should still kick in instead of silently doing nothing (#180).
+ */
+const WINDOWS_DRIVE_PATH = /^[A-Za-z]:\//;
 
 /**
  * qBittorrent's getDirectoryContent returns absolute paths (QDirIterator::next),
@@ -105,7 +113,7 @@ export function PathAutocompleteInput({
       return;
     }
     const lastSlash = text.lastIndexOf('/');
-    if (!text.startsWith('/') || lastSlash < 0) {
+    if ((!text.startsWith('/') && !WINDOWS_DRIVE_PATH.test(text)) || lastSlash < 0) {
       setSuggestions([]);
       return;
     }

--- a/tests/rn/components/PathAutocompleteInput.test.tsx
+++ b/tests/rn/components/PathAutocompleteInput.test.tsx
@@ -74,6 +74,20 @@ describe('PathAutocompleteInput', () => {
     expect(screen.queryByText('data')).toBeNull();
   });
 
+  it('fetches suggestions for a Windows drive-letter path other than the current drive', async () => {
+    jest.mocked(applicationApi.getDirectoryContent).mockResolvedValue(['D:/Downloads']);
+
+    const onChangeText = jest.fn();
+    await render(
+      <PathAutocompleteInput testID="path-input" value="D:/Do" onChangeText={onChangeText} />,
+    );
+
+    fireEvent.changeText(screen.getByTestId('path-input'), 'D:/Do');
+
+    expect(await screen.findByText('D:/Downloads')).toBeTruthy();
+    expect(applicationApi.getDirectoryContent).toHaveBeenCalledWith('D:/', 'dirs');
+  });
+
   it('immediately fetches the next directory level after a suggestion is tapped', async () => {
     jest
       .mocked(applicationApi.getDirectoryContent)


### PR DESCRIPTION
## Summary

- `getDirectoryContent('/', ...)` on a Windows qBittorrent host always resolves to the root of whatever drive qBittorrent happens to be running on (typically `C:`) — there's no API to enumerate other drives, so that part is a qBittorrent limitation.
- The real bug: the autocomplete trigger only fired for text starting with `/`, so a path like `D:/Downloads` never triggered a fetch at all — the suggestion dropdown just silently stayed empty, even though the endpoint accepts a drive-letter path directly.
- Relaxed the trigger in `components/PathAutocompleteInput.tsx` to also match Windows drive-letter paths (`^[A-Za-z]:\/`), so typing a path on another drive now fetches suggestions instead of doing nothing.

Fixes #180.

## Test plan

- [x] `npm test -- tests/rn/components/PathAutocompleteInput.test.tsx tests/rn/components/PathAutocompleteInput.browse.test.tsx` — added a case covering a `D:/` drive-letter path, all passing
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (baseline warnings only)


---
_Generated by [Claude Code](https://claude.ai/code/session_018dZy4frNA5rhsdZERQaToU)_