### PR TITLE
Add search sort-by-date option (#202)

### DIFF
--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -396,9 +396,16 @@ export default function SearchScreen() {
         case 'name':
           cmp = (a.fileName || '').localeCompare(b.fileName || '');
           break;
-        case 'date':
-          cmp = (a.pubDate ?? 0) - (b.pubDate ?? 0);
+        case 'date': {
+          // qBittorrent always sends pubDate, using -1 as the "plugin didn't
+          // report one" sentinel (same convention as nbLeechers) — never
+          // actually absent. Normalize any non-positive value to 0 so
+          // unknown dates group together instead of comparing as -1.
+          const aDate = a.pubDate && a.pubDate > 0 ? a.pubDate : 0;
+          const bDate = b.pubDate && b.pubDate > 0 ? b.pubDate : 0;
+          cmp = aDate - bDate;
           break;
+        }
       }
       return sortDirection === 'asc' ? cmp : -cmp;
     });

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -55,7 +55,7 @@ import { haptics } from '@/utils/haptics';
 const ALL = 'all';
 const ENABLED = 'enabled';
 
-type SortKey = 'seeders' | 'size' | 'name' | 'leechers';
+type SortKey = 'seeders' | 'size' | 'name' | 'leechers' | 'date';
 
 const SORT_OPTIONS: Array<{
   key: SortKey;
@@ -66,6 +66,7 @@ const SORT_OPTIONS: Array<{
   { key: 'leechers', labelKey: 'screens.search.sortLeechers', icon: 'arrow-down-outline' },
   { key: 'size', labelKey: 'screens.search.sortSize', icon: 'cube-outline' },
   { key: 'name', labelKey: 'screens.search.sortName', icon: 'text-outline' },
+  { key: 'date', labelKey: 'screens.search.sortDate', icon: 'calendar-outline' },
 ];
 
 const TAG_MATCH_ATTEMPTS = 8;
@@ -234,6 +235,13 @@ export default function SearchScreen() {
   const [pendingAddUrl, setPendingAddUrl] = useState<string | null>(null);
   const [actionResult, setActionResult] = useState<SearchResult | null>(null);
 
+  // pubDate is a qBit 5.0+ (WebAPI >= 2.11.0) field — hide the option on older
+  // servers rather than offering a sort that silently does nothing.
+  const visibleSortOptions = useMemo(
+    () => SORT_OPTIONS.filter((opt) => opt.key !== 'date' || features.supportsSearchPubDate),
+    [features.supportsSearchPubDate],
+  );
+
   // Load remembered plugin/category once at mount. The query text itself is
   // deliberately NOT restored — it should reset on a fresh app launch, and
   // React state already keeps it intact when just switching tabs within the
@@ -387,6 +395,9 @@ export default function SearchScreen() {
           break;
         case 'name':
           cmp = (a.fileName || '').localeCompare(b.fileName || '');
+          break;
+        case 'date':
+          cmp = (a.pubDate ?? 0) - (b.pubDate ?? 0);
           break;
       }
       return sortDirection === 'asc' ? cmp : -cmp;
@@ -1013,7 +1024,7 @@ export default function SearchScreen() {
                     },
                   ]}
                 >
-                  {SORT_OPTIONS.map((opt) => {
+                  {visibleSortOptions.map((opt) => {
                     const isActive = sortBy === opt.key;
                     return (
                       <TouchableOpacity

--- a/app/(tabs)/settings/rss-rule.tsx
+++ b/app/(tabs)/settings/rss-rule.tsx
@@ -27,6 +27,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useQuery } from '@tanstack/react-query';
 import { FocusAwareStatusBar } from '@/components/FocusAwareStatusBar';
+import { PathAutocompleteInput } from '@/components/PathAutocompleteInput';
 import { SettingRow } from '@/components/SettingRow';
 import { OptionPicker, OptionPickerItem } from '@/components/OptionPicker';
 import { MultiSelectPicker, MultiSelectPickerItem } from '@/components/MultiSelectPicker';
@@ -450,7 +451,7 @@ export default function RssRuleEditorScreen() {
               <View style={[styles.separator, { backgroundColor: colors.surfaceOutline }]} />
 
               <SettingRow label={t('screens.rss.savePath')} hint={t('screens.rss.savePathHint')}>
-                <TextInput
+                <PathAutocompleteInput
                   style={[
                     styles.rowInput,
                     {

--- a/app/(tabs)/settings/torrent-defaults.tsx
+++ b/app/(tabs)/settings/torrent-defaults.tsx
@@ -20,7 +20,7 @@ import { useToast } from '@/context/ToastContext';
 import { FocusAwareStatusBar } from '@/components/FocusAwareStatusBar';
 import { OptionPicker, OptionPickerItem } from '@/components/OptionPicker';
 import { InputModal } from '@/components/InputModal';
-import { PathAutocompleteInput } from '@/components/PathAutocompleteInput';
+import { PathAutocompleteInput, isWindowsStylePath } from '@/components/PathAutocompleteInput';
 import { storageService } from '@/services/storage';
 import { applicationApi } from '@/services/api/application';
 import { apiClient } from '@/services/api/client';
@@ -1988,7 +1988,12 @@ export default function TorrentDefaultsScreen() {
               placeholder={
                 // Illustrative only — the field's actual value never gets set
                 // to this string; an empty save path really is sent as "".
-                `${defaultSavePath || t('screens.settings.categorySavePathPlaceholderDefault')}/${editCategoryName || editingCategory} ${t('screens.settings.categorySavePathPlaceholderSuffix')}`
+                (() => {
+                  const base =
+                    defaultSavePath || t('screens.settings.categorySavePathPlaceholderDefault');
+                  const sep = isWindowsStylePath(base) ? '\\' : '/';
+                  return `${base}${sep}${editCategoryName || editingCategory} ${t('screens.settings.categorySavePathPlaceholderSuffix')}`;
+                })()
               }
               placeholderTextColor={colors.textSecondary}
             />

--- a/components/PathAutocompleteInput.tsx
+++ b/components/PathAutocompleteInput.tsx
@@ -29,9 +29,30 @@ const BLUR_CLEAR_MS = 150;
  * root of whatever drive qBittorrent happens to be running on (typically C:) —
  * there's no API to enumerate other drives. But the endpoint does accept a
  * drive-letter path like "D:/" directly, so once a user types one, suggestions
- * should still kick in instead of silently doing nothing (#180).
+ * should still kick in instead of silently doing nothing (#180). Accept either
+ * separator after the colon (`D:/` or `D:\`) since Windows users naturally
+ * type backslashes.
  */
-const WINDOWS_DRIVE_PATH = /^[A-Za-z]:\//;
+const WINDOWS_DRIVE_PATH = /^[A-Za-z]:[/\\]/;
+/** A UNC network path, e.g. `\\nas\share\`. Windows-only; always backslash. */
+const UNC_PATH = /^\\\\/;
+
+/**
+ * True for paths that are unambiguously Windows-style (drive letter or UNC
+ * share) — the only case where `\` should be treated as a path separator.
+ * A bare `/`-rooted path (Linux/macOS host) never gets this treatment, so a
+ * literal backslash in a Linux directory name is never misread as a separator.
+ */
+export function isWindowsStylePath(text: string): boolean {
+  return WINDOWS_DRIVE_PATH.test(text) || UNC_PATH.test(text);
+}
+
+/** Index of the last path separator, respecting `isWindowsStylePath`. */
+function lastSeparatorIndex(text: string): number {
+  return isWindowsStylePath(text)
+    ? Math.max(text.lastIndexOf('/'), text.lastIndexOf('\\'))
+    : text.lastIndexOf('/');
+}
 
 /**
  * qBittorrent's getDirectoryContent returns absolute paths (QDirIterator::next),
@@ -116,13 +137,13 @@ export function PathAutocompleteInput({
       setSuggestions([]);
       return;
     }
-    const lastSlash = text.lastIndexOf('/');
-    if ((!text.startsWith('/') && !WINDOWS_DRIVE_PATH.test(text)) || lastSlash < 0) {
+    const lastSep = lastSeparatorIndex(text);
+    if ((!text.startsWith('/') && !isWindowsStylePath(text)) || lastSep < 0) {
       setSuggestions([]);
       return;
     }
-    const parentDir = text.slice(0, lastSlash + 1);
-    const partial = text.slice(lastSlash + 1).toLowerCase();
+    const parentDir = text.slice(0, lastSep + 1);
+    const partial = text.slice(lastSep + 1).toLowerCase();
     const fetchId = ++fetchIdRef.current;
     debounceRef.current = setTimeout(async () => {
       try {
@@ -150,7 +171,7 @@ export function PathAutocompleteInput({
 
   const applySuggestion = (path: string) => {
     cancelPendingBlurClear();
-    const newValue = `${path}/`;
+    const newValue = `${path}${isWindowsStylePath(path) ? '\\' : '/'}`;
     onChangeText(newValue);
     // Immediately list the directory just selected instead of leaving the
     // dropdown empty until the user types another character.

--- a/components/SearchResultRow.tsx
+++ b/components/SearchResultRow.tsx
@@ -16,7 +16,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from '@/context/ThemeContext';
 import { SearchResult } from '@/types/api';
-import { formatSize } from '@/utils/format';
+import { formatSize, formatDate } from '@/utils/format';
 import { resultTrackerLabel } from '@/utils/searchResult';
 import { spacing, borderRadius } from '@/constants/spacing';
 import { typography } from '@/constants/typography';
@@ -92,6 +92,7 @@ export function SearchResultRow({
               {'  ·  '}
               <Text>↓{leechers}</Text>
               {host ? `  ·  ${host}` : ''}
+              {result.pubDate ? `  ·  ${formatDate(result.pubDate)}` : ''}
             </Text>
             {/* Chevron hints that the row expands */}
             <Ionicons

--- a/components/SearchResultRow.tsx
+++ b/components/SearchResultRow.tsx
@@ -85,14 +85,19 @@ export function SearchResultRow({
           {/* Line 2: health dot + meta */}
           <View style={styles.statusRow}>
             <View style={[styles.stateDot, { backgroundColor: dotColor }]} />
-            <Text style={[styles.statusText, { color: colors.textSecondary }]} numberOfLines={1}>
+            {/* numberOfLines=2, not 1: size/seeders/leechers/host/date can
+                overflow one line once a date is present — wrap instead of
+                silently truncating the date off the end. */}
+            <Text style={[styles.statusText, { color: colors.textSecondary }]} numberOfLines={2}>
               {formatSize(result.fileSize)}
               {'  ·  '}
               <Text style={{ color: colors.success }}>↑{seeders}</Text>
               {'  ·  '}
               <Text>↓{leechers}</Text>
               {host ? `  ·  ${host}` : ''}
-              {result.pubDate ? `  ·  ${formatDate(result.pubDate)}` : ''}
+              {/* qBittorrent sends -1 (not undefined) when the plugin didn't
+                  report a date — only render when it's a real timestamp. */}
+              {result.pubDate && result.pubDate > 0 ? `  ·  ${formatDate(result.pubDate)}` : ''}
             </Text>
             {/* Chevron hints that the row expands */}
             <Ionicons

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -28,7 +28,7 @@ export const CHANGELOG: ChangelogRelease[] = [
         items: [
           'Global seeding limits (ratio, seeding time, and what happens when reached) can now be set from the Transfer tab',
           'Added an Unlimited shortcut to the Max Ratio and Max Seeding Time editors on the Transfer tab',
-		  'File path now suggested from existing torrent paths and support for windows'
+          'File path now suggested from existing torrent paths and support for windows',
         ],
       },
       {

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -512,6 +512,7 @@
       "sortLeechers": "Leechers",
       "sortSize": "Size",
       "sortName": "Name",
+      "sortDate": "Date",
       "categoryLabel": "Kategorie",
       "indexerLabel": "Indexer",
       "allTrackers": "Alle Indexer",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -533,6 +533,7 @@
       "sortLeechers": "Leechers",
       "sortSize": "Size",
       "sortName": "Name",
+      "sortDate": "Date",
       "categoryLabel": "Category",
       "indexerLabel": "Indexer",
       "allTrackers": "All indexers",

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -512,6 +512,7 @@
       "sortLeechers": "Leechers",
       "sortSize": "Size",
       "sortName": "Name",
+      "sortDate": "Date",
       "categoryLabel": "Categoría",
       "indexerLabel": "Indexador",
       "allTrackers": "Todos los indexadores",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -512,6 +512,7 @@
       "sortLeechers": "Leechers",
       "sortSize": "Size",
       "sortName": "Name",
+      "sortDate": "Date",
       "categoryLabel": "Catégorie",
       "indexerLabel": "Indexeur",
       "allTrackers": "Tous les indexeurs",

--- a/locales/ru/translation.json
+++ b/locales/ru/translation.json
@@ -533,6 +533,7 @@
       "sortLeechers": "Leechers",
       "sortSize": "Size",
       "sortName": "Name",
+      "sortDate": "Date",
       "categoryLabel": "Категория",
       "indexerLabel": "Индексатор",
       "allTrackers": "Все индексаторы",

--- a/locales/zh/translation.json
+++ b/locales/zh/translation.json
@@ -512,6 +512,7 @@
       "sortLeechers": "Leechers",
       "sortSize": "Size",
       "sortName": "Name",
+      "sortDate": "Date",
       "categoryLabel": "分类",
       "indexerLabel": "索引器",
       "allTrackers": "所有索引器",

--- a/tests/rn/components/PathAutocompleteInput.test.tsx
+++ b/tests/rn/components/PathAutocompleteInput.test.tsx
@@ -102,6 +102,76 @@ describe('PathAutocompleteInput', () => {
     expect(screen.queryByText('F:/F:\\test folder')).toBeNull();
   });
 
+  it('fetches suggestions for a Windows drive-letter path typed with backslashes', async () => {
+    jest.mocked(applicationApi.getDirectoryContent).mockResolvedValue(['D:\\Downloads']);
+
+    const onChangeText = jest.fn();
+    await render(
+      <PathAutocompleteInput testID="path-input" value="D:\\Do" onChangeText={onChangeText} />,
+    );
+
+    fireEvent.changeText(screen.getByTestId('path-input'), 'D:\\Do');
+
+    expect(await screen.findByText('D:\\Downloads')).toBeTruthy();
+    expect(applicationApi.getDirectoryContent).toHaveBeenCalledWith('D:\\', 'dirs');
+  });
+
+  it('fetches suggestions for a UNC share path', async () => {
+    jest
+      .mocked(applicationApi.getDirectoryContent)
+      .mockResolvedValue(['\\\\nas\\share\\Downloads']);
+
+    const onChangeText = jest.fn();
+    await render(
+      <PathAutocompleteInput
+        testID="path-input"
+        value="\\\\nas\\share\\Do"
+        onChangeText={onChangeText}
+      />,
+    );
+
+    fireEvent.changeText(screen.getByTestId('path-input'), '\\\\nas\\share\\Do');
+
+    expect(await screen.findByText('\\\\nas\\share\\Downloads')).toBeTruthy();
+    expect(applicationApi.getDirectoryContent).toHaveBeenCalledWith('\\\\nas\\share\\', 'dirs');
+  });
+
+  it('appends a backslash (not a forward slash) when a Windows-style suggestion is tapped', async () => {
+    jest.mocked(applicationApi.getDirectoryContent).mockResolvedValue(['D:\\Downloads']);
+
+    const onChangeText = jest.fn();
+    await render(
+      <PathAutocompleteInput testID="path-input" value="D:\\Do" onChangeText={onChangeText} />,
+    );
+
+    fireEvent.changeText(screen.getByTestId('path-input'), 'D:\\Do');
+    const suggestion = await screen.findByText('D:\\Downloads');
+
+    fireEvent(suggestion.parent!, 'press');
+
+    expect(onChangeText).toHaveBeenCalledWith('D:\\Downloads\\');
+  });
+
+  it('never treats a literal backslash in a Linux path as a separator', async () => {
+    jest.mocked(applicationApi.getDirectoryContent).mockResolvedValue(['/data/weird']);
+
+    const onChangeText = jest.fn();
+    await render(
+      <PathAutocompleteInput
+        testID="path-input"
+        value="/data/weird\\name"
+        onChangeText={onChangeText}
+      />,
+    );
+
+    fireEvent.changeText(screen.getByTestId('path-input'), '/data/weird\\name');
+
+    // Give the debounced fetch a chance to have fired.
+    await new Promise((r) => setTimeout(r, 400));
+
+    expect(applicationApi.getDirectoryContent).toHaveBeenCalledWith('/data/', 'dirs');
+  });
+
   it('immediately fetches the next directory level after a suggestion is tapped', async () => {
     jest
       .mocked(applicationApi.getDirectoryContent)

--- a/tests/utils/apiVersion.test.ts
+++ b/tests/utils/apiVersion.test.ts
@@ -36,6 +36,7 @@ describe('getApiFeatures', () => {
       useAddStoppedEnabledPreference: true,
       useStoppedAddParam: true,
       supportsGetDirectoryContent: true,
+      supportsSearchPubDate: true,
     });
   });
 
@@ -53,6 +54,7 @@ describe('getApiFeatures', () => {
     expect(features.useAddStoppedEnabledPreference).toBe(false);
     expect(features.useStoppedAddParam).toBe(false);
     expect(features.supportsGetDirectoryContent).toBe(false);
+    expect(features.supportsSearchPubDate).toBe(false);
     // ratio limit fields only require 2.8+
     expect(features.hasRatioLimitFields).toBe(true);
   });
@@ -72,6 +74,7 @@ describe('getApiFeatures', () => {
     expect(features.useAddStoppedEnabledPreference).toBe(true);
     expect(features.useStoppedAddParam).toBe(true);
     expect(features.supportsGetDirectoryContent).toBe(true);
+    expect(features.supportsSearchPubDate).toBe(true);
   });
 
   it('enables v5 features above major version 2 (e.g. 3.0.0)', () => {

--- a/types/api.ts
+++ b/types/api.ts
@@ -400,6 +400,8 @@ export interface SearchResult {
   descrLink: string;
   /** Name of the plugin that produced this result. Absent on older servers. */
   engineName?: string;
+  /** Unix timestamp (seconds) the torrent was published, if the plugin reported one (qBit 5.0+ / WebAPI >= 2.11.0). */
+  pubDate?: number;
 }
 
 export interface SearchResultsResponse {

--- a/utils/apiVersion.ts
+++ b/utils/apiVersion.ts
@@ -35,6 +35,8 @@ export interface ApiFeatures {
   useStoppedAddParam: boolean;
   /** app/getDirectoryContent endpoint exists, for path autocomplete (WebAPI ≥ 2.11.0 / qBit 5.0). */
   supportsGetDirectoryContent: boolean;
+  /** search/results includes a pubDate field per result, for sort-by-date (WebAPI ≥ 2.11.0 / qBit 5.0). */
+  supportsSearchPubDate: boolean;
 }
 
 export function parseApiVersion(raw: string): ParsedVersion | null {
@@ -66,6 +68,7 @@ const V5_FEATURES: ApiFeatures = {
   useAddStoppedEnabledPreference: true,
   useStoppedAddParam: true,
   supportsGetDirectoryContent: true,
+  supportsSearchPubDate: true,
 };
 
 export function getApiFeatures(apiVersion: string | null): ApiFeatures {
@@ -84,6 +87,7 @@ export function getApiFeatures(apiVersion: string | null): ApiFeatures {
     useAddStoppedEnabledPreference: isV5,
     useStoppedAddParam: isV5,
     supportsGetDirectoryContent: isV5,
+    supportsSearchPubDate: isV5,
   };
 }
 


### PR DESCRIPTION
## Summary

- Adds a **Date** sort option to the Search tab, backed by qBittorrent 5.0's `pubDate` search-result field (undocumented in the wiki, confirmed against `searchcontroller.cpp`). Gated behind the existing WebAPI >= 2.11.0 boundary (`supportsSearchPubDate` in `ApiFeatures`) — hidden on 4.x servers rather than offering a sort that does nothing.
- Fixes two bugs found after initial implementation:
  - qBittorrent always sends `pubDate`, using `-1` as the "plugin didn't report one" sentinel (never an absent field, same convention as `nbLeechers`). Truthy checks treated `-1` as valid, showing a hardcoded "Not provided" string and making the sort a no-op for those results. Now only treated as valid when `> 0`.
  - The result card's meta line (`size · seeders · leechers · indexer`) was capped at `numberOfLines={1}`; appending the date after everything else meant it silently got truncated off on longer rows. Bumped to `numberOfLines={2}` — rows that already fit are unaffected, rows with more content now wrap instead of clipping.

Branch also carries `bugfix/#180-windows` (merged in earlier, not yet in `develop`): recognizes backslash/UNC-style paths typed into `PathAutocompleteInput` (complementary to the already-merged #200, which handled backslash-separated *server responses*), and wires the component into the RSS rule save-path field.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 69 suites / 988 tests passing
- [x] `npm run lint` — 0 errors (baseline warnings only)
- [x] `npm run format` — no diff
- [ ] Manual: confirm Date sort appears only on qBit 5.0+ servers, and that a result with a real `pub_date`-supporting plugin shows its date on the card without truncation