### PR TITLE
Fix rate-app link doing nothing after StoreReview limit

### DIFF
--- a/app/(tabs)/settings/index.tsx
+++ b/app/(tabs)/settings/index.tsx
@@ -19,7 +19,6 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useRouter, useFocusEffect } from 'expo-router';
 import { Ionicons } from '@expo/vector-icons';
-import * as StoreReview from 'expo-store-review';
 import { useServer } from '@/context/ServerContext';
 import { useToast } from '@/context/ToastContext';
 import { useTheme, ThemeColors } from '@/context/ThemeContext';
@@ -174,15 +173,12 @@ export default function SettingsScreen() {
     }
   };
 
-  const handleRate = useCallback(async () => {
-    try {
-      if (await StoreReview.isAvailableAsync()) {
-        await StoreReview.requestReview();
-        return;
-      }
-    } catch {
-      // Fall through to opening the App Store listing directly.
-    }
+  const handleRate = useCallback(() => {
+    // This is an explicit "rate us" button, not a soft in-context ask, so it
+    // must go straight to the App Store review page. StoreReview.requestReview()
+    // is throttled by iOS to ~3 prompts/year and resolves silently with no
+    // dialog once that's exhausted -- it would make this button appear to do
+    // nothing on repeat taps (#212).
     Linking.openURL(`${APP_STORE_URL}?action=write-review`).catch(() => {});
   }, []);
 


### PR DESCRIPTION
## Summary
- Fixes #212 — the "rate the app" link in Settings stopped working after iOS's native review prompt hit its ~3-times-per-year throttle limit, since `StoreReview.requestReview()` resolves silently (no dialog, no error) once exhausted, so the fallback to opening the App Store page never ran.
- Since this is an explicit "rate us" button rather than a soft contextual ask, it now opens the App Store review page directly every time.
- Removed the now-unused `expo-store-review` import.

## Test plan
- [x] `npx tsc --noEmit` — exit 0
- [x] `npm test` — 69 suites / 988 tests passing
- [x] `npm run lint` — 0 errors (baseline warnings only)
- [x] `npm run format`