### PR TITLE
Show seeds and leeches count per tracker

### DIFF
--- a/app/(tabs)/(torrents)/torrent/manage-trackers.tsx
+++ b/app/(tabs)/(torrents)/torrent/manage-trackers.tsx
@@ -131,6 +131,10 @@ export default function ManageTrackersScreen() {
     }
   };
 
+  // qBittorrent reports -1 for seeds/leeches until the tracker has been
+  // contacted at least once — show a placeholder rather than "-1".
+  const formatTrackerCount = (count: number) => (count < 0 ? '—' : String(count));
+
   const handleCopyTracker = async (tracker: Tracker) => {
     await Clipboard.setStringAsync(tracker.url);
     showToast(t('screens.trackers.urlCopied'), 'success');
@@ -391,6 +395,22 @@ export default function ManageTrackersScreen() {
                         {getStatusText(tracker.status)}
                       </Text>
                     </View>
+                    <View style={styles.statsRow}>
+                      <Text style={[styles.statsText, { color: colors.textSecondary }]}>
+                        {t('screens.trackers.seeds')}
+                        {': '}
+                        <Text style={{ color: colors.success }}>
+                          {formatTrackerCount(tracker.num_seeds)}
+                        </Text>
+                      </Text>
+                      <Text style={[styles.statsText, { color: colors.textSecondary }]}>
+                        {t('screens.trackers.leeches')}
+                        {': '}
+                        <Text style={{ color: colors.text }}>
+                          {formatTrackerCount(tracker.num_leeches)}
+                        </Text>
+                      </Text>
+                    </View>
                     {tracker.msg && (
                       <Text style={[styles.errorText, { color: colors.error }]} numberOfLines={1}>
                         {tracker.msg}
@@ -504,6 +524,14 @@ const styles = StyleSheet.create({
     marginRight: spacing.xs + 2,
   },
   statusText: {
+    ...typography.caption,
+  },
+  statsRow: {
+    flexDirection: 'row',
+    gap: spacing.md,
+    marginTop: spacing.xs,
+  },
+  statsText: {
     ...typography.caption,
   },
   errorText: {

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -19,6 +19,16 @@ export interface ChangelogRelease {
 }
 export const CHANGELOG: ChangelogRelease[] = [
   {
+    version: '3.8.38',
+    date: '2026-08-14',
+    sections: [
+      {
+        title: 'New Features',
+        items: ['Trackers now show each tracker’s reported seed and leech counts'],
+      },
+    ],
+  },
+  {
     version: '3.8.37',
     date: '2026-08-12',
     sections: [

--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -467,6 +467,8 @@
     },
     "trackers": {
       "title": "Manage Trackers",
+      "seeds": "Seeds",
+      "leeches": "Leechers",
       "newTrackerUrl": "New Tracker URL",
       "editTrackerUrl": "Tracker-URL bearbeiten",
       "addNewTracker": "Add New Tracker",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -488,6 +488,8 @@
     },
     "trackers": {
       "title": "Manage Trackers",
+      "seeds": "Seeds",
+      "leeches": "Leeches",
       "newTrackerUrl": "New Tracker URL",
       "editTrackerUrl": "Edit Tracker URL",
       "addNewTracker": "Add New Tracker",

--- a/locales/es/translation.json
+++ b/locales/es/translation.json
@@ -467,6 +467,8 @@
     },
     "trackers": {
       "title": "Manage Trackers",
+      "seeds": "Semillas",
+      "leeches": "Leechers",
       "newTrackerUrl": "New Tracker URL",
       "editTrackerUrl": "Editar URL del tracker",
       "addNewTracker": "Add New Tracker",

--- a/locales/fr/translation.json
+++ b/locales/fr/translation.json
@@ -467,6 +467,8 @@
     },
     "trackers": {
       "title": "Manage Trackers",
+      "seeds": "Seeds",
+      "leeches": "Leechers",
       "newTrackerUrl": "New Tracker URL",
       "editTrackerUrl": "Modifier l'URL du tracker",
       "addNewTracker": "Add New Tracker",

--- a/locales/ru/translation.json
+++ b/locales/ru/translation.json
@@ -488,6 +488,8 @@
     },
     "trackers": {
       "title": "Трекеры",
+      "seeds": "Сиды",
+      "leeches": "Личи",
       "newTrackerUrl": "URL нового трекера",
       "editTrackerUrl": "Изменить URL трекера",
       "addNewTracker": "Добавить трекер",

--- a/locales/zh/translation.json
+++ b/locales/zh/translation.json
@@ -467,6 +467,8 @@
     },
     "trackers": {
       "title": "Manage Trackers",
+      "seeds": "做种",
+      "leeches": "下载者",
       "newTrackerUrl": "New Tracker URL",
       "editTrackerUrl": "编辑 Tracker URL",
       "addNewTracker": "Add New Tracker",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qRemote",
-  "version": "3.8.37",
+  "version": "3.8.38",
   "easBuild": true,
   "main": "index.ts",
   "scripts": {

--- a/types/api.ts
+++ b/types/api.ts
@@ -344,6 +344,10 @@ export interface Tracker {
   url: string;
   status: number;
   tier: number;
+  num_peers: number;
+  num_seeds: number;
+  num_leeches: number;
+  num_downloaded: number;
   msg: string;
 }
 


### PR DESCRIPTION
## Summary
- Adds `num_seeds`, `num_leeches`, `num_peers`, and `num_downloaded` to the `Tracker` type, matching the `torrents/trackers` response fields (confirmed against both the 5.0 and 4.1 WebUI API wikis — no version gating needed, these fields are present in both).
- Manage Trackers screen now shows each tracker's reported Seeds and Leeches counts under its status line. A value of `-1` (tracker not yet contacted/scraped) renders as `—` instead of a raw negative number.
- Adds `screens.trackers.seeds` / `screens.trackers.leeches` i18n keys to all six locales.

Closes #222.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 72 suites / 1011 tests passing (includes locale parity)
- [x] `npm run lint` — 0 errors (pre-existing warning baseline unchanged)
- [x] `npm run format`