### PR TITLE
Fix backslash suggestions and unscrollable list in path autocomplete

### DIFF
--- a/components/PathAutocompleteInput.tsx
+++ b/components/PathAutocompleteInput.tsx
@@ -36,10 +36,14 @@ const WINDOWS_DRIVE_PATH = /^[A-Za-z]:\//;
 /**
  * qBittorrent's getDirectoryContent returns absolute paths (QDirIterator::next),
  * not basenames. Strip to the final segment so we can filter and apply safely.
+ * On Windows the server returns entries with backslash separators (e.g.
+ * "F:\test folder") even when queried with a forward-slash dirPath, so both
+ * separators have to be recognized or the "basename" ends up being the whole
+ * backslash path (#180).
  */
 function toBaseName(entry: string): string {
-  const trimmed = entry.replace(/\/+$/, '');
-  const idx = trimmed.lastIndexOf('/');
+  const trimmed = entry.replace(/[/\\]+$/, '');
+  const idx = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'));
   return idx >= 0 ? trimmed.slice(idx + 1) : trimmed;
 }
 
@@ -196,7 +200,7 @@ export function PathAutocompleteInput({
             <TouchableOpacity
               key={path}
               style={styles.suggestionRow}
-              onPressIn={() => applySuggestion(path)}
+              onPress={() => applySuggestion(path)}
             >
               <Text style={[styles.suggestionText, { color: colors.text }]} numberOfLines={1}>
                 {path}

--- a/tests/rn/components/PathAutocompleteInput.test.tsx
+++ b/tests/rn/components/PathAutocompleteInput.test.tsx
@@ -88,6 +88,20 @@ describe('PathAutocompleteInput', () => {
     expect(applicationApi.getDirectoryContent).toHaveBeenCalledWith('D:/', 'dirs');
   });
 
+  it('normalizes backslash-separated Windows entries to forward-slash suggestions', async () => {
+    jest.mocked(applicationApi.getDirectoryContent).mockResolvedValue(['F:\\test folder']);
+
+    const onChangeText = jest.fn();
+    await render(
+      <PathAutocompleteInput testID="path-input" value="F:/" onChangeText={onChangeText} />,
+    );
+
+    fireEvent.changeText(screen.getByTestId('path-input'), 'F:/');
+
+    expect(await screen.findByText('F:/test folder')).toBeTruthy();
+    expect(screen.queryByText('F:/F:\\test folder')).toBeNull();
+  });
+
   it('immediately fetches the next directory level after a suggestion is tapped', async () => {
     jest
       .mocked(applicationApi.getDirectoryContent)
@@ -102,7 +116,7 @@ describe('PathAutocompleteInput', () => {
     fireEvent.changeText(screen.getByTestId('path-input'), '/da');
     const suggestion = await screen.findByText('/data');
 
-    fireEvent(suggestion.parent!, 'pressIn');
+    fireEvent(suggestion.parent!, 'press');
 
     // applySuggestion calls onChangeText synchronously with the new value —
     // simulate the parent re-rendering with that value, as a real screen would.


### PR DESCRIPTION
## Summary

Follow-up to #193 — the reporter on #180 found two more issues once they could actually type a drive letter:

- On Windows, `getDirectoryContent` returns entries with **backslash** separators (e.g. `F:\test folder`) even when queried with a forward-slash `dirPath`. `toBaseName` only recognized `/`, so the "basename" ended up being the whole backslash path, producing garbage suggestions like `F:/F:\test folder`. Now both separators are recognized.
- The suggestion list couldn't be scrolled — a swipe meant to scroll immediately applied whatever row was under the finger, because rows used `onPressIn` (fires on touch-down, before the `ScrollView` can claim the gesture as a scroll). Switched to `onPress` (fires on release, after the scroll/tap distinction is resolved).

Neither change affects forward-slash (Linux/macOS) paths — backslash characters never appear in those, and the existing forward-slash tests still pass unchanged.

## Test plan

- [x] `npm test -- tests/rn/components/PathAutocompleteInput.test.tsx tests/rn/components/PathAutocompleteInput.browse.test.tsx` — added cases for backslash-separated Windows entries; all 8 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors (baseline warnings only)


---
_Generated by [Claude Code](https://claude.ai/code/session_018dZy4frNA5rhsdZERQaToU)_