### PR TITLE
Add multi-select queue for Search torrent results

### DIFF
--- a/.eas/workflows/publish-update.yml
+++ b/.eas/workflows/publish-update.yml
@@ -2,7 +2,7 @@ name: Publish update
 
 on:
   push:
-    branches: ['preview']
+    branches: ['preview-deploy']
 
 jobs:
   update_preview:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,6 +346,11 @@ nested under `advanced`, not on the hub.
 - **`ThemeContext.tsx`** — `useTheme()`, the `colors` object, user overrides.
 - **`ApiVersionContext.tsx`** — detected qBittorrent API version → feature gating
   through `utils/apiVersion.ts`.
+- **`SearchCartContext.tsx`** — session-scoped queue of Search results the user
+  wants to add together (#217). Not persisted — plugin download URLs are often
+  session/token-bound. Dedupes by `fileUrl`. Consumed by `app/torrents/add.tsx`
+  (gated on the `fromCart` route param) and grouped for submission via
+  `utils/search-cart.ts`.
 
 ### Components (`components/`)
 
@@ -358,13 +363,15 @@ All PascalCase function components taking a `…Props` interface.
   qBit 5.0+ / WebAPI ≥ 2.11 — silent no-op when unsupported; also renders the
   browse button), `SavePathPickerModal` (filterable list of save paths already in
   use, derived from TorrentContext via `utils/save-paths.ts` — works on any
-  qBittorrent version).
+  qBittorrent version), `SearchCartModal` (review sheet for the Search tab's add
+  queue — list, per-item remove, Clear all, Checkout — see `SearchCartContext.tsx`).
 - **Torrent / search UI** — `TorrentCard` (`React.memo` with a **custom
   comparator — keep it in sync when you add a rendered field**, or the card
   silently stops updating; category/tag stickers use `categoryColors`/`tagColors`
   then defaults then the `avatarColor` fallback), `SearchResultRow` (+ internal
-  ActionPill), `FilterChip`, `EmptyState`, `SkeletonLoader` (+ `SkeletonTorrentCard`),
-  `PieceMap`.
+  ActionPill; the `+` button and the cart-toggle button are independent — see
+  its header comment), `FilterChip`, `EmptyState`, `SkeletonLoader`
+  (+ `SkeletonTorrentCard`), `PieceMap`.
 - **Visuals** — `SpeedGraph`, `CircularProgress`, `AnimatedProgressBar`,
   `AnimatedButton`, `Confetti`.
 - **Chrome / diagnostics** — `FocusAwareStatusBar`, `SettingRow`,
@@ -449,7 +456,11 @@ label, completion and ETA rules) · `limit-input.ts` (share-limit sentinels:
 (RSS tree flattening; paths join with `\`) · `searchResult.ts` (indexer-label
 heuristics) · `login-response.ts` (qBittorrent login body/cookie interpretation) ·
 `haptics.ts` (global toggle + wrappers) · `tags.ts` (CSV tag parsing) ·
-`add-torrent-dialogue.ts` (compact vs full variant) · `server-export.ts` (strips
+`add-torrent-dialogue.ts` (compact vs full variant, plus `getSearchAddOpensDialogue`
+for the Search tab's `+` behavior — #217) · `search-cart.ts`
+(`groupCartItemsForAdd` — splits a `SearchCartContext` cart into one
+`torrents/add` batch per indexer when auto-tag-by-tracker is on, since that
+endpoint applies one `tags` value per request) · `server-export.ts` (strips
 `password`/`basicAuthPassword`/`apiKey` on export, forces them empty on import) ·
 `save-paths.ts` (`getKnownSavePaths`, derived from live data — no API call) ·
 `version.ts` (`APP_VERSION`).

--- a/app/(tabs)/(torrents)/index.tsx
+++ b/app/(tabs)/(torrents)/index.tsx
@@ -86,6 +86,7 @@ export default function TorrentsScreen() {
     magnet?: string | string[];
     torrentFileUri?: string | string[];
     torrentFileName?: string | string[];
+    sourceUrl?: string | string[];
   }>();
 
   // State
@@ -136,6 +137,7 @@ export default function TorrentsScreen() {
 
   const lastAppliedMagnetRef = useRef<{ value: string; at: number } | null>(null);
   const lastAppliedTorrentFileRef = useRef<{ value: string; at: number } | null>(null);
+  const lastAppliedSourceUrlRef = useRef<{ value: string; at: number } | null>(null);
 
   // Action menu state
   const [selectedTorrent, setSelectedTorrent] = useState<TorrentInfo | null>(null);
@@ -343,6 +345,31 @@ export default function TorrentsScreen() {
 
     void handleIncomingMagnet();
   }, [params.magnet, router]);
+
+  // Search tab's + button (#217), compact-dialogue branch — search.tsx has
+  // already decided the variant before navigating here, so unlike the magnet
+  // handoff above this never redirects to the full screen. Uses a distinct
+  // sourceUrl param (set verbatim, not run through extractMagnetLink) because
+  // Search results are often plain https:// download URLs, not magnets.
+  useEffect(() => {
+    const rawSourceUrl = Array.isArray(params.sourceUrl) ? params.sourceUrl[0] : params.sourceUrl;
+    const sourceUrl = rawSourceUrl?.trim();
+    if (!sourceUrl) return;
+
+    const now = Date.now();
+    if (
+      lastAppliedSourceUrlRef.current &&
+      lastAppliedSourceUrlRef.current.value === sourceUrl &&
+      now - lastAppliedSourceUrlRef.current.at < 1500
+    ) {
+      return;
+    }
+    lastAppliedSourceUrlRef.current = { value: sourceUrl, at: now };
+
+    setTorrentUrl(sourceUrl);
+    setShowAddModal(true);
+    router.setParams({ sourceUrl: undefined });
+  }, [params.sourceUrl, router]);
 
   useEffect(() => {
     const fileUri = Array.isArray(params.torrentFileUri)

--- a/app/(tabs)/search.tsx
+++ b/app/(tabs)/search.tsx
@@ -31,12 +31,14 @@ import * as Clipboard from 'expo-clipboard';
 import { FocusAwareStatusBar } from '@/components/FocusAwareStatusBar';
 import { SearchResultRow } from '@/components/SearchResultRow';
 import { ActionMenu, ActionMenuItemDef } from '@/components/ActionMenu';
+import { SearchCartModal } from '@/components/SearchCartModal';
 import { EmptyState } from '@/components/EmptyState';
 import { FilterChip } from '@/components/FilterChip';
 import { useApiFeatures } from '@/context/ApiVersionContext';
 import { useServer } from '@/context/ServerContext';
 import { useTheme } from '@/context/ThemeContext';
 import { useToast } from '@/context/ToastContext';
+import { useSearchCart } from '@/context/SearchCartContext';
 import { useSearchJob } from '@/hooks/useSearchJob';
 import { searchApi } from '@/services/api/search';
 import { torrentsApi } from '@/services/api/torrents';
@@ -45,6 +47,10 @@ import { storageService } from '@/services/storage';
 import { clogDebug, clogWarn } from '@/services/connectivity-log';
 import { SearchPlugin, SearchResult } from '@/types/api';
 import { siteHost, resultTrackerLabel } from '@/utils/searchResult';
+import {
+  getAddTorrentDialogueVariant,
+  getSearchAddOpensDialogue,
+} from '@/utils/add-torrent-dialogue';
 import { spacing, borderRadius } from '@/constants/spacing';
 import { shadows } from '@/constants/shadows';
 import { typography } from '@/constants/typography';
@@ -140,6 +146,8 @@ export default function SearchScreen() {
   const { features } = useApiFeatures();
   const { isDark, colors } = useTheme();
   const { showToast } = useToast();
+  const cart = useSearchCart();
+  const [cartModalVisible, setCartModalVisible] = useState(false);
   const queryInputRef = useRef<TextInput>(null);
   const activeTagPollsRef = useRef(new Set<AbortController>());
 
@@ -510,7 +518,13 @@ export default function SearchScreen() {
     prevStatusRef.current = status;
   }, [status, total, showToast, t]);
 
-  const handleAddResult = useCallback(
+  // The escape hatch behind the new searchAddOpensDialogue pref (#217) and
+  // the long-press action sheet's "Add now" item — unchanged from before the
+  // cart/dialogue feature. Also the only path that still routes eligible
+  // results through search/downloadTorrent (see the isMagnet branch below),
+  // which cart checkout (torrents/add only, see app/torrents/add.tsx)
+  // deliberately does not use.
+  const instantAddResult = useCallback(
     async (result: SearchResult) => {
       if (!result.fileUrl) return;
       setPendingAddUrl(result.fileUrl);
@@ -564,6 +578,48 @@ export default function SearchScreen() {
       }
     },
     [features.supportsSearchDownloadTorrent, isAggregatedSource, showToast, t],
+  );
+
+  // + button handler (#217). Gated by searchAddOpensDialogue (default true):
+  // opens the add-torrent dialogue pre-filled with this one result instead of
+  // instantly adding, honoring the user's useFullAddTorrentDialogue variant
+  // choice the same way the existing magnet-deep-link handoff does. Falls
+  // back to instantAddResult if preferences can't be read or navigation
+  // fails, so a storage hiccup never leaves the + button doing nothing.
+  const handleAddResult = useCallback(
+    async (result: SearchResult) => {
+      if (!result.fileUrl) return;
+      try {
+        const prefs = await storageService.getPreferences();
+        if (!getSearchAddOpensDialogue(prefs)) {
+          await instantAddResult(result);
+          return;
+        }
+        const variant = getAddTorrentDialogueVariant(prefs);
+        if (variant === 'full') {
+          router.push({ pathname: '/torrents/add', params: { sourceUrl: result.fileUrl } });
+        } else {
+          router.push({ pathname: '/', params: { sourceUrl: result.fileUrl } });
+        }
+      } catch {
+        await instantAddResult(result);
+      }
+    },
+    [instantAddResult, router],
+  );
+
+  const handleToggleCart = useCallback(
+    (result: SearchResult) => {
+      if (!result.fileUrl) return;
+      cart.toggle({
+        fileUrl: result.fileUrl,
+        fileName: result.fileName,
+        fileSize: result.fileSize,
+        nbSeeders: result.nbSeeders ?? 0,
+        indexerLabel: resultTrackerLabel(result, isAggregatedSource),
+      });
+    },
+    [cart, isAggregatedSource],
   );
 
   const handleLongPressResult = useCallback((result: SearchResult) => {
@@ -620,11 +676,17 @@ export default function SearchScreen() {
   // Long-press action sheet items
   const actionItems: ActionMenuItemDef[] = useMemo(() => {
     if (!actionResult) return [];
+    const resultInCart = cart.has(actionResult.fileUrl);
     const items: ActionMenuItemDef[] = [
       {
-        label: t('screens.search.addToQueue'),
+        label: t('screens.search.addNow'),
         icon: 'add-circle-outline',
-        onPress: () => void handleAddResult(actionResult),
+        onPress: () => void instantAddResult(actionResult),
+      },
+      {
+        label: resultInCart ? t('screens.search.removeFromCart') : t('screens.search.addToCart'),
+        icon: resultInCart ? 'cart' : 'cart-outline',
+        onPress: () => handleToggleCart(actionResult),
       },
     ];
     if (actionResult.descrLink) {
@@ -654,7 +716,16 @@ export default function SearchScreen() {
       });
     }
     return items;
-  }, [actionResult, handleAddResult, handleCopyUrl, handleOpenLink, handleShareUrl, t]);
+  }, [
+    actionResult,
+    cart,
+    handleToggleCart,
+    instantAddResult,
+    handleCopyUrl,
+    handleOpenLink,
+    handleShareUrl,
+    t,
+  ]);
 
   // ────────────────────────────────────────────────── chip data ───────────
 
@@ -1116,6 +1187,8 @@ export default function SearchScreen() {
                 onOpenLink={handleOpenLink}
                 onCopyUrl={handleCopyUrl}
                 isAdding={pendingAddUrl === item.fileUrl}
+                inCart={cart.has(item.fileUrl)}
+                onToggleCart={handleToggleCart}
               />
             )}
             contentContainerStyle={{
@@ -1134,12 +1207,52 @@ export default function SearchScreen() {
             windowSize={10}
           />
         )}
+
+        {/* Floating cart button (#217) — appears once something is queued,
+            opens the review sheet rather than checking out directly so the
+            user can prune the batch first. */}
+        {cart.count > 0 && (
+          <TouchableOpacity
+            style={[styles.cartFab, { backgroundColor: colors.primary }]}
+            onPress={() => {
+              haptics.medium();
+              setCartModalVisible(true);
+            }}
+            activeOpacity={0.85}
+            accessibilityLabel={t('screens.search.cartAccessibility', { count: cart.count })}
+          >
+            <Ionicons name="cart" size={24} color="#FFFFFF" />
+            <View
+              style={[
+                styles.cartFabBadge,
+                { backgroundColor: colors.error, borderColor: colors.background },
+              ]}
+            >
+              <Text style={styles.cartFabBadgeText}>{cart.count}</Text>
+            </View>
+          </TouchableOpacity>
+        )}
       </View>
 
       <ActionMenu
         visible={actionResult !== null}
         onClose={() => setActionResult(null)}
         items={actionItems}
+      />
+
+      <SearchCartModal
+        visible={cartModalVisible}
+        items={cart.items}
+        onRemove={cart.remove}
+        onClearAll={() => {
+          cart.clear();
+          setCartModalVisible(false);
+        }}
+        onCheckout={() => {
+          setCartModalVisible(false);
+          router.push({ pathname: '/torrents/add', params: { fromCart: '1' } });
+        }}
+        onClose={() => setCartModalVisible(false)}
       />
     </>
   );
@@ -1304,5 +1417,32 @@ const styles = StyleSheet.create({
   emptySubtitle: {
     ...typography.secondary,
     textAlign: 'center',
+  },
+  cartFab: {
+    position: 'absolute',
+    right: spacing.lg,
+    bottom: spacing.lg,
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...shadows.large,
+  },
+  cartFabBadge: {
+    position: 'absolute',
+    top: -2,
+    right: -2,
+    minWidth: 22,
+    height: 22,
+    borderRadius: 11,
+    borderWidth: 2,
+    paddingHorizontal: 5,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  cartFabBadgeText: {
+    ...typography.captionSemibold,
+    color: '#FFFFFF',
   },
 });

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -22,6 +22,7 @@ import { TorrentProvider } from '@/context/TorrentContext';
 import { TransferProvider } from '@/context/TransferContext';
 import { ThemeProvider, useTheme } from '@/context/ThemeContext';
 import { ToastProvider, useToast } from '@/context/ToastContext';
+import { SearchCartProvider } from '@/context/SearchCartContext';
 import { logStorage } from '@/services/log-storage';
 import { storageService } from '@/services/storage';
 import { apiClient } from '@/services/api/client';
@@ -351,7 +352,9 @@ export default function RootLayout() {
                 <ApiVersionProvider>
                   <TorrentProvider>
                     <TransferProvider>
-                      <StackNavigator />
+                      <SearchCartProvider>
+                        <StackNavigator />
+                      </SearchCartProvider>
                     </TransferProvider>
                   </TorrentProvider>
                 </ApiVersionProvider>

--- a/app/search/plugins.tsx
+++ b/app/search/plugins.tsx
@@ -28,6 +28,8 @@ import { useToast } from '@/context/ToastContext';
 import { useServer } from '@/context/ServerContext';
 import { searchApi } from '@/services/api/search';
 import { SearchPlugin } from '@/types/api';
+import { storageService } from '@/services/storage';
+import { getSearchAddOpensDialogue } from '@/utils/add-torrent-dialogue';
 import { spacing, borderRadius } from '@/constants/spacing';
 import { typography } from '@/constants/typography';
 import { getErrorMessage } from '@/utils/error';
@@ -44,6 +46,7 @@ export default function PluginsScreen() {
   const [installModalVisible, setInstallModalVisible] = useState(false);
   const [busyName, setBusyName] = useState<string | null>(null);
   const [updating, setUpdating] = useState(false);
+  const [searchOpensDialogue, setSearchOpensDialogue] = useState(true);
 
   const pluginsQuery = useQuery<SearchPlugin[]>({
     queryKey: ['search', 'plugins'],
@@ -58,6 +61,29 @@ export default function PluginsScreen() {
       void queryClient.invalidateQueries({ queryKey: ['search', 'plugins'] });
     }, [queryClient]),
   );
+
+  useFocusEffect(
+    useCallback(() => {
+      (async () => {
+        try {
+          const prefs = await storageService.getPreferences();
+          setSearchOpensDialogue(getSearchAddOpensDialogue(prefs));
+        } catch {
+          setSearchOpensDialogue(true);
+        }
+      })();
+    }, []),
+  );
+
+  const handleToggleSearchOpensDialogue = useCallback(async (value: boolean) => {
+    setSearchOpensDialogue(value);
+    try {
+      const prefs = await storageService.getPreferences();
+      await storageService.savePreferences({ ...prefs, searchAddOpensDialogue: value });
+    } catch {
+      // Ignore save errors — this is a convenience preference, not critical state.
+    }
+  }, []);
 
   const refresh = useCallback(async () => {
     await queryClient.invalidateQueries({ queryKey: ['search', 'plugins'] });
@@ -212,6 +238,29 @@ export default function PluginsScreen() {
             </TouchableOpacity>
           </View>
 
+          {/* Search add-dialogue behavior (#217) */}
+          <View style={[styles.card, { backgroundColor: colors.surface }]}>
+            <View style={styles.settingRow}>
+              <View style={styles.settingLeft}>
+                <Ionicons name="albums-outline" size={22} color={colors.primary} />
+                <View style={{ flex: 1 }}>
+                  <Text style={[styles.settingLabel, { color: colors.text }]}>
+                    {t('screens.settings.searchAddOpensDialogue')}
+                  </Text>
+                  <Text style={[styles.settingHint, { color: colors.textSecondary }]}>
+                    {t('screens.settings.searchAddOpensDialogueHint')}
+                  </Text>
+                </View>
+              </View>
+              <Switch
+                value={searchOpensDialogue}
+                onValueChange={(value) => void handleToggleSearchOpensDialogue(value)}
+                thumbColor="#FFFFFF"
+                trackColor={{ false: colors.surfaceOutline, true: colors.primary }}
+              />
+            </View>
+          </View>
+
           {/* Plugin list */}
           {pluginsQuery.isLoading ? (
             <View style={styles.center}>
@@ -333,6 +382,23 @@ const styles = StyleSheet.create({
     paddingTop: spacing.lg,
     gap: spacing.sm,
   },
+  settingRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  settingLeft: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    flex: 1,
+    flexShrink: 1,
+    marginRight: spacing.md,
+  },
+  settingLabel: { fontSize: 16, fontWeight: '500', flexShrink: 1 },
+  settingHint: { fontSize: 12, marginTop: 1 },
   primaryButton: {
     flex: 1,
     flexDirection: 'row',

--- a/app/torrents/add.tsx
+++ b/app/torrents/add.tsx
@@ -26,6 +26,7 @@ import { useTheme } from '@/context/ThemeContext';
 import { useToast } from '@/context/ToastContext';
 import { useServer } from '@/context/ServerContext';
 import { useTorrents } from '@/context/TorrentContext';
+import { useSearchCart } from '@/context/SearchCartContext';
 import { torrentsApi } from '@/services/api/torrents';
 import { categoriesApi } from '@/services/api/categories';
 import { tagsApi } from '@/services/api/tags';
@@ -36,6 +37,7 @@ import { spacing, borderRadius } from '@/constants/spacing';
 import { shadows } from '@/constants/shadows';
 import { typography } from '@/constants/typography';
 import { extractMagnetLink } from '@/utils/magnet';
+import { groupCartItemsForAdd } from '@/utils/search-cart';
 
 type AddTorrentOptions = Parameters<typeof torrentsApi.addTorrent>[1];
 type AddTorrentFileOptions = Parameters<typeof torrentsApi.addTorrentFile>[1];
@@ -48,13 +50,27 @@ export default function AddTorrentFullScreen() {
   const { showToast } = useToast();
   const { isConnected } = useServer();
   const { categories, tags } = useTorrents();
+  const cart = useSearchCart();
   const params = useLocalSearchParams<{
     magnet?: string | string[];
     torrentFileUri?: string | string[];
     torrentFileName?: string | string[];
+    sourceUrl?: string | string[];
+    fromCart?: string | string[];
   }>();
   const lastAppliedMagnetRef = useRef<{ value: string; at: number } | null>(null);
   const lastAppliedTorrentFileRef = useRef<{ value: string; at: number } | null>(null);
+  const lastAppliedSourceUrlRef = useRef<{ value: string; at: number } | null>(null);
+
+  // The Search tab's cart checkout (#217) — read live rather than snapshotted
+  // so removing an item here also removes it from the Search tab's cart (one
+  // source of truth). Gated on fromCart so a lingering cart from a prior
+  // Search-tab session doesn't leak into an add opened from elsewhere.
+  // Memoized so its identity is stable when fromCart is false (a bare `[]`
+  // ternary would otherwise be a new array every render, defeating the
+  // useCallback below it's a dependency of).
+  const fromCart = (Array.isArray(params.fromCart) ? params.fromCart[0] : params.fromCart) === '1';
+  const cartItems = useMemo(() => (fromCart ? cart.items : []), [fromCart, cart.items]);
 
   const [fieldVisibility, setFieldVisibility] = useState<Record<AddTorrentDialogField, boolean>>(
     DEFAULT_PREFERENCES.addTorrentDialogueFields,
@@ -277,7 +293,9 @@ export default function AddTorrentFullScreen() {
       .split('\n')
       .map((url) => url.trim())
       .filter(Boolean);
-    const sourceOk = (urls.length > 0 || selectedFiles.length > 0) && fieldVisibility.source;
+    const sourceOk =
+      (urls.length > 0 || selectedFiles.length > 0 || cartItems.length > 0) &&
+      fieldVisibility.source;
     if (!sourceOk) {
       showToast(t('errors.enterUrlOrMagnet'), 'error');
       return;
@@ -298,8 +316,30 @@ export default function AddTorrentFullScreen() {
       if (urls.length > 0) {
         tasks.push(torrentsApi.addTorrent(urls, opts));
       }
+      if (cartItems.length > 0) {
+        // Cart checkout always goes through torrents/add (#217) — the whole
+        // point of the batch dialogue is that savepath/category/tags apply,
+        // and search/downloadTorrent (used by the Search tab's instant-add
+        // for cookie-gated plugin URLs) takes no options at all.
+        const prefs = await storageService.getPreferences().catch(() => null);
+        const groups = groupCartItemsForAdd(cartItems, !!prefs?.autoCategorizeByTracker);
+        for (const group of groups) {
+          tasks.push(
+            torrentsApi.addTorrent(group.urls, {
+              ...opts,
+              tags: group.tag ? [...(opts?.tags ?? []), group.tag] : opts?.tags,
+            }),
+          );
+        }
+      }
       await Promise.all(tasks);
-      showToast(t('toast.torrentAdded', { count: urls.length + selectedFiles.length }), 'success');
+      showToast(
+        t('toast.torrentAdded', {
+          count: urls.length + selectedFiles.length + cartItems.length,
+        }),
+        'success',
+      );
+      if (cartItems.length > 0) cart.clear();
       router.back();
     } catch {
       showToast(t('errors.failedToAdd'), 'error');
@@ -308,6 +348,8 @@ export default function AddTorrentFullScreen() {
     }
   }, [
     buildOptions,
+    cart,
+    cartItems,
     fieldVisibility.source,
     isConnected,
     router,
@@ -342,6 +384,29 @@ export default function AddTorrentFullScreen() {
     lastAppliedMagnetRef.current = { value: magnetLink, at: now };
     setTorrentUrl(magnetLink);
   }, [params.magnet]);
+
+  // Search tab's + button (#217), full-dialogue branch. Assigned verbatim —
+  // NOT run through extractMagnetLink, which returns null for a plain
+  // https://…/file.torrent — Search results are frequently non-magnet direct
+  // download URLs, and this screen's textarea already accepts any URL typed
+  // by hand.
+  useEffect(() => {
+    const rawSourceUrl = Array.isArray(params.sourceUrl) ? params.sourceUrl[0] : params.sourceUrl;
+    const sourceUrl = rawSourceUrl?.trim();
+    if (!sourceUrl) return;
+
+    const now = Date.now();
+    if (
+      lastAppliedSourceUrlRef.current &&
+      lastAppliedSourceUrlRef.current.value === sourceUrl &&
+      now - lastAppliedSourceUrlRef.current.at < 1500
+    ) {
+      return;
+    }
+
+    lastAppliedSourceUrlRef.current = { value: sourceUrl, at: now };
+    setTorrentUrl(sourceUrl);
+  }, [params.sourceUrl]);
 
   useEffect(() => {
     const fileUri = Array.isArray(params.torrentFileUri)
@@ -408,6 +473,60 @@ export default function AddTorrentFullScreen() {
                   {t('screens.addTorrent.source').toUpperCase()}
                 </Text>
                 <View style={[styles.card, { backgroundColor: colors.surface }]}>
+                  {cartItems.length > 0 && (
+                    <>
+                      <View style={styles.block}>
+                        <Text style={[styles.label, { color: colors.textSecondary }]}>
+                          {t('screens.addTorrent.fromSearch')}
+                        </Text>
+                        <View
+                          style={[
+                            styles.fileListContainer,
+                            { borderColor: colors.primary, backgroundColor: colors.background },
+                          ]}
+                        >
+                          <ScrollView style={styles.fileListScroll} nestedScrollEnabled>
+                            {cartItems.map((item, index) => (
+                              <View
+                                key={item.fileUrl}
+                                style={[
+                                  styles.fileListRow,
+                                  index > 0 && {
+                                    borderTopColor: colors.surfaceOutline,
+                                    borderTopWidth: 1,
+                                  },
+                                ]}
+                              >
+                                <Ionicons name="cart-outline" size={18} color={colors.primary} />
+                                <Text
+                                  style={[styles.fileListRowText, { color: colors.text }]}
+                                  numberOfLines={1}
+                                >
+                                  {item.fileName}
+                                </Text>
+                                <TouchableOpacity
+                                  onPress={() => cart.remove(item.fileUrl)}
+                                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                                  accessibilityLabel={t('common.remove')}
+                                >
+                                  <Ionicons
+                                    name="close-circle"
+                                    size={18}
+                                    color={colors.textSecondary}
+                                  />
+                                </TouchableOpacity>
+                              </View>
+                            ))}
+                          </ScrollView>
+                        </View>
+                      </View>
+
+                      <View
+                        style={[styles.separatorFull, { backgroundColor: colors.surfaceOutline }]}
+                      />
+                    </>
+                  )}
+
                   <View style={styles.block}>
                     <Text style={[styles.label, { color: colors.textSecondary }]}>
                       {t('screens.torrents.urlOrMagnet')}

--- a/components/SearchCartModal.tsx
+++ b/components/SearchCartModal.tsx
@@ -1,0 +1,241 @@
+/**
+ * SearchCartModal.tsx — Review sheet for the Search tab's add queue (#217).
+ *
+ * Tapping the floating cart button on the Search tab opens this: a themed
+ * list of every queued result (removable individually or all at once) plus a
+ * Checkout button that hands off to the full add-torrent screen. Structure
+ * mirrors SavePathPickerModal (same overlay/card/header/list shape).
+ *
+ * Key exports: SearchCartModal
+ */
+import React from 'react';
+import { Modal, View, Text, TouchableOpacity, ScrollView, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
+import { useTheme } from '@/context/ThemeContext';
+import { SearchCartItem } from '@/context/SearchCartContext';
+import { formatSize } from '@/utils/format';
+import { spacing, borderRadius } from '@/constants/spacing';
+import { shadows } from '@/constants/shadows';
+import { typography } from '@/constants/typography';
+import { haptics } from '@/utils/haptics';
+
+interface SearchCartModalProps {
+  visible: boolean;
+  items: SearchCartItem[];
+  onRemove: (fileUrl: string) => void;
+  onClearAll: () => void;
+  onCheckout: () => void;
+  onClose: () => void;
+}
+
+export function SearchCartModal({
+  visible,
+  items,
+  onRemove,
+  onClearAll,
+  onCheckout,
+  onClose,
+}: SearchCartModalProps) {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="fade"
+      onRequestClose={onClose}
+      accessibilityViewIsModal
+      accessibilityLabel={t('screens.search.cartTitle')}
+    >
+      <TouchableOpacity style={styles.overlay} activeOpacity={1} onPress={onClose}>
+        <TouchableOpacity
+          activeOpacity={1}
+          style={[
+            styles.card,
+            shadows.medium,
+            { backgroundColor: colors.surface, borderColor: colors.surfaceOutline },
+          ]}
+        >
+          <View style={[styles.header, { borderBottomColor: colors.surfaceOutline }]}>
+            <Text style={[styles.title, { color: colors.text }]}>
+              {t('screens.search.cartTitle')}
+            </Text>
+            <TouchableOpacity
+              onPress={onClose}
+              hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+              accessibilityLabel={t('common.close')}
+            >
+              <Ionicons name="close" size={24} color={colors.textSecondary} />
+            </TouchableOpacity>
+          </View>
+
+          {items.length === 0 ? (
+            <Text style={[styles.emptyText, { color: colors.textSecondary }]}>
+              {t('screens.search.cartEmpty')}
+            </Text>
+          ) : (
+            <ScrollView style={styles.list} keyboardShouldPersistTaps="handled">
+              {items.map((item, index) => (
+                <React.Fragment key={item.fileUrl}>
+                  <View style={styles.row}>
+                    <Ionicons name="cart-outline" size={18} color={colors.primary} />
+                    <View style={styles.rowBody}>
+                      <Text style={[styles.rowText, { color: colors.text }]} numberOfLines={2}>
+                        {item.fileName || '—'}
+                      </Text>
+                      <Text
+                        style={[styles.rowMeta, { color: colors.textSecondary }]}
+                        numberOfLines={1}
+                      >
+                        {formatSize(item.fileSize)}
+                        {'  ·  '}
+                        <Text style={{ color: colors.success }}>
+                          ↑{Math.max(0, item.nbSeeders)}
+                        </Text>
+                        {item.indexerLabel ? `  ·  ${item.indexerLabel}` : ''}
+                      </Text>
+                    </View>
+                    <TouchableOpacity
+                      onPress={() => {
+                        haptics.light();
+                        onRemove(item.fileUrl);
+                      }}
+                      hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                      accessibilityLabel={t('common.remove')}
+                    >
+                      <Ionicons name="close-circle" size={20} color={colors.textSecondary} />
+                    </TouchableOpacity>
+                  </View>
+                  {index < items.length - 1 && (
+                    <View style={[styles.divider, { backgroundColor: colors.surfaceOutline }]} />
+                  )}
+                </React.Fragment>
+              ))}
+            </ScrollView>
+          )}
+
+          <View style={styles.footer}>
+            <TouchableOpacity
+              onPress={() => {
+                haptics.medium();
+                onClearAll();
+              }}
+              disabled={items.length === 0}
+              style={styles.clearButton}
+              activeOpacity={0.7}
+            >
+              <Text
+                style={[
+                  styles.clearButtonText,
+                  { color: items.length === 0 ? colors.textSecondary : colors.error },
+                ]}
+              >
+                {t('screens.search.cartClearAll')}
+              </Text>
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={() => {
+                haptics.medium();
+                onCheckout();
+              }}
+              disabled={items.length === 0}
+              style={[
+                styles.checkoutButton,
+                {
+                  backgroundColor: items.length === 0 ? colors.surfaceOutline : colors.primary,
+                },
+              ]}
+              activeOpacity={0.7}
+            >
+              <Text style={styles.checkoutButtonText}>
+                {t('screens.search.cartCheckout', { count: items.length })}
+              </Text>
+            </TouchableOpacity>
+          </View>
+        </TouchableOpacity>
+      </TouchableOpacity>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.4)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: spacing.lg,
+  },
+  card: {
+    width: '90%',
+    maxWidth: 480,
+    maxHeight: '75%',
+    borderRadius: borderRadius.large,
+    borderWidth: StyleSheet.hairlineWidth,
+    padding: spacing.lg,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingBottom: spacing.sm,
+    marginBottom: spacing.sm,
+    borderBottomWidth: 1,
+  },
+  title: { ...typography.h3, fontSize: 18 },
+  list: {
+    flexGrow: 0,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm,
+    paddingVertical: spacing.md,
+  },
+  rowBody: {
+    flex: 1,
+    minWidth: 0,
+    gap: 2,
+  },
+  rowText: {
+    ...typography.bodyMedium,
+  },
+  rowMeta: {
+    ...typography.caption,
+  },
+  divider: {
+    height: 1,
+  },
+  emptyText: {
+    ...typography.secondary,
+    textAlign: 'center',
+    paddingVertical: spacing.xl,
+  },
+  footer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    marginTop: spacing.md,
+    gap: spacing.sm,
+  },
+  clearButton: {
+    paddingVertical: spacing.sm + 2,
+    paddingHorizontal: spacing.sm,
+  },
+  clearButtonText: {
+    ...typography.bodyMedium,
+  },
+  checkoutButton: {
+    flex: 1,
+    borderRadius: borderRadius.medium,
+    paddingVertical: spacing.sm + 4,
+    alignItems: 'center',
+  },
+  checkoutButtonText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+});

--- a/components/SearchResultRow.tsx
+++ b/components/SearchResultRow.tsx
@@ -2,9 +2,14 @@
  * SearchResultRow.tsx — Search result card.
  *
  * Tap semantics (mirrors TorrentCard's "tap = explore, button = act"):
- *   - tap on the row      → expand/collapse inline details + action buttons
- *   - tap on the + button → add the torrent (the ONLY way to add)
- *   - long-press          → opens the parent's action sheet (full menu)
+ *   - tap on the row       → expand/collapse inline details + action buttons
+ *   - tap on the + button  → add the torrent (behavior depends on the
+ *                            searchAddOpensDialogue preference — see search.tsx)
+ *   - tap on the cart      → queue/unqueue this result for a batch add (#217)
+ *   - long-press           → opens the parent's action sheet (full menu)
+ *
+ * The + button and the cart button are independent affordances: + never
+ * touches the cart, and the cart button never adds anything by itself.
  *
  * Visuals mirror TorrentCard: surface card, colored "health dot", filename
  * on line 1, meta line on line 2. Expanded state reveals the un-truncated
@@ -32,6 +37,10 @@ interface SearchResultRowProps {
   onOpenLink?: (url: string) => void;
   onCopyUrl?: (url: string) => void;
   isAdding?: boolean;
+  /** True when this result is already queued in the cart (#217). */
+  inCart?: boolean;
+  /** Omit to hide the cart button entirely. */
+  onToggleCart?: (result: SearchResult) => void;
 }
 
 // Health dot mirrors the Torrents "state dot" convention:
@@ -52,6 +61,8 @@ export function SearchResultRow({
   onOpenLink,
   onCopyUrl,
   isAdding,
+  inCart,
+  onToggleCart,
 }: SearchResultRowProps) {
   const { colors } = useTheme();
   const { t } = useTranslation();
@@ -109,30 +120,60 @@ export function SearchResultRow({
           </View>
         </View>
 
-        {/* Right: the explicit add action. Inner TouchableOpacity does NOT
-            propagate to the outer one in React Native, so tapping it adds
-            the torrent without toggling the expand state. */}
-        <TouchableOpacity
-          onPress={() => {
-            haptics.medium();
-            onAdd(result);
-          }}
-          disabled={isAdding}
-          accessibilityLabel={t('screens.search.addToQueue')}
-          style={[
-            styles.addButton,
-            {
-              backgroundColor: isAdding ? colors.surfaceOutline : colors.primary,
-            },
-          ]}
-          activeOpacity={0.7}
-        >
-          {isAdding ? (
-            <ActivityIndicator size="small" color="#FFFFFF" />
-          ) : (
-            <Ionicons name="add" size={20} color="#FFFFFF" />
-          )}
-        </TouchableOpacity>
+        {/* Right: the explicit add action, plus the cart toggle underneath.
+            Inner TouchableOpacity does NOT propagate to the outer one in
+            React Native, so tapping either button acts without toggling the
+            expand state. */}
+        <View style={styles.actionColumn}>
+          <TouchableOpacity
+            onPress={() => {
+              haptics.medium();
+              onAdd(result);
+            }}
+            disabled={isAdding}
+            accessibilityLabel={t('screens.search.addToQueue')}
+            style={[
+              styles.addButton,
+              {
+                backgroundColor: isAdding ? colors.surfaceOutline : colors.primary,
+              },
+            ]}
+            activeOpacity={0.7}
+          >
+            {isAdding ? (
+              <ActivityIndicator size="small" color="#FFFFFF" />
+            ) : (
+              <Ionicons name="add" size={20} color="#FFFFFF" />
+            )}
+          </TouchableOpacity>
+
+          {onToggleCart && result.fileUrl ? (
+            <TouchableOpacity
+              onPress={() => {
+                haptics.selection();
+                onToggleCart(result);
+              }}
+              accessibilityLabel={
+                inCart ? t('screens.search.removeFromCart') : t('screens.search.addToCart')
+              }
+              accessibilityState={{ selected: !!inCart }}
+              style={[
+                styles.cartButton,
+                {
+                  backgroundColor: inCart ? colors.primaryOpac : colors.background,
+                  borderColor: inCart ? colors.primary : colors.surfaceOutline,
+                },
+              ]}
+              activeOpacity={0.7}
+            >
+              <Ionicons
+                name={inCart ? 'cart' : 'cart-outline'}
+                size={18}
+                color={inCart ? colors.primary : colors.textSecondary}
+              />
+            </TouchableOpacity>
+          ) : null}
+        </View>
       </View>
 
       {/* Inline action row appears when expanded */}
@@ -241,10 +282,22 @@ const styles = StyleSheet.create({
   chevron: {
     marginLeft: spacing.xs,
   },
+  actionColumn: {
+    flexDirection: 'column',
+    gap: spacing.xs,
+  },
   addButton: {
     width: 36,
     height: 36,
     borderRadius: borderRadius.medium,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  cartButton: {
+    width: 36,
+    height: 36,
+    borderRadius: borderRadius.medium,
+    borderWidth: 0.5,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -24,14 +24,11 @@ export const CHANGELOG: ChangelogRelease[] = [
     sections: [
       {
         title: 'New Features',
-        items: [
-        
-        ],
+        items: ['Added new add dialogue to the search page + queue'],
       },
       {
         title: 'Bugs Fixed',
-        items: [
-        ],
+        items: [],
       },
     ],
   },
@@ -63,7 +60,7 @@ export const CHANGELOG: ChangelogRelease[] = [
       {
         title: 'New Features',
         items: [
-		  'Allow self-signed-certs',
+          'Allow self-signed-certs',
           'Global seeding limits (ratio, seeding time, and what happens when reached) can now be set from the Transfer tab',
           'Added an Unlimited shortcut to the Max Ratio and Max Seeding Time editors on the Transfer tab',
           'File path now suggested from existing torrent paths and support for windows',

--- a/context/SearchCartContext.tsx
+++ b/context/SearchCartContext.tsx
@@ -1,0 +1,80 @@
+import React, { createContext, useContext, useCallback, useMemo, useState, ReactNode } from 'react';
+
+export interface SearchCartItem {
+  /** Unique key — the result's download URL. */
+  fileUrl: string;
+  fileName: string;
+  fileSize: number;
+  nbSeeders: number;
+  /**
+   * resultTrackerLabel(result, isAggregatedSource) resolved at the moment the
+   * item was carted. Captured here because isAggregatedSource is Search-screen
+   * state the add screen can't see, and it's what checkout groups by (#217).
+   */
+  indexerLabel: string;
+}
+
+interface SearchCartContextType {
+  items: SearchCartItem[];
+  count: number;
+  has: (fileUrl: string) => boolean;
+  add: (item: SearchCartItem) => void;
+  remove: (fileUrl: string) => void;
+  toggle: (item: SearchCartItem) => void;
+  clear: () => void;
+}
+
+const SearchCartContext = createContext<SearchCartContextType | undefined>(undefined);
+
+/**
+ * Session-scoped queue of Search results a user wants to add together with
+ * one shared set of options (#217). Deliberately not persisted to
+ * AsyncStorage — plugin download URLs are often session/token-bound, so
+ * surviving an app restart would just accumulate stale entries.
+ */
+export function SearchCartProvider({ children }: { children: ReactNode }) {
+  const [items, setItems] = useState<SearchCartItem[]>([]);
+
+  const has = useCallback(
+    (fileUrl: string) => items.some((item) => item.fileUrl === fileUrl),
+    [items],
+  );
+
+  const add = useCallback((item: SearchCartItem) => {
+    setItems((prev) =>
+      prev.some((existing) => existing.fileUrl === item.fileUrl) ? prev : [...prev, item],
+    );
+  }, []);
+
+  const remove = useCallback((fileUrl: string) => {
+    setItems((prev) => prev.filter((item) => item.fileUrl !== fileUrl));
+  }, []);
+
+  const toggle = useCallback((item: SearchCartItem) => {
+    setItems((prev) => {
+      if (prev.some((existing) => existing.fileUrl === item.fileUrl)) {
+        return prev.filter((existing) => existing.fileUrl !== item.fileUrl);
+      }
+      return [...prev, item];
+    });
+  }, []);
+
+  const clear = useCallback(() => {
+    setItems([]);
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({ items, count: items.length, has, add, remove, toggle, clear }),
+    [items, has, add, remove, toggle, clear],
+  );
+
+  return <SearchCartContext.Provider value={contextValue}>{children}</SearchCartContext.Provider>;
+}
+
+export function useSearchCart() {
+  const context = useContext(SearchCartContext);
+  if (context === undefined) {
+    throw new Error('useSearchCart must be used within a SearchCartProvider');
+  }
+  return context;
+}

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -94,7 +94,8 @@
       "ratioLimit": "Verhältnis-Limit",
       "seedingTimeLimit": "Seed-Zeit-Limit",
       "cookie": "Cookie",
-      "cookiePlaceholder": "Optionaler Cookie-Header-Wert"
+      "cookiePlaceholder": "Optionaler Cookie-Header-Wert",
+      "fromSearch": "Aus der Suche"
     },
     "settings": {
       "title": "Einstellungen",
@@ -358,7 +359,9 @@
         "category": "Kategorie",
         "progress": "Fortschritt %",
         "addedTime": "Uhrzeit"
-      }
+      },
+      "searchAddOpensDialogue": "+ in der Suche öffnet den Dialog",
+      "searchAddOpensDialogueHint": "Ein Tippen auf + bei einem Suchergebnis öffnet den Torrent-Hinzufügen-Dialog, statt sofort hinzuzufügen."
     },
     "transfer": {
       "title": "Übertragung",
@@ -524,7 +527,15 @@
       "openSite": "Open site",
       "copyLink": "Copy link",
       "shareLink": "Share link",
-      "linkCopied": "Link copied"
+      "linkCopied": "Link copied",
+      "addToCart": "Zur Warteschlange hinzufügen",
+      "removeFromCart": "Aus der Warteschlange entfernen",
+      "addNow": "Jetzt mit Standardwerten hinzufügen",
+      "cartTitle": "Warteschlange",
+      "cartEmpty": "Noch nichts in der Warteschlange",
+      "cartClearAll": "Alle entfernen",
+      "cartCheckout": "Weiter ({{count}})",
+      "cartAccessibility": "Warteschlange, {{count}} Torrent(s)"
     },
     "rss": {
       "feedsTitle": "RSS-Feeds",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -115,7 +115,8 @@
       "ratioLimit": "Share ratio limit",
       "seedingTimeLimit": "Seeding time limit",
       "cookie": "Cookie",
-      "cookiePlaceholder": "Optional cookie header value"
+      "cookiePlaceholder": "Optional cookie header value",
+      "fromSearch": "From search"
     },
     "settings": {
       "title": "Settings",
@@ -379,7 +380,9 @@
         "category": "Category",
         "progress": "Progress %",
         "addedTime": ""
-      }
+      },
+      "searchAddOpensDialogue": "Search + opens dialogue",
+      "searchAddOpensDialogueHint": "Tapping + on a search result opens the add-torrent dialogue instead of adding straight away."
     },
     "transfer": {
       "title": "Transfer",
@@ -545,7 +548,15 @@
       "openSite": "Open site",
       "copyLink": "Copy link",
       "shareLink": "Share link",
-      "linkCopied": "Link copied"
+      "linkCopied": "Link copied",
+      "addToCart": "Add to queue",
+      "removeFromCart": "Remove from queue",
+      "addNow": "Add now with defaults",
+      "cartTitle": "Add queue",
+      "cartEmpty": "Nothing queued yet",
+      "cartClearAll": "Clear all",
+      "cartCheckout": "Continue ({{count}})",
+      "cartAccessibility": "Add queue, {{count}} torrent(s)"
     },
     "rss": {
       "feedsTitle": "RSS Feeds",

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -94,7 +94,8 @@
       "ratioLimit": "Límite de ratio",
       "seedingTimeLimit": "Límite de tiempo de compartición",
       "cookie": "Cookie",
-      "cookiePlaceholder": "Valor opcional de cabecera Cookie"
+      "cookiePlaceholder": "Valor opcional de cabecera Cookie",
+      "fromSearch": "Desde la búsqueda"
     },
     "settings": {
       "title": "Configuración",
@@ -358,7 +359,9 @@
         "category": "Categoría",
         "progress": "Progreso %",
         "addedTime": "Hora"
-      }
+      },
+      "searchAddOpensDialogue": "El + de búsqueda abre el diálogo",
+      "searchAddOpensDialogueHint": "Al tocar + en un resultado de búsqueda se abre el diálogo de añadir torrent en lugar de añadirlo directamente."
     },
     "transfer": {
       "title": "Transferencia",
@@ -524,7 +527,15 @@
       "openSite": "Open site",
       "copyLink": "Copy link",
       "shareLink": "Share link",
-      "linkCopied": "Link copied"
+      "linkCopied": "Link copied",
+      "addToCart": "Añadir a la cola",
+      "removeFromCart": "Quitar de la cola",
+      "addNow": "Añadir ahora con valores predeterminados",
+      "cartTitle": "Cola de adición",
+      "cartEmpty": "Aún no hay nada en cola",
+      "cartClearAll": "Borrar todo",
+      "cartCheckout": "Continuar ({{count}})",
+      "cartAccessibility": "Cola de adición, {{count}} torrent(s)"
     },
     "rss": {
       "feedsTitle": "Feeds RSS",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -94,7 +94,8 @@
       "ratioLimit": "Limite de ratio",
       "seedingTimeLimit": "Limite de temps de partage",
       "cookie": "Cookie",
-      "cookiePlaceholder": "Valeur optionnelle d'en-tête Cookie"
+      "cookiePlaceholder": "Valeur optionnelle d'en-tête Cookie",
+      "fromSearch": "Depuis la recherche"
     },
     "settings": {
       "title": "Paramètres",
@@ -358,7 +359,9 @@
         "category": "Catégorie",
         "progress": "Progression %",
         "addedTime": "Heure"
-      }
+      },
+      "searchAddOpensDialogue": "Le + de la recherche ouvre la boîte de dialogue",
+      "searchAddOpensDialogueHint": "Appuyer sur + sur un résultat de recherche ouvre la boîte de dialogue d'ajout au lieu d'ajouter directement."
     },
     "transfer": {
       "title": "Transfert",
@@ -524,7 +527,15 @@
       "openSite": "Open site",
       "copyLink": "Copy link",
       "shareLink": "Share link",
-      "linkCopied": "Link copied"
+      "linkCopied": "Link copied",
+      "addToCart": "Ajouter à la file",
+      "removeFromCart": "Retirer de la file",
+      "addNow": "Ajouter maintenant avec les valeurs par défaut",
+      "cartTitle": "File d'ajout",
+      "cartEmpty": "Rien en attente pour le moment",
+      "cartClearAll": "Tout effacer",
+      "cartCheckout": "Continuer ({{count}})",
+      "cartAccessibility": "File d'ajout, {{count}} torrent(s)"
     },
     "rss": {
       "feedsTitle": "Flux RSS",

--- a/locales/ru/translation.json
+++ b/locales/ru/translation.json
@@ -115,7 +115,8 @@
       "ratioLimit": "Лимит коэффициента раздачи",
       "seedingTimeLimit": "Лимит времени раздачи",
       "cookie": "Cookie",
-      "cookiePlaceholder": "Значение заголовка Cookie (необязательно)"
+      "cookiePlaceholder": "Значение заголовка Cookie (необязательно)",
+      "fromSearch": "Из поиска"
     },
     "settings": {
       "title": "Настройки",
@@ -379,7 +380,9 @@
         "category": "Категория",
         "progress": "Прогресс %",
         "addedTime": "Время"
-      }
+      },
+      "searchAddOpensDialogue": "+ в поиске открывает диалог",
+      "searchAddOpensDialogueHint": "Нажатие + на результате поиска открывает диалог добавления торрента вместо немедленного добавления."
     },
     "transfer": {
       "title": "Передача",
@@ -545,7 +548,15 @@
       "openSite": "Open site",
       "copyLink": "Copy link",
       "shareLink": "Share link",
-      "linkCopied": "Link copied"
+      "linkCopied": "Link copied",
+      "addToCart": "Добавить в очередь",
+      "removeFromCart": "Удалить из очереди",
+      "addNow": "Добавить сейчас со значениями по умолчанию",
+      "cartTitle": "Очередь добавления",
+      "cartEmpty": "В очереди пока ничего нет",
+      "cartClearAll": "Очистить всё",
+      "cartCheckout": "Продолжить ({{count}})",
+      "cartAccessibility": "Очередь добавления, {{count}} торрент(ов)"
     },
     "rss": {
       "feedsTitle": "RSS-ленты",

--- a/locales/zh/translation.json
+++ b/locales/zh/translation.json
@@ -94,7 +94,8 @@
       "ratioLimit": "分享率限制",
       "seedingTimeLimit": "做种时间限制",
       "cookie": "Cookie",
-      "cookiePlaceholder": "可选 Cookie 头部值"
+      "cookiePlaceholder": "可选 Cookie 头部值",
+      "fromSearch": "来自搜索"
     },
     "settings": {
       "title": "设置",
@@ -358,7 +359,9 @@
         "category": "分类",
         "progress": "进度 %",
         "addedTime": "时间"
-      }
+      },
+      "searchAddOpensDialogue": "搜索中的 + 打开对话框",
+      "searchAddOpensDialogueHint": "点击搜索结果上的 + 将打开添加种子对话框，而不是直接添加。"
     },
     "transfer": {
       "title": "传输",
@@ -524,7 +527,15 @@
       "openSite": "Open site",
       "copyLink": "Copy link",
       "shareLink": "Share link",
-      "linkCopied": "Link copied"
+      "linkCopied": "Link copied",
+      "addToCart": "加入队列",
+      "removeFromCart": "从队列中移除",
+      "addNow": "立即使用默认设置添加",
+      "cartTitle": "添加队列",
+      "cartEmpty": "队列中还没有内容",
+      "cartClearAll": "清空全部",
+      "cartCheckout": "继续（{{count}}）",
+      "cartAccessibility": "添加队列，共 {{count}} 个种子"
     },
     "rss": {
       "feedsTitle": "RSS 订阅",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qRemote",
   "version": "3.8.35",
-  "easBuild": false,
+  "easBuild": true,
   "main": "index.ts",
   "scripts": {
     "start": "expo start --dev-client",

--- a/tests/rn/components/SearchCartModal.test.tsx
+++ b/tests/rn/components/SearchCartModal.test.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react-native';
+import { SearchCartModal } from '@/components/SearchCartModal';
+import { SearchCartItem } from '@/context/SearchCartContext';
+
+jest.mock('@/context/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      surface: '#fff',
+      text: '#000',
+      textSecondary: '#666',
+      surfaceOutline: '#ccc',
+      primary: '#007aff',
+      background: '#fff',
+      success: '#34c759',
+      error: '#ff3b30',
+    },
+  }),
+}));
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const itemA: SearchCartItem = {
+  fileUrl: 'magnet:?xt=urn:btih:AAA',
+  fileName: 'Result A',
+  fileSize: 1024,
+  nbSeeders: 10,
+  indexerLabel: 'IndexerA',
+};
+
+const itemB: SearchCartItem = {
+  fileUrl: 'magnet:?xt=urn:btih:BBB',
+  fileName: 'Result B',
+  fileSize: 2048,
+  nbSeeders: 5,
+  indexerLabel: 'IndexerB',
+};
+
+describe('SearchCartModal', () => {
+  it('renders nothing when not visible', async () => {
+    await render(
+      <SearchCartModal
+        visible={false}
+        items={[itemA]}
+        onRemove={jest.fn()}
+        onClearAll={jest.fn()}
+        onCheckout={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    );
+    expect(screen.queryByText('Result A')).toBeNull();
+  });
+
+  it('lists every queued item when visible', async () => {
+    await render(
+      <SearchCartModal
+        visible
+        items={[itemA, itemB]}
+        onRemove={jest.fn()}
+        onClearAll={jest.fn()}
+        onCheckout={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    );
+    expect(screen.getByText('Result A')).toBeTruthy();
+    expect(screen.getByText('Result B')).toBeTruthy();
+  });
+
+  it('shows the empty state when the cart has no items', async () => {
+    await render(
+      <SearchCartModal
+        visible
+        items={[]}
+        onRemove={jest.fn()}
+        onClearAll={jest.fn()}
+        onCheckout={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    );
+    expect(screen.getByText('screens.search.cartEmpty')).toBeTruthy();
+  });
+
+  it("calls onRemove with the tapped item's fileUrl", async () => {
+    const onRemove = jest.fn();
+    await render(
+      <SearchCartModal
+        visible
+        items={[itemA, itemB]}
+        onRemove={onRemove}
+        onClearAll={jest.fn()}
+        onCheckout={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    );
+    const removeButtons = screen.getAllByLabelText('common.remove');
+    await fireEvent.press(removeButtons[0]);
+    expect(onRemove).toHaveBeenCalledWith(itemA.fileUrl);
+  });
+
+  it('calls onClearAll when Clear all is tapped', async () => {
+    const onClearAll = jest.fn();
+    await render(
+      <SearchCartModal
+        visible
+        items={[itemA]}
+        onRemove={jest.fn()}
+        onClearAll={onClearAll}
+        onCheckout={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    );
+    await fireEvent.press(screen.getByText('screens.search.cartClearAll'));
+    expect(onClearAll).toHaveBeenCalled();
+  });
+
+  it('calls onCheckout when Checkout is tapped', async () => {
+    const onCheckout = jest.fn();
+    await render(
+      <SearchCartModal
+        visible
+        items={[itemA]}
+        onRemove={jest.fn()}
+        onClearAll={jest.fn()}
+        onCheckout={onCheckout}
+        onClose={jest.fn()}
+      />,
+    );
+    await fireEvent.press(screen.getByText('screens.search.cartCheckout'));
+    expect(onCheckout).toHaveBeenCalled();
+  });
+
+  it('calls onClose when the backdrop is tapped', async () => {
+    const onClose = jest.fn();
+    await render(
+      <SearchCartModal
+        visible
+        items={[itemA]}
+        onRemove={jest.fn()}
+        onClearAll={jest.fn()}
+        onCheckout={jest.fn()}
+        onClose={onClose}
+      />,
+    );
+    await fireEvent.press(screen.getByLabelText('common.close'));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/tests/rn/context/SearchCartContext.test.tsx
+++ b/tests/rn/context/SearchCartContext.test.tsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import { Text, TouchableOpacity } from 'react-native';
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react-native';
+import { SearchCartProvider, useSearchCart, SearchCartItem } from '@/context/SearchCartContext';
+
+const itemA: SearchCartItem = {
+  fileUrl: 'magnet:?xt=urn:btih:AAA',
+  fileName: 'Result A',
+  fileSize: 100,
+  nbSeeders: 10,
+  indexerLabel: 'IndexerA',
+};
+
+const itemB: SearchCartItem = {
+  fileUrl: 'magnet:?xt=urn:btih:BBB',
+  fileName: 'Result B',
+  fileSize: 200,
+  nbSeeders: 20,
+  indexerLabel: 'IndexerB',
+};
+
+function Consumer() {
+  const { items, count, has, add, remove, toggle, clear } = useSearchCart();
+  return (
+    <>
+      <Text testID="count">{count}</Text>
+      <Text testID="order">{items.map((item) => item.fileUrl).join(',')}</Text>
+      <Text testID="has-a">{has(itemA.fileUrl) ? 'yes' : 'no'}</Text>
+      <TouchableOpacity testID="add-a" onPress={() => add(itemA)} />
+      <TouchableOpacity testID="add-b" onPress={() => add(itemB)} />
+      <TouchableOpacity testID="remove-a" onPress={() => remove(itemA.fileUrl)} />
+      <TouchableOpacity testID="toggle-a" onPress={() => toggle(itemA)} />
+      <TouchableOpacity testID="clear" onPress={clear} />
+    </>
+  );
+}
+
+describe('SearchCartContext', () => {
+  it('throws when useSearchCart used outside provider', async () => {
+    const Bad = () => {
+      useSearchCart();
+      return null;
+    };
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(render(<Bad />)).rejects.toThrow(
+      'useSearchCart must be used within a SearchCartProvider',
+    );
+    spy.mockRestore();
+  });
+
+  it('starts empty', async () => {
+    await render(
+      <SearchCartProvider>
+        <Consumer />
+      </SearchCartProvider>,
+    );
+    expect(screen.getByTestId('count').props.children).toBe(0);
+    expect(screen.getByTestId('has-a').props.children).toBe('no');
+  });
+
+  it('add() dedupes by fileUrl and preserves insertion order', async () => {
+    await render(
+      <SearchCartProvider>
+        <Consumer />
+      </SearchCartProvider>,
+    );
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('add-b'));
+    });
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('add-a'));
+    });
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('add-a'));
+    });
+    await waitFor(() => expect(screen.getByTestId('count').props.children).toBe(2));
+    expect(screen.getByTestId('order').props.children).toBe(`${itemB.fileUrl},${itemA.fileUrl}`);
+    expect(screen.getByTestId('has-a').props.children).toBe('yes');
+  });
+
+  it('remove() drops the item', async () => {
+    await render(
+      <SearchCartProvider>
+        <Consumer />
+      </SearchCartProvider>,
+    );
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('add-a'));
+    });
+    await waitFor(() => expect(screen.getByTestId('count').props.children).toBe(1));
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('remove-a'));
+    });
+    await waitFor(() => expect(screen.getByTestId('count').props.children).toBe(0));
+    expect(screen.getByTestId('has-a').props.children).toBe('no');
+  });
+
+  it('toggle() flips membership both ways', async () => {
+    await render(
+      <SearchCartProvider>
+        <Consumer />
+      </SearchCartProvider>,
+    );
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('toggle-a'));
+    });
+    await waitFor(() => expect(screen.getByTestId('has-a').props.children).toBe('yes'));
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('toggle-a'));
+    });
+    await waitFor(() => expect(screen.getByTestId('has-a').props.children).toBe('no'));
+  });
+
+  it('clear() empties the cart', async () => {
+    await render(
+      <SearchCartProvider>
+        <Consumer />
+      </SearchCartProvider>,
+    );
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('add-a'));
+    });
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('add-b'));
+    });
+    await waitFor(() => expect(screen.getByTestId('count').props.children).toBe(2));
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId('clear'));
+    });
+    await waitFor(() => expect(screen.getByTestId('count').props.children).toBe(0));
+  });
+});

--- a/tests/utils/add-torrent-dialogue.test.ts
+++ b/tests/utils/add-torrent-dialogue.test.ts
@@ -1,4 +1,7 @@
-import { getAddTorrentDialogueVariant } from '@/utils/add-torrent-dialogue';
+import {
+  getAddTorrentDialogueVariant,
+  getSearchAddOpensDialogue,
+} from '@/utils/add-torrent-dialogue';
 
 describe('getAddTorrentDialogueVariant', () => {
   it('returns compact by default', () => {
@@ -13,5 +16,21 @@ describe('getAddTorrentDialogueVariant', () => {
 
   it('returns full when full dialogue is enabled', () => {
     expect(getAddTorrentDialogueVariant({ useFullAddTorrentDialogue: true })).toBe('full');
+  });
+});
+
+describe('getSearchAddOpensDialogue', () => {
+  it('defaults to true for users with no stored value', () => {
+    expect(getSearchAddOpensDialogue(undefined)).toBe(true);
+    expect(getSearchAddOpensDialogue(null)).toBe(true);
+    expect(getSearchAddOpensDialogue({})).toBe(true);
+  });
+
+  it('returns true when explicitly enabled', () => {
+    expect(getSearchAddOpensDialogue({ searchAddOpensDialogue: true })).toBe(true);
+  });
+
+  it('returns false only when explicitly disabled', () => {
+    expect(getSearchAddOpensDialogue({ searchAddOpensDialogue: false })).toBe(false);
   });
 });

--- a/tests/utils/search-cart.test.ts
+++ b/tests/utils/search-cart.test.ts
@@ -1,0 +1,70 @@
+import { groupCartItemsForAdd } from '@/utils/search-cart';
+import { SearchCartItem } from '@/context/SearchCartContext';
+
+function item(overrides: Partial<SearchCartItem>): SearchCartItem {
+  return {
+    fileUrl: 'magnet:?xt=urn:btih:default',
+    fileName: 'Result',
+    fileSize: 100,
+    nbSeeders: 5,
+    indexerLabel: 'IndexerA',
+    ...overrides,
+  };
+}
+
+describe('groupCartItemsForAdd', () => {
+  it('returns an empty array for an empty cart', () => {
+    expect(groupCartItemsForAdd([], true)).toEqual([]);
+    expect(groupCartItemsForAdd([], false)).toEqual([]);
+  });
+
+  it('returns a single untagged group when auto-tag is off, regardless of indexer mix', () => {
+    const items = [
+      item({ fileUrl: 'url1', indexerLabel: 'IndexerA' }),
+      item({ fileUrl: 'url2', indexerLabel: 'IndexerB' }),
+    ];
+    expect(groupCartItemsForAdd(items, false)).toEqual([{ urls: ['url1', 'url2'], tag: null }]);
+  });
+
+  it('returns a single tagged group when auto-tag is on and every item shares one indexer', () => {
+    const items = [
+      item({ fileUrl: 'url1', indexerLabel: 'IndexerA' }),
+      item({ fileUrl: 'url2', indexerLabel: 'IndexerA' }),
+    ];
+    expect(groupCartItemsForAdd(items, true)).toEqual([
+      { urls: ['url1', 'url2'], tag: 'IndexerA' },
+    ]);
+  });
+
+  it('splits into one group per indexer, in first-appearance order', () => {
+    const items = [
+      item({ fileUrl: 'url1', indexerLabel: 'IndexerA' }),
+      item({ fileUrl: 'url2', indexerLabel: 'IndexerB' }),
+      item({ fileUrl: 'url3', indexerLabel: 'IndexerA' }),
+    ];
+    expect(groupCartItemsForAdd(items, true)).toEqual([
+      { urls: ['url1', 'url3'], tag: 'IndexerA' },
+      { urls: ['url2'], tag: 'IndexerB' },
+    ]);
+  });
+
+  it('groups empty and whitespace-only labels into one untagged bucket', () => {
+    const items = [
+      item({ fileUrl: 'url1', indexerLabel: '' }),
+      item({ fileUrl: 'url2', indexerLabel: '   ' }),
+    ];
+    expect(groupCartItemsForAdd(items, true)).toEqual([{ urls: ['url1', 'url2'], tag: null }]);
+  });
+
+  it('produces both a labeled and an untagged group for a mixed cart', () => {
+    const items = [
+      item({ fileUrl: 'url1', indexerLabel: 'IndexerA' }),
+      item({ fileUrl: 'url2', indexerLabel: '' }),
+      item({ fileUrl: 'url3', indexerLabel: 'IndexerA' }),
+    ];
+    expect(groupCartItemsForAdd(items, true)).toEqual([
+      { urls: ['url1', 'url3'], tag: 'IndexerA' },
+      { urls: ['url2'], tag: null },
+    ]);
+  });
+});

--- a/types/preferences.ts
+++ b/types/preferences.ts
@@ -137,6 +137,12 @@ export interface AppPreferences {
   /** When enabled, the add-torrent button opens the full add-torrent screen */
   useFullAddTorrentDialogue: boolean;
 
+  /**
+   * When enabled, the + on a Search result opens the add-torrent dialogue
+   * pre-filled instead of instantly adding with server defaults (#217).
+   */
+  searchAddOpensDialogue: boolean;
+
   /** Per-field visibility for the full add-torrent screen */
   addTorrentDialogueFields: Record<AddTorrentDialogField, boolean>;
 
@@ -190,6 +196,7 @@ export const DEFAULT_PREFERENCES: AppPreferences = {
   hasCompletedOnboarding: false,
   autoCategorizeByTracker: false,
   useFullAddTorrentDialogue: false,
+  searchAddOpensDialogue: true,
   addTorrentDialogueFields: {
     source: true,
     savePath: true,

--- a/utils/add-torrent-dialogue.ts
+++ b/utils/add-torrent-dialogue.ts
@@ -7,3 +7,12 @@ export const getAddTorrentDialogueVariant = (
 ): AddTorrentDialogueVariant => {
   return preferences?.useFullAddTorrentDialogue === true ? 'full' : 'compact';
 };
+
+/**
+ * Whether the + on a Search result opens the add-torrent dialogue (#217).
+ * Defaults to true: the key is new, so users upgrading have no stored value
+ * and must land on the new behavior, not on a falsy default.
+ */
+export const getSearchAddOpensDialogue = (
+  preferences: Partial<AppPreferences> | null | undefined,
+): boolean => preferences?.searchAddOpensDialogue !== false;

--- a/utils/search-cart.ts
+++ b/utils/search-cart.ts
@@ -1,0 +1,47 @@
+import type { SearchCartItem } from '@/context/SearchCartContext';
+
+export interface CartAddGroup {
+  urls: string[];
+  /** Tracker tag to apply to this group, or null for no extra tag. */
+  tag: string | null;
+}
+
+/**
+ * Split cart items into torrents/add batches (#217).
+ *
+ * torrents/add applies one `tags` value to every URL in the request, but a
+ * cart can mix indexers — so when auto-tag-by-tracker is on, each indexer
+ * needs its own request. Items with no resolvable indexer label collect into
+ * a single untagged group. With the pref off, everything is one group, which
+ * is also the single-request fast path.
+ *
+ * Group order follows first appearance in `items`, so a retry issues the same
+ * requests in the same order.
+ */
+export function groupCartItemsForAdd(
+  items: SearchCartItem[],
+  autoTagByTracker: boolean,
+): CartAddGroup[] {
+  if (items.length === 0) return [];
+
+  if (!autoTagByTracker) {
+    return [{ urls: items.map((item) => item.fileUrl), tag: null }];
+  }
+
+  const order: string[] = [];
+  const buckets = new Map<string, string[]>();
+
+  for (const item of items) {
+    const label = item.indexerLabel.trim();
+    if (!buckets.has(label)) {
+      order.push(label);
+      buckets.set(label, []);
+    }
+    buckets.get(label)!.push(item.fileUrl);
+  }
+
+  return order.map((label) => ({
+    urls: buckets.get(label)!,
+    tag: label ? label : null,
+  }));
+}


### PR DESCRIPTION
## Summary

Closes #217.

- `+` on a Search result now opens the add-torrent dialogue pre-filled instead of instantly adding, gated behind a new `searchAddOpensDialogue` preference (default on). Toggle lives on the Search Plugins settings screen. The long-press action sheet's "Add now with defaults" keeps the previous one-tap-add behavior available.
- A cart button per result row feeds a floating cart button on the Search tab. Tapping it opens a review sheet (list, per-item remove, Clear all); Checkout pushes the full add-torrent screen with every queued result listed by name, so save path/category/tags apply once to the whole batch via `torrents/add`.
- When auto-tag-by-tracker is on, checkout groups the cart by indexer and issues one `torrents/add` request per group, since that endpoint only accepts one `tags` value per call.
- Fixes a latent gap where the add screen's magnet-only param couldn't carry a plain `https://` search-result URL — added a `sourceUrl` param (set verbatim, not run through `extractMagnetLink`) on both the full add screen and the Torrents tab's compact-modal handoff.
- Includes an unrelated commit bundled in at the repo owner's request: EAS publish-update workflow now watches `preview-deploy` instead of `preview`, plus a changelog entry/formatting fix.

## Test plan

- [x] `npx tsc --noEmit` — exit 0
- [x] `npm test` — 1011 passing, both projects (72 suites, including 4 new test files for `SearchCartContext`, `SearchCartModal`, `search-cart` grouping, and the updated `add-torrent-dialogue` helper)
- [x] `npm run lint` — 0 errors, warning count matches the pre-existing baseline (verified via a stashed clean-checkout diff)
- [x] `npm run format`
- [ ] Manual device/simulator pass (not run — no simulator available in this environment): + behavior with the pref on/off, carting across two searches, review sheet remove/clear, checkout with category+save path set, mixed-indexer auto-tag grouping, backing out of the add screen leaves the cart intact