### PR TITLE
Fix magnet-triggered Add Torrent dialog dismissing on background resume

### DIFF
--- a/app/(tabs)/(torrents)/index.tsx
+++ b/app/(tabs)/(torrents)/index.tsx
@@ -1119,9 +1119,17 @@ export default function TorrentsScreen() {
   // data fetch), during background recovery, or while a fresh error is still
   // within its grace window — most poll failures self-heal within a couple
   // of seconds and shouldn't flash a hard error.
+  //
+  // Skip this entirely while the compact Add Torrent modal is open (#220):
+  // opening a magnet link foregrounds the app, which flips
+  // isRecoveringFromBackground true on the exact same tick the magnet
+  // handler is opening this modal. Returning the skeleton here unmounts the
+  // Modal along with the rest of the screen, so the dialogue flashes and is
+  // immediately dismissed. The modal already re-syncs on its own once
+  // submitted, so there's no correctness reason to interrupt it.
   if (
     (!initialLoadComplete && (serverIsLoading || !isConnected || isLoading)) ||
-    (initialLoadComplete && (isRecoveringFromBackground || isPendingError))
+    (initialLoadComplete && !showAddModal && (isRecoveringFromBackground || isPendingError))
   ) {
     return (
       <>

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -19,6 +19,18 @@ export interface ChangelogRelease {
 }
 export const CHANGELOG: ChangelogRelease[] = [
   {
+    version: '3.8.37',
+    date: '2026-08-12',
+    sections: [
+      {
+        title: 'Bugs Fixed',
+        items: [
+          'Fixed opening a magnet link from the background briefly showing the Add Torrent dialog before dismissing it',
+        ],
+      },
+    ],
+  },
+  {
     version: '3.8.36',
     date: '2026-08-09',
     sections: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qRemote",
-  "version": "3.8.36",
+  "version": "3.8.37",
   "easBuild": true,
   "main": "index.ts",
   "scripts": {


### PR DESCRIPTION
Opening a magnet link while qRemote was backgrounded foregrounds the app, which flips isRecoveringFromBackground true on the same tick the magnet handler opens the compact Add Torrent modal. The resulting background-recovery skeleton screen unmounted the whole tree (including the modal), so the dialog flashed and immediately dismissed. Skip that skeleton while the modal is open.

Fixes #220