### PR TITLE
Fix broken TorrentCard compact padding test

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -102,12 +102,12 @@ module.exports = {
         projectId: 'e2539074-777d-46d3-ae9e-9e584f9e9bb0',
       },
     },
-    "updates": {
-      "url": "https://u.expo.dev/e2539074-777d-46d3-ae9e-9e584f9e9bb0"
+    updates: {
+      url: 'https://u.expo.dev/e2539074-777d-46d3-ae9e-9e584f9e9bb0',
     },
-    "runtimeVersion": {
-      "policy": "appVersion"
-  },
+    runtimeVersion: {
+      policy: 'appVersion',
+    },
     owner: 'taylorcox75',
   },
 };

--- a/components/TorrentCard.tsx
+++ b/components/TorrentCard.tsx
@@ -521,8 +521,8 @@ const styles = StyleSheet.create({
     borderRadius: borderRadius.medium,
     borderLeftWidth: 1.5,
     marginVertical: spacing.xs,
-    paddingHorizontal: spacing.sm,
-    paddingVertical: spacing.sm - 2,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
     ...shadows.card,
   },
   cardDetailed: {

--- a/components/TorrentCard.tsx
+++ b/components/TorrentCard.tsx
@@ -521,8 +521,8 @@ const styles = StyleSheet.create({
     borderRadius: borderRadius.medium,
     borderLeftWidth: 1.5,
     marginVertical: spacing.xs,
-    paddingHorizontal: spacing.md,
-    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.sm - 2,
     ...shadows.card,
   },
   cardDetailed: {

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -27,10 +27,10 @@ export const CHANGELOG: ChangelogRelease[] = [
         title: 'Bugs Fixed',
         items: [
           'Fixed a false "couldn\'t read torrent file" error that could briefly flash when opening a .torrent file from a cold launch',
-		  'Fixed server background restoration bug',
+          'Fixed server background restoration bug',
           'Spacing of cards',
-		  'Windows drive path autocomplete'
-		],
+          'Windows drive path autocomplete',
+        ],
       },
     ],
   },
@@ -43,7 +43,7 @@ export const CHANGELOG: ChangelogRelease[] = [
         items: [
           'Global seeding limits (ratio, seeding time, and what happens when reached) can now be set from the Transfer tab',
           'Added an Unlimited shortcut to the Max Ratio and Max Seeding Time editors on the Transfer tab',
-		  'File path now suggested from existing torrent paths and support for windows'
+          'File path now suggested from existing torrent paths and support for windows',
         ],
       },
       {

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -29,7 +29,7 @@ export const CHANGELOG: ChangelogRelease[] = [
           'Fixed a false "couldn\'t read torrent file" error that could briefly flash when opening a .torrent file from a cold launch',
           'Fixed server background restoration bug',
           'Spacing of cards',
-          'Windows drive path autocomplete',
+          'Windows drive path autocomplete'
         ],
       },
     ],

--- a/eas.json
+++ b/eas.json
@@ -20,7 +20,7 @@
         "autoIncrement": true
       },
       "channel": "production"
-    },
+    }
   },
   "submit": {
     "production": {


### PR DESCRIPTION
## Summary
- `styles.card` compact padding had drifted to `spacing.md`/`spacing.sm`, but the test (and intended tightened compact density) expects `spacing.sm`/`spacing.sm - 2`.
- Also picked up prettier formatting drift in `app.config.js`, `eas.json`, and `constants/changelog.ts` from `npm run format`.

## Test plan
- `npx tsc --noEmit` — exit 0
- `npm test` — 983/983 passing
- `npm run lint` — 0 errors