### PR TITLE
v3.8.44: root folder param, proxy cookies, cold-launch timeout, retries=0, quick-switch flash

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -384,8 +384,14 @@ proxy server incl. auth, IP filtering/banned IPs, I2P (qBit 5.0+ /
   `isRecoveringFromBackground` covers the foreground re-sync; it's cleared only
   once a fetch *newer than the pre-recovery `dataUpdatedAt`* lands, never by
   that timestamp merely being nonzero (which cleared it instantly, since it
-  holds the last success from potentially hours ago).
-- **`TransferContext.tsx`** — transfer-info poll; relies on TorrentContext's reconnect.
+  holds the last success from potentially hours ago). A foreground return
+  backgrounded for less than `LONG_BACKGROUND_THRESHOLD_MS` (`constants/timing.ts`,
+  10s) is treated as a quick app-switch: it skips the recovery dance entirely and
+  just nudges an incremental refresh, so a brief glance at another app doesn't
+  flash the recovery skeleton.
+- **`TransferContext.tsx`** — transfer-info poll; relies on TorrentContext's
+  reconnect. Mirrors TorrentContext's quick-app-switch threshold
+  (`LONG_BACKGROUND_THRESHOLD_MS`) for its own foreground recovery.
 - **`ToastContext.tsx`** + `components/Toast.tsx` — the global toast is a plain
   view. **Never wrap it in an RN `<Modal>`** — a Modal captures all touches and
   freezes the UI. Native-modal-sheet screens mount `ModalToast` locally instead.
@@ -513,6 +519,10 @@ and availability **FLOOR**, never round up) · `torrent-state.ts` (state → col
 label, completion and ETA rules) · `limit-input.ts` (share-limit sentinels:
 `-2` = follow global, `-1` = unlimited; own-vs-effective limit resolution) ·
 `error.ts` (`getErrorMessage`) · `apiVersion.ts` (parse + `ApiFeatures` gating) ·
+`connection-settings.ts` (`resolveConnectionSettings` — resolves the axios
+connection timeout / retry count from raw stored preferences, falling back to
+`DEFAULT_PREFERENCES` on missing or corrupt values while still honoring a
+legitimately saved `retryAttempts: 0`) ·
 `server.ts` (endpoint resolution incl. fallback URL, avatar colors, and
 `getServerIcon`/`getServerIconColor` for the per-server badge — #224) ·
 `authMode.ts` (derives `password`/`apiKey`/`none`) · `basicAuth.ts` ·
@@ -547,7 +557,9 @@ base).
   [docs/RELEASING.md](docs/RELEASING.md)),
   `spacing.ts`, `typography.ts`, `shadows.ts`, `buttons.ts`, `serverIcons.ts`
   (`SERVER_ICON_OPTIONS`, `DEFAULT_SERVER_ICON` — the curated Ionicons set for
-  a server's badge, #224). **Use these tokens; don't invent ad-hoc spacing.**
+  a server's badge, #224), `timing.ts` (`LONG_BACKGROUND_THRESHOLD_MS` — shared
+  by `TorrentContext` and `TransferContext` for their quick-app-switch gate).
+  **Use these tokens; don't invent ad-hoc spacing.**
 - `i18n/index.ts` initializes react-i18next. Each locale is ONE file,
   `locales/{en,es,zh,fr,de,ru}/translation.json`, holding every namespace:
   `common`, `states`, `screens`, `placeholders`, `actions`, `alerts`, `server`,
@@ -759,3 +771,12 @@ Keep entries factual and current; if you find one that's no longer true
   component just never re-renders, and it looks exactly like a product bug.
   Full detail and the working pattern live in [§6](#6-task-recipes)'s "Add a
   test" recipe, under the `rn`-project traps.
+- **The 5.0 wiki's `torrents/add` page still documents a `root_folder` param
+  that no supported qBittorrent version reads.** It looks like it "works" —
+  the request 200s, the field is just silently dropped — but it has done
+  nothing since qBit 4.3.2 (WebAPI 2.7.0). The live parameter is
+  `contentLayout` (`Original`/`Subfolder`/`NoSubfolder`), gated by
+  `ApiFeatures.useContentLayoutAddParam` in `utils/apiVersion.ts`. When a
+  parameter "works" in the UI but has no visible server-side effect, check it
+  against qBittorrent's `torrentscontroller.cpp` source, not the wiki — the
+  wiki is not reliably kept in sync with parameter renames.

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -27,6 +27,7 @@ import { logStorage } from '@/services/log-storage';
 import { storageService } from '@/services/storage';
 import { apiClient } from '@/services/api/client';
 import { setHapticsEnabled } from '@/utils/haptics';
+import { resolveConnectionSettings } from '@/utils/connection-settings';
 import {
   setDebugMode as setConnectivityDebugMode,
   clogInfo,
@@ -332,10 +333,7 @@ export default function RootLayout() {
       .then((prefs) => {
         setHapticsEnabled(prefs.hapticFeedback !== false);
         setConnectivityDebugMode(prefs.debugMode === true);
-        apiClient.updateSettings({
-          connectionTimeout: Number(prefs.connectionTimeout) || 10000,
-          retryAttempts: Number(prefs.retryAttempts) || 3,
-        });
+        apiClient.updateSettings(resolveConnectionSettings(prefs));
       })
       .catch(() => {
         // Defaults already applied in each module — safe to ignore

--- a/constants/changelog.ts
+++ b/constants/changelog.ts
@@ -19,6 +19,26 @@ export interface ChangelogRelease {
 }
 export const CHANGELOG: ChangelogRelease[] = [
   {
+    version: '3.8.44',
+    date: '2026-09-09',
+    sections: [
+      {
+        title: 'Bugs Fixed',
+        items: [
+          'Fixed turning off "Create root folder" in the add torrent dialog having no effect',
+          'Fixed losing the login session behind some reverse proxies that set their own cookies',
+          'Fixed the connection timeout and retry settings being ignored on the first connect after launch',
+          'Fixed the retry attempts setting resetting to 3 when set to 0',
+          'Fixed a loading screen flashing every time the app was reopened after a quick switch to another app',
+        ],
+      },
+      {
+        title: 'Maintenance',
+        items: ['Connecting to a server is slightly faster'],
+      },
+    ],
+  },
+  {
     version: '3.8.43',
     date: '2026-09-07',
     sections: [

--- a/constants/timing.ts
+++ b/constants/timing.ts
@@ -1,0 +1,14 @@
+/**
+ * Shared timing thresholds used across contexts.
+ */
+
+// Below this backgrounded duration, treat a foreground return as a quick
+// app-switch: the session can't plausibly have expired and the data can't
+// have gone meaningfully stale, so skip the forced full resync + recovery
+// skeleton and let the normal 2s poll pick up right where it left off. Above
+// it, do the full "might need to reconnect, don't show stale/wrong data"
+// dance. Without this gate, every single foreground return — even a
+// glance at another app — forced a full resync and blocked on it with a
+// skeleton, which is the "briefly shows loading every time I reopen" flash.
+// Used by TorrentContext and TransferContext.
+export const LONG_BACKGROUND_THRESHOLD_MS = 10_000;

--- a/context/ServerContext.tsx
+++ b/context/ServerContext.tsx
@@ -13,6 +13,7 @@ import { ServerManager } from '@/services/server-manager';
 import { apiClient } from '@/services/api/client';
 import { storageService } from '@/services/storage';
 import { getActiveEndpoint } from '@/utils/server';
+import { resolveConnectionSettings } from '@/utils/connection-settings';
 import { clogInfo, clogWarn } from '@/services/connectivity-log';
 
 interface ServerContextType {
@@ -97,6 +98,13 @@ export function ServerProvider({ children }: { children: ReactNode }) {
     async function autoConnect() {
       try {
         const prefs = await storageService.getPreferences();
+        // Apply connection settings before the first connect attempt fires.
+        // RootLayout also applies these from the same preferences, but its
+        // effect runs after this provider's (child effects fire before a
+        // parent's on mount) — without this, the very first cold-launch
+        // connect always uses apiClient's built-in defaults instead of the
+        // user's configured timeout/retry count.
+        apiClient.updateSettings(resolveConnectionSettings(prefs));
         const autoConnectLastServer = prefs.autoConnectLastServer !== false;
         const manualDisconnect = await storageService.getManualDisconnect();
 

--- a/context/TorrentContext.tsx
+++ b/context/TorrentContext.tsx
@@ -20,6 +20,7 @@ import { syncApi } from '@/services/api/sync';
 import { useServer } from './ServerContext';
 import { getErrorMessage } from '@/utils/error';
 import { useReactiveReconnect } from '@/hooks/useReactiveReconnect';
+import { LONG_BACKGROUND_THRESHOLD_MS } from '@/constants/timing';
 
 interface TorrentContextType {
   torrents: TorrentInfo[];
@@ -231,15 +232,10 @@ export function TorrentProvider({ children }: { children: ReactNode }) {
       setIsAppActive(nextAppState === 'active');
 
       if (previousAppState === 'background' && nextAppState === 'active') {
+        const backgroundedMs = Date.now() - lastActiveTime.current;
         lastActiveTime.current = Date.now();
 
         if (isConnected) {
-          // Baseline against the last successful sync *before* flipping the
-          // flag, so the clear effect above can tell a genuinely new fetch
-          // apart from the stale timestamp already sitting there.
-          recoveryBaselineRef.current = dataUpdatedAtRef.current;
-          setIsRecoveringState(true);
-
           // Deliberately NOT eagerly reconnecting here. checkAndReconnect
           // always performs a fresh login (server-manager.ts has no
           // lightweight "is my session still valid" path) — calling it on
@@ -251,6 +247,21 @@ export function TorrentProvider({ children }: { children: ReactNode }) {
           // will fail naturally and the reactive effect above (which
           // watches queryError) picks it up and reconnects — but only when
           // it's actually needed.
+
+          if (backgroundedMs < LONG_BACKGROUND_THRESHOLD_MS) {
+            // Quick app-switch — nudge an immediate incremental refresh
+            // (rid-based, not a full resync) without blocking on it or
+            // showing the recovery skeleton. The normal 2s poll would catch
+            // this shortly anyway; this just makes it feel instant.
+            queryClient.invalidateQueries({ queryKey: ['torrents'] });
+            return;
+          }
+
+          // Baseline against the last successful sync *before* flipping the
+          // flag, so the clear effect above can tell a genuinely new fetch
+          // apart from the stale timestamp already sitting there.
+          recoveryBaselineRef.current = dataUpdatedAtRef.current;
+          setIsRecoveringState(true);
 
           // Force full re-sync on foreground
           syncVersionRef.current++;

--- a/context/TransferContext.tsx
+++ b/context/TransferContext.tsx
@@ -14,6 +14,7 @@ import { transferApi } from '@/services/api/transfer';
 import { applicationApi } from '@/services/api/application';
 import { useServer } from './ServerContext';
 import { getErrorMessage } from '@/utils/error';
+import { LONG_BACKGROUND_THRESHOLD_MS } from '@/constants/timing';
 
 interface TransferContextType {
   transferInfo: GlobalTransferInfo | null;
@@ -96,12 +97,10 @@ export function TransferProvider({ children }: { children: ReactNode }) {
       setIsAppActive(nextState === 'active');
 
       if (prevState === 'background' && nextState === 'active') {
+        const backgroundedMs = Date.now() - lastActiveTime.current;
         lastActiveTime.current = Date.now();
 
         if (isConnected) {
-          setIsRecoveringState(true);
-          setMutationError(null);
-
           // Deliberately NOT eagerly reconnecting here (mirrors TorrentContext
           // and useSearchJob): checkAndReconnect always performs a fresh
           // login, and qBittorrent ties search jobs to session state — an
@@ -110,6 +109,17 @@ export function TransferProvider({ children }: { children: ReactNode }) {
           // torrents sync poll fails the same way and TorrentContext's
           // reactive reconnect effect recovers the shared session for this
           // query too — only when it's actually needed.
+
+          if (backgroundedMs < LONG_BACKGROUND_THRESHOLD_MS) {
+            // Quick app-switch — nudge an immediate refresh without blocking
+            // on it or showing the recovery state. See TorrentContext.tsx.
+            queryClient.invalidateQueries({ queryKey: ['transfer'] });
+            return;
+          }
+
+          setIsRecoveringState(true);
+          setMutationError(null);
+
           await new Promise<void>((resolve) => {
             InteractionManager.runAfterInteractions(() => {
               queryClient.invalidateQueries({ queryKey: ['transfer'] }).finally(() => resolve());

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qRemote",
-  "version": "3.8.42",
+  "version": "3.8.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qRemote",
-      "version": "3.8.42",
+      "version": "3.8.44",
       "dependencies": {
         "@expo/vector-icons": "^15.1.1",
         "@react-native-async-storage/async-storage": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qRemote",
-  "version": "3.8.43",
+  "version": "3.8.44",
   "easBuild": true,
   "main": "index.ts",
   "scripts": {

--- a/services/api/application.ts
+++ b/services/api/application.ts
@@ -9,12 +9,13 @@ export const applicationApi = {
    * Get application version
    */
   async getVersion(signal?: AbortSignal): Promise<ApplicationVersion> {
-    const version = await apiClient.get(`/api/${API_VERSION}/app/version`, undefined, signal);
-    const apiVersion = await apiClient.get(
-      `/api/${API_VERSION}/app/webapiVersion`,
-      undefined,
-      signal,
-    );
+    // Independent reads — run them concurrently instead of sequentially so a
+    // connect (cold launch, reconnect) doesn't pay for two round trips where
+    // one would do.
+    const [version, apiVersion] = await Promise.all([
+      apiClient.get(`/api/${API_VERSION}/app/version`, undefined, signal),
+      apiClient.get(`/api/${API_VERSION}/app/webapiVersion`, undefined, signal),
+    ]);
     return {
       version: version as string,
       apiVersion: apiVersion as string,

--- a/services/api/client.ts
+++ b/services/api/client.ts
@@ -163,27 +163,8 @@ class ApiClient {
           (typeof headers.get === 'function' ? headers.get('set-cookie') : null);
 
         if (setCookieHeader) {
-          if (Array.isArray(setCookieHeader)) {
-            // Join multiple cookies with semicolon and space
-            // Also extract CSRF token if present in cookies
-            this.cookies = setCookieHeader
-              .map((cookie) => {
-                return cookie.split(';')[0].trim();
-              })
-              .join('; ');
-          } else {
-            this.cookies = setCookieHeader.split(';')[0].trim();
-          }
+          this.mergeCookies(setCookieHeader);
           clogDebug('HTTP', `Cookies captured: ${this.cookies.substring(0, 60)}...`);
-          // console.log('Cookies captured after request:', this.cookies.substring(0, 100));
-        } else {
-          // Log available headers for debugging
-          const headerKeys = Object.keys(headers);
-          // console.log('No set-cookie header found. Available headers:', headerKeys);
-          // Check if cookies might be in a different format
-          if (headerKeys.length > 0) {
-            // console.log('Sample header values:', headerKeys.slice(0, 5).map(key => `${key}: ${String(headers[key]).substring(0, 50)}`));
-          }
         }
         return response;
       },
@@ -318,6 +299,25 @@ class ApiClient {
 
   getCookies(): string {
     return this.cookies;
+  }
+
+  /**
+   * Merge Set-Cookie values into the jar by name instead of replacing it.
+   * A reverse proxy in front of qBittorrent may set its own cookie on any
+   * response (Cloudflare __cf_bm, forward-auth session cookies); replacing the
+   * jar wholesale dropped SID and forced a re-login on the next request.
+   */
+  private mergeCookies(setCookie: string | string[]): void {
+    const jar = new Map<string, string>();
+    const put = (pair: string) => {
+      const trimmed = pair.trim();
+      if (!trimmed) return;
+      const eq = trimmed.indexOf('=');
+      jar.set(eq === -1 ? trimmed : trimmed.slice(0, eq), trimmed);
+    };
+    this.cookies.split(';').forEach(put);
+    (Array.isArray(setCookie) ? setCookie : [setCookie]).forEach((raw) => put(raw.split(';')[0]));
+    this.cookies = Array.from(jar.values()).join('; ');
   }
 
   async postFormData(url: string, data: FormData): Promise<unknown> {

--- a/services/api/torrents.ts
+++ b/services/api/torrents.ts
@@ -236,7 +236,17 @@ export const torrentsApi = {
         formData.append(stoppedField, String(options.stopped));
       }
       if (options.root_folder !== undefined) {
-        formData.append('root_folder', String(options.root_folder));
+        if (apiClient.getApiFeatures().useContentLayoutAddParam) {
+          // "root_folder" has been a no-op since qBit 4.3.2; the live parameter is
+          // contentLayout. The switch is ON by default and has never done anything,
+          // so ON must keep meaning "server default" (omit the field) — sending
+          // 'Subfolder' or 'Original' here would silently change the layout of
+          // every add for every existing user. Only OFF sends anything.
+          if (!options.root_folder) formData.append('contentLayout', 'NoSubfolder');
+        } else {
+          // WebAPI < 2.7 (qBit ≤ 4.3.1) genuinely reads root_folder — unchanged.
+          formData.append('root_folder', String(options.root_folder));
+        }
       }
       if (options.rename) formData.append('rename', options.rename);
       if (options.upLimit !== undefined) {
@@ -345,7 +355,17 @@ export const torrentsApi = {
         formData.append(stoppedField, String(options.stopped));
       }
       if (options.root_folder !== undefined) {
-        formData.append('root_folder', String(options.root_folder));
+        if (apiClient.getApiFeatures().useContentLayoutAddParam) {
+          // "root_folder" has been a no-op since qBit 4.3.2; the live parameter is
+          // contentLayout. The switch is ON by default and has never done anything,
+          // so ON must keep meaning "server default" (omit the field) — sending
+          // 'Subfolder' or 'Original' here would silently change the layout of
+          // every add for every existing user. Only OFF sends anything.
+          if (!options.root_folder) formData.append('contentLayout', 'NoSubfolder');
+        } else {
+          // WebAPI < 2.7 (qBit ≤ 4.3.1) genuinely reads root_folder — unchanged.
+          formData.append('root_folder', String(options.root_folder));
+        }
       }
       if (options.rename) formData.append('rename', options.rename);
       if (options.upLimit !== undefined) {

--- a/tests/rn/context/ServerContext.test.tsx
+++ b/tests/rn/context/ServerContext.test.tsx
@@ -22,6 +22,7 @@ jest.mock('@/services/api/client', () => ({
   apiClient: {
     getServer: jest.fn(),
     setServer: jest.fn(),
+    updateSettings: jest.fn(),
   },
 }));
 

--- a/tests/rn/context/TorrentContext.test.tsx
+++ b/tests/rn/context/TorrentContext.test.tsx
@@ -57,6 +57,12 @@ beforeEach(() => {
     .mockReturnValue({ isConnected: true } as unknown as ReturnType<typeof useServer>);
 });
 
+afterEach(() => {
+  // Some tests below spy on Date.now — restore it (and any other spies) so a
+  // mocked clock can't leak into a later test.
+  jest.restoreAllMocks();
+});
+
 describe('TorrentContext', () => {
   it('throws when useTorrents used outside provider', async () => {
     const BadConsumer = () => {
@@ -71,7 +77,7 @@ describe('TorrentContext', () => {
     spy.mockRestore();
   });
 
-  it('keeps isRecoveringFromBackground true across a foreground re-sync that fails', async () => {
+  it('keeps isRecoveringFromBackground true across a foreground re-sync that fails, after a long background', async () => {
     jest.mocked(syncApi.getMainData).mockResolvedValue(emptyMainData);
 
     let appStateHandler: ((state: string) => void) | undefined;
@@ -79,6 +85,8 @@ describe('TorrentContext', () => {
       appStateHandler = handler as (state: string) => void;
       return { remove: jest.fn() } as unknown as ReturnType<typeof AppState.addEventListener>;
     });
+    let now = 1_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
 
     const getLatest = await renderProvider();
 
@@ -96,6 +104,9 @@ describe('TorrentContext', () => {
     await act(async () => {
       appStateHandler?.('background');
     });
+    // Longer than the "quick app-switch" threshold, so the full recovery
+    // dance (not just a quiet incremental refresh) is expected to run.
+    now += 11_000;
     await act(async () => {
       appStateHandler?.('active');
     });
@@ -112,7 +123,7 @@ describe('TorrentContext', () => {
     expect(getLatest().error).toBeNull();
   });
 
-  it('clears isRecoveringFromBackground once a genuinely new sync succeeds', async () => {
+  it('clears isRecoveringFromBackground once a genuinely new sync succeeds, after a long background', async () => {
     jest.mocked(syncApi.getMainData).mockResolvedValue(emptyMainData);
 
     let appStateHandler: ((state: string) => void) | undefined;
@@ -120,6 +131,8 @@ describe('TorrentContext', () => {
       appStateHandler = handler as (state: string) => void;
       return { remove: jest.fn() } as unknown as ReturnType<typeof AppState.addEventListener>;
     });
+    let now = 1_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
 
     const getLatest = await renderProvider();
     await waitFor(() => expect(getLatest().initialLoadComplete).toBe(true));
@@ -127,6 +140,7 @@ describe('TorrentContext', () => {
     await act(async () => {
       appStateHandler?.('background');
     });
+    now += 11_000;
     await act(async () => {
       appStateHandler?.('active');
     });
@@ -134,5 +148,39 @@ describe('TorrentContext', () => {
     await waitFor(() => {
       expect(getLatest().isRecoveringFromBackground).toBe(false);
     });
+  });
+
+  it('skips the recovery skeleton for a quick app-switch, but still refreshes', async () => {
+    jest.mocked(syncApi.getMainData).mockResolvedValue(emptyMainData);
+
+    let appStateHandler: ((state: string) => void) | undefined;
+    jest.spyOn(AppState, 'addEventListener').mockImplementation((_event, handler) => {
+      appStateHandler = handler as (state: string) => void;
+      return { remove: jest.fn() } as unknown as ReturnType<typeof AppState.addEventListener>;
+    });
+    let now = 1_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+
+    const getLatest = await renderProvider();
+    await waitFor(() => expect(getLatest().initialLoadComplete).toBe(true));
+
+    const callsBeforeSwitch = jest.mocked(syncApi.getMainData).mock.calls.length;
+
+    await act(async () => {
+      appStateHandler?.('background');
+    });
+    // Well under the "long background" threshold — a glance at another app.
+    now += 1_000;
+    await act(async () => {
+      appStateHandler?.('active');
+    });
+
+    // Still nudges an immediate refresh rather than waiting out the normal
+    // poll interval...
+    await waitFor(() => {
+      expect(jest.mocked(syncApi.getMainData).mock.calls.length).toBeGreaterThan(callsBeforeSwitch);
+    });
+    // ...but never shows the recovery skeleton for it.
+    expect(getLatest().isRecoveringFromBackground).toBe(false);
   });
 });

--- a/tests/services/client.test.ts
+++ b/tests/services/client.test.ts
@@ -193,6 +193,10 @@ describe('apiClient', () => {
   describe('response interceptor — success (cookie capture)', () => {
     beforeEach(() => {
       apiClient.setServer(makeServer());
+      // Cookies now merge by name rather than being replaced wholesale, so
+      // the jar persists across requests within a test — start each test
+      // from an empty jar so tests stay independent of ordering.
+      apiClient.clearCookies();
     });
 
     it('captures a single set-cookie header', () => {
@@ -227,6 +231,34 @@ describe('apiClient', () => {
         status: 200,
       });
       expect(apiClient.getCookies()).toBe('SID=viaget');
+    });
+
+    it('merges a proxy cookie set on a later response, keeping the session cookie', () => {
+      capturedResponseInterceptorSuccess!({
+        headers: { 'set-cookie': 'SID=abc; Path=/' },
+        data: 'Ok.',
+        status: 200,
+      });
+      capturedResponseInterceptorSuccess!({
+        headers: { 'set-cookie': '__cf_bm=zzz; Path=/' },
+        data: '',
+        status: 200,
+      });
+      expect(apiClient.getCookies()).toBe('SID=abc; __cf_bm=zzz');
+    });
+
+    it('replaces a cookie in place by name on re-login instead of appending a duplicate', () => {
+      capturedResponseInterceptorSuccess!({
+        headers: { 'set-cookie': 'SID=old; Path=/' },
+        data: 'Ok.',
+        status: 200,
+      });
+      capturedResponseInterceptorSuccess!({
+        headers: { 'set-cookie': 'SID=new; HttpOnly' },
+        data: 'Ok.',
+        status: 200,
+      });
+      expect(apiClient.getCookies()).toBe('SID=new');
     });
 
     it('leaves cookies untouched when no set-cookie header exists', () => {

--- a/tests/services/torrents.test.ts
+++ b/tests/services/torrents.test.ts
@@ -240,6 +240,24 @@ describe('torrentsApi', () => {
       expect(formData).toBeInstanceOf(FormData);
     });
 
+    it('sends neither contentLayout nor root_folder when the toggle is ON (server default)', async () => {
+      mockGetApiFeatures.mockReturnValue({ useContentLayoutAddParam: true });
+      mockPostFormData.mockResolvedValueOnce(undefined);
+      await torrentsApi.addTorrent('magnet:?xt=1', { root_folder: true });
+      const formData = mockPostFormData.mock.calls[0][1] as FormData;
+      expect(formData.get('contentLayout')).toBeNull();
+      expect(formData.get('root_folder')).toBeNull();
+    });
+
+    it('sends contentLayout=NoSubfolder when the toggle is OFF', async () => {
+      mockGetApiFeatures.mockReturnValue({ useContentLayoutAddParam: true });
+      mockPostFormData.mockResolvedValueOnce(undefined);
+      await torrentsApi.addTorrent('magnet:?xt=1', { root_folder: false });
+      const formData = mockPostFormData.mock.calls[0][1] as FormData;
+      expect(formData.get('contentLayout')).toBe('NoSubfolder');
+      expect(formData.get('root_folder')).toBeNull();
+    });
+
     it('appends useDownloadPath and downloadPath when provided', async () => {
       mockPostFormData.mockResolvedValueOnce(undefined);
       await torrentsApi.addTorrent('magnet:?xt=1', {

--- a/tests/utils/apiVersion.test.ts
+++ b/tests/utils/apiVersion.test.ts
@@ -35,6 +35,7 @@ describe('getApiFeatures', () => {
       supportsSearchDownloadTorrent: true,
       useAddStoppedEnabledPreference: true,
       useStoppedAddParam: true,
+      useContentLayoutAddParam: true,
       supportsGetDirectoryContent: true,
       supportsSearchPubDate: true,
       hasIsPrivate: true,
@@ -59,10 +60,16 @@ describe('getApiFeatures', () => {
     expect(features.supportsGetDirectoryContent).toBe(false);
     expect(features.supportsSearchPubDate).toBe(false);
     expect(features.supportsI2p).toBe(false);
-    // ratio limit fields only require 2.8+, modern proxy fields and is_private only require 2.9+
+    // ratio limit fields only require 2.8+, modern proxy fields and is_private only require 2.9+,
+    // contentLayout only requires 2.7+
     expect(features.hasRatioLimitFields).toBe(true);
     expect(features.hasModernProxyFields).toBe(true);
     expect(features.hasIsPrivate).toBe(true);
+    expect(features.useContentLayoutAddParam).toBe(true);
+  });
+
+  it('gates useContentLayoutAddParam off below 2.7', () => {
+    expect(getApiFeatures('2.6.0').useContentLayoutAddParam).toBe(false);
   });
 
   it('gates hasIsPrivate off below 2.9 (is_private was added alongside the 4.6 proxy fields)', () => {
@@ -97,6 +104,7 @@ describe('getApiFeatures', () => {
     expect(features.supportsSearchDownloadTorrent).toBe(true);
     expect(features.useAddStoppedEnabledPreference).toBe(true);
     expect(features.useStoppedAddParam).toBe(true);
+    expect(features.useContentLayoutAddParam).toBe(true);
     expect(features.supportsGetDirectoryContent).toBe(true);
     expect(features.supportsSearchPubDate).toBe(true);
     expect(features.hasIsPrivate).toBe(true);

--- a/tests/utils/connection-settings.test.ts
+++ b/tests/utils/connection-settings.test.ts
@@ -1,0 +1,29 @@
+import { resolveConnectionSettings } from '@/utils/connection-settings';
+
+describe('resolveConnectionSettings', () => {
+  it('falls back to defaults when preferences are empty', () => {
+    expect(resolveConnectionSettings({})).toEqual({
+      connectionTimeout: 10000,
+      retryAttempts: 3,
+    });
+  });
+
+  it('preserves a legitimately saved retryAttempts of 0', () => {
+    expect(resolveConnectionSettings({ connectionTimeout: 5000, retryAttempts: 0 })).toEqual({
+      connectionTimeout: 5000,
+      retryAttempts: 0,
+    });
+  });
+
+  it('falls back to defaults for corrupt/invalid values', () => {
+    expect(
+      resolveConnectionSettings({
+        connectionTimeout: 'abc' as unknown as number,
+        retryAttempts: -1,
+      }),
+    ).toEqual({
+      connectionTimeout: 10000,
+      retryAttempts: 3,
+    });
+  });
+});

--- a/utils/apiVersion.ts
+++ b/utils/apiVersion.ts
@@ -33,6 +33,13 @@ export interface ApiFeatures {
    * boundary, and only the preference one was handled previously.
    */
   useStoppedAddParam: boolean;
+  /**
+   * torrents/add takes "contentLayout" (Original/Subfolder/NoSubfolder) — WebAPI ≥ 2.7.0 /
+   * qBit 4.3.2. The wiki still documents "root_folder", but qBittorrent's
+   * torrentscontroller.cpp has not read that field since 4.3.x (verified against
+   * release-4.6.0 and release-5.0.0) — it is silently dropped with HTTP 200.
+   */
+  useContentLayoutAddParam: boolean;
   /** app/getDirectoryContent endpoint exists, for path autocomplete (WebAPI ≥ 2.11.0 / qBit 5.0). */
   supportsGetDirectoryContent: boolean;
   /** search/results includes a pubDate field per result, for sort-by-date (WebAPI ≥ 2.11.0 / qBit 5.0). */
@@ -88,6 +95,7 @@ const V5_FEATURES: ApiFeatures = {
   supportsSearchDownloadTorrent: true,
   useAddStoppedEnabledPreference: true,
   useStoppedAddParam: true,
+  useContentLayoutAddParam: true,
   supportsGetDirectoryContent: true,
   supportsSearchPubDate: true,
   hasIsPrivate: true,
@@ -110,6 +118,7 @@ export function getApiFeatures(apiVersion: string | null): ApiFeatures {
     supportsSearchDownloadTorrent: isV5,
     useAddStoppedEnabledPreference: isV5,
     useStoppedAddParam: isV5,
+    useContentLayoutAddParam: gte(v, 2, 7),
     supportsGetDirectoryContent: isV5,
     supportsSearchPubDate: isV5,
     hasIsPrivate: gte(v, 2, 9),

--- a/utils/connection-settings.ts
+++ b/utils/connection-settings.ts
@@ -1,0 +1,20 @@
+import { DEFAULT_PREFERENCES, AppPreferences } from '@/types/preferences';
+
+/**
+ * Resolve the axios timeout / retry count from raw stored preferences.
+ * `storageService.getPreferences()` returns a Partial with no defaults merged,
+ * so missing or corrupt values fall back — but a legitimately saved 0 for
+ * retryAttempts must survive (Settings → Advanced accepts 0..10).
+ */
+export function resolveConnectionSettings(
+  prefs: Partial<Pick<AppPreferences, 'connectionTimeout' | 'retryAttempts'>>,
+): { connectionTimeout: number; retryAttempts: number } {
+  const timeout = Number(prefs.connectionTimeout);
+  const retries = Number(prefs.retryAttempts);
+  return {
+    connectionTimeout:
+      Number.isFinite(timeout) && timeout > 0 ? timeout : DEFAULT_PREFERENCES.connectionTimeout,
+    retryAttempts:
+      Number.isFinite(retries) && retries >= 0 ? retries : DEFAULT_PREFERENCES.retryAttempts,
+  };
+}


### PR DESCRIPTION
## Summary

- **Fixed:** "Create root folder" toggle in the add-torrent dialog was a silent no-op on every supported server — qBittorrent has ignored the `root_folder` parameter on `torrents/add` since 4.3.2 (WebAPI 2.7.0). Switched to the real `contentLayout` parameter, gated by a new `ApiFeatures.useContentLayoutAddParam`. Toggle ON still sends nothing (server default — unchanged behavior for every current user); only toggling OFF now sends `contentLayout=NoSubfolder`. Verified against qBittorrent's `torrentscontroller.cpp` source at the 4.6.0 and 5.0.0 tags, not just the wiki (which still documents the dead parameter).
- **Fixed:** losing the login session behind reverse proxies that set their own cookies (Cloudflare `__cf_bm`, Authelia/Traefik forward-auth, etc.) — the client now merges `Set-Cookie` values into the jar by cookie name instead of replacing it wholesale, so a proxy-issued cookie can no longer silently drop the qBittorrent `SID` cookie and force an unnecessary re-login.
- **Fixed:** connection timeout / retry-attempts preferences being ignored on the very first cold-launch connect attempt.
- **Fixed:** a saved `retryAttempts` of `0` always getting coerced back to `3` on launch (an `|| 3` fallback also caught the legitimate value `0`). Extracted a shared `resolveConnectionSettings()` helper used by both cold-start call sites so they can't drift again.
- **Fixed:** a loading skeleton flashing on every foreground return, even a quick app-switch — `TorrentContext`/`TransferContext` now only run the full recovery dance when backgrounded 10s or more; a shorter background just nudges an incremental refresh.
- **Maintenance:** connecting to a server is slightly faster — `application.ts`'s `getVersion` now fetches `app/version` and `app/webapiVersion` concurrently instead of sequentially.
- Bumped to v3.8.44 (v3.8.43 already shipped 2026-09-07) with a matching changelog entry, and updated `AGENTS.md` (File Index + a new Gotchas entry on the `root_folder`/`contentLayout` wiki drift).

## Compatibility

No stored preference key, `ServerConfig` field, or `colors` key was added, renamed, or repurposed. The root-folder fix specifically preserves "toggle ON = server default" as the behavior every existing user already has today; only turning it OFF changes anything, and only on WebAPI ≥ 2.7 (qBit 4.3.2+) — older servers keep getting the legacy `root_folder` field unchanged.

## Test plan

- `npx tsc --noEmit` — exit 0
- `npm test` — 78 suites / 1104 tests passing (both projects)
- `npm run lint` — 0 errors, 37 warnings (documented baseline)
- `npm run format` — no changes needed
- Manual verification recommended on device before merge:
  - Add a multi-file torrent with "Create root folder" OFF on a qBit 5.x server → files land without a wrapper folder. With it ON → identical layout to today.
  - Settings → Advanced → Retry Attempts = 0, kill and relaunch → connectivity log shows no "Retrying request" lines on a failing request.
  - Background the app ~3s and return → no skeleton flash; background ≥15s → skeleton as before.
  - If available, a reverse-proxy setup (Cloudflare/forward-auth) that sets its own cookie → leave the app open >30 min, confirm no unexpected re-login entries in the connectivity log.

Note: pushing this branch's merge to `main` will trigger the App Store build (`easBuild: true` in `package.json`) — not part of this PR, that's a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)